### PR TITLE
Add .gitattributes file with  Jupyter Notebooks configuration

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Exclude Jupyter Notebook files from language statistics
+*.ipynb linguist-vendored


### PR DESCRIPTION
## Purpose

<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
This PR addresses the issue of large file sizes in Jupyter Notebooks due to the inclusion of numerous example images. These large `.ipynb` files are significantly affecting the language statistics of the repository, causing Jupyter Notebook to be displayed as the primary language, which may not accurately reflect the project's main focus.

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[x] No
```

## Type of change

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[x] Other... Please describe: Add .gitattributes file 
```

