### PR TITLE
Translator: Refactor Config class to use static methods for configuration access and add tests for config

### DIFF
--- a/src/co_op_translator/__main__.py
+++ b/src/co_op_translator/__main__.py
@@ -4,6 +4,7 @@ import click
 import importlib.resources
 import yaml
 from co_op_translator.translators.project_translator import ProjectTranslator
+from co_op_translator.config.base_config import Config
 
 logger = logging.getLogger(__name__)
 
@@ -50,6 +51,9 @@ def main(language_codes, root_dir, add, update, images, markdown, debug, check):
     Debug mode example:
     - translate -l "ko" -d: Enable debug logging.
     """
+
+    # Check that the required environment variables are set
+    Config.check_configuration()
 
     if debug:
         logging.basicConfig(level=logging.DEBUG)

--- a/src/co_op_translator/config/base_config.py
+++ b/src/co_op_translator/config/base_config.py
@@ -4,36 +4,66 @@ from dotenv import load_dotenv
 load_dotenv()
 
 class Config:
+    """
+    Configuration class for managing environment variables.
+    Provides static methods to retrieve required Azure configuration values.
+    """
+    
     @staticmethod
     def get_azure_subscription_key():
+        """
+        Retrieve the Azure subscription key from environment variables.
+        """
         return os.getenv("AZURE_SUBSCRIPTION_KEY")
 
     @staticmethod
     def get_azure_openai_api_key():
+        """
+        Retrieve the Azure OpenAI API key from environment variables.
+        """
         return os.getenv("AZURE_OPENAI_API_KEY")
 
     @staticmethod
     def get_azure_openai_endpoint():
+        """
+        Retrieve the Azure OpenAI endpoint from environment variables.
+        """
         return os.getenv("AZURE_OPENAI_ENDPOINT")
 
     @staticmethod
     def get_azure_openai_model_name():
+        """
+        Retrieve the Azure OpenAI model name from environment variables.
+        """
         return os.getenv("AZURE_OPENAI_MODEL_NAME")
 
     @staticmethod
     def get_azure_openai_chat_deployment_name():
+        """
+        Retrieve the Azure OpenAI chat deployment name from environment variables.
+        """
         return os.getenv("AZURE_OPENAI_CHAT_DEPLOYMENT_NAME")
 
     @staticmethod
     def get_azure_openai_api_version():
+        """
+        Retrieve the Azure OpenAI API version from environment variables.
+        """
         return os.getenv("AZURE_OPENAI_API_VERSION")
 
     @staticmethod
     def get_azure_ai_service_endpoint():
+        """
+        Retrieve the Azure AI service endpoint from environment variables.
+        """
         return os.getenv("AZURE_AI_SERVICE_ENDPOINT")
 
     @staticmethod
     def check_configuration():
+        """
+        Checks if all required environment variables are set.
+        Raises an OSError if any required environment variables are missing.
+        """
         required_vars = {
             "AZURE_SUBSCRIPTION_KEY": Config.get_azure_subscription_key(),
             "AZURE_OPENAI_API_KEY": Config.get_azure_openai_api_key(),
@@ -47,4 +77,4 @@ class Config:
         missing_keys = [key for key, value in required_vars.items() if not value]
 
         if missing_keys:
-            raise EnvironmentError(f"Missing required environment variables: {', '.join(missing_keys)}")
+            raise OSError(f"Missing required environment variables: {', '.join(missing_keys)}")

--- a/src/co_op_translator/config/base_config.py
+++ b/src/co_op_translator/config/base_config.py
@@ -3,36 +3,48 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
-# Base configuration class with common settings for all environments
 class Config:
-    AZURE_SUBSCRIPTION_KEY = os.getenv("AZURE_SUBSCRIPTION_KEY")
-    AZURE_OPENAI_API_KEY = os.getenv("AZURE_OPENAI_API_KEY")
-    AZURE_OPENAI_ENDPOINT = os.getenv("AZURE_OPENAI_ENDPOINT")
-    AZURE_OPENAI_MODEL_NAME = os.getenv("AZURE_OPENAI_MODEL_NAME")
-    AZURE_OPENAI_CHAT_DEPLOYMENT_NAME = os.getenv("AZURE_OPENAI_CHAT_DEPLOYMENT_NAME")
-    AZURE_OPENAI_API_VERSION = os.getenv("AZURE_OPENAI_API_VERSION")
-    AZURE_AI_SERVICE_ENDPOINT = os.getenv("AZURE_AI_SERVICE_ENDPOINT")
+    @staticmethod
+    def get_azure_subscription_key():
+        return os.getenv("AZURE_SUBSCRIPTION_KEY")
+
+    @staticmethod
+    def get_azure_openai_api_key():
+        return os.getenv("AZURE_OPENAI_API_KEY")
+
+    @staticmethod
+    def get_azure_openai_endpoint():
+        return os.getenv("AZURE_OPENAI_ENDPOINT")
+
+    @staticmethod
+    def get_azure_openai_model_name():
+        return os.getenv("AZURE_OPENAI_MODEL_NAME")
+
+    @staticmethod
+    def get_azure_openai_chat_deployment_name():
+        return os.getenv("AZURE_OPENAI_CHAT_DEPLOYMENT_NAME")
+
+    @staticmethod
+    def get_azure_openai_api_version():
+        return os.getenv("AZURE_OPENAI_API_VERSION")
+
+    @staticmethod
+    def get_azure_ai_service_endpoint():
+        return os.getenv("AZURE_AI_SERVICE_ENDPOINT")
 
     @staticmethod
     def check_configuration():
-        missing_keys = []
-        if not Config.AZURE_SUBSCRIPTION_KEY:
-            missing_keys.append("AZURE_SUBSCRIPTION_KEY")
-        if not Config.AZURE_OPENAI_API_KEY:
-            missing_keys.append("AZURE_OPENAI_API_KEY")
-        if not Config.AZURE_OPENAI_ENDPOINT:
-            missing_keys.append("AZURE_OPENAI_ENDPOINT")
-        if not Config.AZURE_OPENAI_MODEL_NAME:
-            missing_keys.append("AZURE_OPENAI_MODEL_NAME")
-        if not Config.AZURE_OPENAI_CHAT_DEPLOYMENT_NAME:
-            missing_keys.append("AZURE_OPENAI_CHAT_DEPLOYMENT_NAME")
-        if not Config.AZURE_OPENAI_API_VERSION:
-            missing_keys.append("AZURE_OPENAI_API_VERSION")
-        if not Config.AZURE_AI_SERVICE_ENDPOINT:
-            missing_keys.append("AZURE_AI_SERVICE_ENDPOINT")
+        required_vars = {
+            "AZURE_SUBSCRIPTION_KEY": Config.get_azure_subscription_key(),
+            "AZURE_OPENAI_API_KEY": Config.get_azure_openai_api_key(),
+            "AZURE_OPENAI_ENDPOINT": Config.get_azure_openai_endpoint(),
+            "AZURE_OPENAI_MODEL_NAME": Config.get_azure_openai_model_name(),
+            "AZURE_OPENAI_CHAT_DEPLOYMENT_NAME": Config.get_azure_openai_chat_deployment_name(),
+            "AZURE_OPENAI_API_VERSION": Config.get_azure_openai_api_version(),
+            "AZURE_AI_SERVICE_ENDPOINT": Config.get_azure_ai_service_endpoint(),
+        }
+
+        missing_keys = [key for key, value in required_vars.items() if not value]
 
         if missing_keys:
             raise EnvironmentError(f"Missing required environment variables: {', '.join(missing_keys)}")
-
-# Check the configuration
-Config.check_configuration()

--- a/src/co_op_translator/config/font_config.py
+++ b/src/co_op_translator/config/font_config.py
@@ -1,4 +1,3 @@
-import os
 import importlib.resources
 import yaml
 

--- a/src/co_op_translator/translators/image_translator.py
+++ b/src/co_op_translator/translators/image_translator.py
@@ -42,8 +42,8 @@ class ImageTranslator:
         Returns:
             ImageAnalysisClient: The initialized client.
         """
-        endpoint = Config.AZURE_AI_SERVICE_ENDPOINT
-        subscription_key = Config.AZURE_SUBSCRIPTION_KEY
+        endpoint = Config.get_azure_ai_service_endpoint()
+        subscription_key = Config.get_azure_subscription_key()
         return ImageAnalysisClient(endpoint, AzureKeyCredential(subscription_key))
 
     def extract_line_bounding_boxes(self, image_path):

--- a/src/co_op_translator/translators/markdown_translator.py
+++ b/src/co_op_translator/translators/markdown_translator.py
@@ -44,9 +44,9 @@ class MarkdownTranslator:
         kernel.add_service(
             AzureChatCompletion(
                 service_id=service_id,
-                deployment_name=Config.AZURE_OPENAI_CHAT_DEPLOYMENT_NAME,
-                endpoint=Config.AZURE_OPENAI_ENDPOINT,
-                api_key=Config.AZURE_OPENAI_API_KEY,
+                deployment_name=Config.get_azure_openai_chat_deployment_name(),
+                endpoint=Config.get_azure_openai_endpoint(),
+                api_key=Config.get_azure_openai_api_key()
             )
         )
         return kernel

--- a/src/co_op_translator/translators/project_translator.py
+++ b/src/co_op_translator/translators/project_translator.py
@@ -51,9 +51,9 @@ class ProjectTranslator:
         kernel.add_service(
             AzureChatCompletion(
                 service_id=service_id,
-                deployment_name=Config.AZURE_OPENAI_CHAT_DEPLOYMENT_NAME,
-                endpoint=Config.AZURE_OPENAI_ENDPOINT,
-                api_key=Config.AZURE_OPENAI_API_KEY,
+                deployment_name=Config.get_azure_openai_chat_deployment_name(),
+                endpoint=Config.get_azure_openai_endpoint(),
+                api_key=Config.get_azure_openai_api_key(),
             )
         )
         return kernel

--- a/src/co_op_translator/translators/text_translator.py
+++ b/src/co_op_translator/translators/text_translator.py
@@ -17,9 +17,9 @@ class TextTranslator:
             AzureOpenAI: The initialized OpenAI client.
         """
         return AzureOpenAI(
-            api_key=Config.AZURE_OPENAI_API_KEY,
-            api_version=Config.AZURE_OPENAI_API_VERSION,
-            base_url=f"{Config.AZURE_OPENAI_ENDPOINT}/openai/deployments/{Config.AZURE_OPENAI_CHAT_DEPLOYMENT_NAME}"
+            api_key=Config.get_azure_openai_api_key(),
+            api_version=Config.get_azure_openai_api_version(),
+            base_url=f"{Config.get_azure_openai_endpoint()}/openai/deployments/{Config.get_azure_openai_chat_deployment_name()}"
         )
 
     def translate_image_text(self, text_data, target_language):
@@ -35,7 +35,7 @@ class TextTranslator:
         """
         prompt = gen_image_translation_prompt(text_data, target_language)
         response = self.client.chat.completions.create(
-            model=Config.AZURE_OPENAI_MODEL_NAME,
+            model=Config.get_azure_openai_model_name(),
             messages=[
                 {"role": "system", "content": "You are a helpful assistant."},
                 {"role": "user", "content": prompt}
@@ -57,7 +57,7 @@ class TextTranslator:
         """
         prompt = f"Translate the following text into {target_language}:\n\n{text}"
         response = self.client.chat.completions.create(
-            model=Config.AZURE_OPENAI_MODEL_NAME,
+            model=Config.get_azure_openai_model_name(),
             messages=[
                 {"role": "system", "content": "You are a helpful assistant."},
                 {"role": "user", "content": prompt}

--- a/tests/co_op_translator/config/test_base_config.py
+++ b/tests/co_op_translator/config/test_base_config.py
@@ -1,0 +1,74 @@
+import pytest
+import os
+from unittest.mock import patch
+from co_op_translator.config.base_config import Config
+
+@pytest.fixture
+def mock_env_vars():
+    """
+    Provides a set of common environment variables for the project.
+    This function returns mock environment variables that simulate
+    the real ones used in the application.
+    """
+    env_vars = {
+        'AZURE_SUBSCRIPTION_KEY': 'fake_subscription_key',
+        'AZURE_OPENAI_API_KEY': 'fake_openai_key',
+        'AZURE_OPENAI_ENDPOINT': 'https://fake-openai-endpoint.com',
+        'AZURE_OPENAI_MODEL_NAME': 'gpt-3.5',
+        'AZURE_OPENAI_CHAT_DEPLOYMENT_NAME': 'chat-deployment',
+        'AZURE_OPENAI_API_VERSION': 'v1',
+        'AZURE_AI_SERVICE_ENDPOINT': 'https://fake-ai-service-endpoint.com'
+    }
+    return env_vars
+
+def test_config_with_all_env_vars(mock_env_vars):
+    """
+    Test that verifies if the configuration check passes when
+    all required environment variables are properly set.
+    """
+    with patch.dict(os.environ, mock_env_vars, clear=True):
+        Config.check_configuration()
+
+# Parametrized test for missing environment variables
+@pytest.mark.parametrize("missing_var, expected_message", [
+    ('AZURE_OPENAI_API_KEY', 'AZURE_OPENAI_API_KEY'),
+    ('AZURE_SUBSCRIPTION_KEY', 'AZURE_SUBSCRIPTION_KEY'),
+    ('AZURE_OPENAI_ENDPOINT', 'AZURE_OPENAI_ENDPOINT')
+])
+
+def test_config_missing_single_env_var(mock_env_vars, missing_var, expected_message):
+    """
+    Test that simulates a missing environment variable scenario.
+    This test checks that an appropriate error message is raised
+    when one of the required environment variables is missing.
+    """
+    mock_env_vars.pop(missing_var)
+    
+    with patch.dict(os.environ, mock_env_vars, clear=True):
+        with pytest.raises(EnvironmentError) as excinfo:
+            Config.check_configuration()
+        
+        assert expected_message in str(excinfo.value)
+
+def test_config_missing_multiple_env_vars():
+    """
+    Test that verifies behavior when all environment variables are missing.
+    This ensures that the configuration check raises an error listing all
+    the missing variables when none are provided.
+    """
+    with patch.dict(os.environ, {}, clear=True):
+        with pytest.raises(EnvironmentError) as excinfo:
+            Config.check_configuration()
+
+        missing_keys = [
+            "AZURE_SUBSCRIPTION_KEY",
+            "AZURE_OPENAI_API_KEY",
+            "AZURE_OPENAI_ENDPOINT",
+            "AZURE_OPENAI_MODEL_NAME",
+            "AZURE_OPENAI_CHAT_DEPLOYMENT_NAME",
+            "AZURE_OPENAI_API_VERSION",
+            "AZURE_AI_SERVICE_ENDPOINT"
+        ]
+        
+        for key in missing_keys:
+            assert key in str(excinfo.value)

--- a/tests/co_op_translator/config/test_base_config.py
+++ b/tests/co_op_translator/config/test_base_config.py
@@ -5,11 +5,6 @@ from co_op_translator.config.base_config import Config
 
 @pytest.fixture
 def mock_env_vars():
-    """
-    Provides a set of common environment variables for the project.
-    This function returns mock environment variables that simulate
-    the real ones used in the application.
-    """
     env_vars = {
         'AZURE_SUBSCRIPTION_KEY': 'fake_subscription_key',
         'AZURE_OPENAI_API_KEY': 'fake_openai_key',
@@ -22,42 +17,26 @@ def mock_env_vars():
     return env_vars
 
 def test_config_with_all_env_vars(mock_env_vars):
-    """
-    Test that verifies if the configuration check passes when
-    all required environment variables are properly set.
-    """
     with patch.dict(os.environ, mock_env_vars, clear=True):
         Config.check_configuration()
 
-# Parametrized test for missing environment variables
 @pytest.mark.parametrize("missing_var, expected_message", [
     ('AZURE_OPENAI_API_KEY', 'AZURE_OPENAI_API_KEY'),
     ('AZURE_SUBSCRIPTION_KEY', 'AZURE_SUBSCRIPTION_KEY'),
     ('AZURE_OPENAI_ENDPOINT', 'AZURE_OPENAI_ENDPOINT')
 ])
-
 def test_config_missing_single_env_var(mock_env_vars, missing_var, expected_message):
-    """
-    Test that simulates a missing environment variable scenario.
-    This test checks that an appropriate error message is raised
-    when one of the required environment variables is missing.
-    """
     mock_env_vars.pop(missing_var)
     
     with patch.dict(os.environ, mock_env_vars, clear=True):
-        with pytest.raises(EnvironmentError) as excinfo:
+        with pytest.raises(OSError) as excinfo:
             Config.check_configuration()
         
         assert expected_message in str(excinfo.value)
 
 def test_config_missing_multiple_env_vars():
-    """
-    Test that verifies behavior when all environment variables are missing.
-    This ensures that the configuration check raises an error listing all
-    the missing variables when none are provided.
-    """
     with patch.dict(os.environ, {}, clear=True):
-        with pytest.raises(EnvironmentError) as excinfo:
+        with pytest.raises(OSError) as excinfo:
             Config.check_configuration()
 
         missing_keys = [

--- a/tests/co_op_translator/config/test_font_config.py
+++ b/tests/co_op_translator/config/test_font_config.py
@@ -1,0 +1,89 @@
+import pytest
+from unittest.mock import patch, mock_open
+from pathlib import Path
+from co_op_translator.config.font_config import FontConfig
+
+# Sample YAML data for mocking font_language_mappings.yml
+sample_yaml = """
+en:
+  name: English
+  font: "Arial.ttf"
+  rtl: False
+ar:
+  name: Arabic
+  font: "Arial_Arabic.ttf"
+  rtl: True
+"""
+
+@pytest.fixture
+def mock_font_mappings():
+    """
+    Fixture that provides an instance of FontConfig with mocked font mappings.
+    Mocks the loading of 'font_language_mappings.yml'.
+    """
+    with patch('importlib.resources.path') as mock_path, \
+         patch('builtins.open', mock_open(read_data=sample_yaml)):
+        mock_path.return_value = Path('fake_path/font_language_mappings.yml')
+        return FontConfig()
+
+def test_get_font_path(mock_font_mappings):
+    """
+    Test retrieving the font path for a valid language code.
+    Ensures the correct path is returned for a valid language code.
+    """
+    with patch('importlib.resources.path', return_value=Path('fake_font_path/Arial.ttf')) as mock_path:
+        font_path = mock_font_mappings.get_font_path('en')
+
+        assert Path(font_path) == Path('fake_font_path/Arial.ttf'), "Font path for 'en' should return the correct path"
+        mock_path.assert_called_once_with('co_op_translator.fonts', 'Arial.ttf')
+
+def test_get_font_path_invalid(mock_font_mappings):
+    """
+    Test that an invalid language code raises a ValueError.
+    Ensures that requesting a font for an unsupported language code raises the appropriate error.
+    """
+    with pytest.raises(ValueError) as excinfo:
+        mock_font_mappings.get_font_path('xx')
+    assert "Font for language code 'xx' is not supported or not found." in str(excinfo.value)
+
+def test_get_language_name(mock_font_mappings):
+    """
+    Test retrieving the language name for a valid language code.
+    Ensures the correct language name is returned for a valid language code.
+    """
+    language_name = mock_font_mappings.get_language_name('en')
+    assert language_name == 'English', "Language name for 'en' should be 'English'"
+
+def test_get_language_name_invalid(mock_font_mappings):
+    """
+    Test that an invalid language code raises a ValueError when retrieving the language name.
+    Ensures that requesting a language name for an unsupported language code raises an error.
+    """
+    with pytest.raises(ValueError) as excinfo:
+        mock_font_mappings.get_language_name('xx')
+    assert "Language code 'xx' is not supported." in str(excinfo.value)
+
+def test_is_rtl(mock_font_mappings):
+    """
+    Test if the language is RTL (Right-to-Left) for a valid language code.
+    Ensures that the RTL value is correctly returned for RTL languages like Arabic.
+    """
+    is_rtl = mock_font_mappings.is_rtl('ar')
+    assert is_rtl is True, "The 'ar' language code should return True for RTL"
+
+def test_is_rtl_false(mock_font_mappings):
+    """
+    Test if the language is not RTL (Left-to-Right) for a valid language code.
+    Ensures that the RTL value is correctly returned as False for non-RTL languages like English.
+    """
+    is_rtl = mock_font_mappings.is_rtl('en')
+    assert is_rtl is False, "The 'en' language code should return False for RTL"
+
+def test_is_rtl_invalid(mock_font_mappings):
+    """
+    Test that an invalid language code raises a ValueError when checking RTL.
+    Ensures that requesting RTL info for an unsupported language code raises an error.
+    """
+    with pytest.raises(ValueError) as excinfo:
+        mock_font_mappings.is_rtl('xx')
+    assert "Language code 'xx' is not supported." in str(excinfo.value)


### PR DESCRIPTION
## Purpose

<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->

The primary goal of this change is to refactor the Config class, replacing the old constant-based configuration access with static methods. This refactor helps improve encapsulation and allows for better testability and flexibility in how configuration values are retrieved. This change affects how Azure-related keys (e.g., AZURE_SUBSCRIPTION_KEY, AZURE_OPENAI_API_KEY, etc.) are accessed throughout the translation logic.

This PR also includes added tests related to config to ensure the refactor does not break existing functionality.

## Description

<!-- Provide a concise summary of your changes. Why is this change necessary? -->

I've added test for config, and refactor the Config class, replacing the old constant-based configuration access with static methods



## Related Issue

<!-- If this PR addresses an issue, please link it here (e.g., Fixes #123) -->

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

- [ ] Yes
- [x] No

## Type of change

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (e.g., formatting, local variables)
- [x] Refactoring (no functional or API changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Checklist

Before submitting your pull request, please confirm the following:

- [x] **I have thoroughly tested my changes**: I confirm that I have run the code and manually tested all affected areas.
- [x] **All existing tests pass**: I have run all tests and confirmed that nothing is broken.
- [x] **I have added new tests** (if applicable): I have written tests that cover the new functionality introduced by my code changes.
- [x] **I have followed the Co-op Translators coding conventions**: My code adheres to the style guide and coding conventions outlined in the repository.
- [x] **I have documented my changes** (if applicable): I have updated the documentation to reflect the changes where necessary.

## Additional context

<!-- Add any additional context or screenshots if applicable -->
