### PR TITLE
Translator: Improve test_image_translator to use temp_path instead of real path and add tests for markdown translator

### DIFF
--- a/tests/co_op_translator/translators/test_image_translator.py
+++ b/tests/co_op_translator/translators/test_image_translator.py
@@ -8,11 +8,11 @@ TEST_IMAGE_PATH = Path("test_image.png").resolve()
 ROOT_DIR = Path(".").resolve()
 
 @pytest.fixture
-def image_translator():
+def image_translator(tmp_path):
     """
-    Fixture to provide an instance of ImageTranslator for each test.
+    Fixture to provide an instance of ImageTranslator for each test, using a temporary directory for output.
     """
-    return ImageTranslator(default_output_dir="./test_translated_images", root_dir=ROOT_DIR)
+    return ImageTranslator(default_output_dir=tmp_path, root_dir=ROOT_DIR)
 
 @pytest.fixture
 def mock_line_bounding_boxes():
@@ -56,7 +56,6 @@ def test_extract_line_bounding_boxes(mock_get_image_analysis_client, mock_makedi
     """
     Test extract_line_bounding_boxes method to ensure it extracts text and bounding boxes correctly.
     """
-
     mock_client = MagicMock()
     mock_result = MagicMock()
     mock_block = MagicMock()
@@ -85,11 +84,10 @@ def test_extract_line_bounding_boxes(mock_get_image_analysis_client, mock_makedi
 @patch('co_op_translator.translators.image_translator.TextTranslator.translate_image_text')
 @patch('co_op_translator.translators.image_translator.ImageTranslator.extract_line_bounding_boxes')
 @patch('os.makedirs')
-def test_translate_image(mock_makedirs, mock_extract_boxes, mock_translate_text, mock_plot_annotated_image, image_translator, mock_line_bounding_boxes):
+def test_translate_image(mock_makedirs, mock_extract_boxes, mock_translate_text, mock_plot_annotated_image, image_translator, mock_line_bounding_boxes, tmp_path):
     """
     Test translate_image method to ensure the image is correctly translated and annotated.
     """
-
     mock_extract_boxes.return_value = mock_line_bounding_boxes
     mock_translate_text.return_value = [
         'LA VIDA ES COMO',
@@ -98,13 +96,12 @@ def test_translate_image(mock_makedirs, mock_extract_boxes, mock_translate_text,
         'MANTENER EL EQUILIBRIO',
         'DEBES SEGUIR MOVIÉNDOTE'
     ]
-    mock_plot_annotated_image.return_value = "./test_translated_images/translated_image.png"
+    mock_plot_annotated_image.return_value = tmp_path / "translated_image.png"
 
     target_language = "es"
-
     result_path = image_translator.translate_image(TEST_IMAGE_PATH, target_language)
 
-    assert result_path == "./test_translated_images/translated_image.png"
+    assert str(result_path) == str(tmp_path / "translated_image.png")
 
     mock_extract_boxes.assert_called_once_with(TEST_IMAGE_PATH)
     mock_translate_text.assert_called_once_with(

--- a/tests/co_op_translator/translators/test_markdown_translator.py
+++ b/tests/co_op_translator/translators/test_markdown_translator.py
@@ -1,0 +1,158 @@
+from textwrap import dedent
+import pytest
+from unittest.mock import patch, MagicMock, AsyncMock
+from co_op_translator.translators.markdown_translator import MarkdownTranslator
+from pathlib import Path
+
+TEST_MD_CONTENT = """
+# Sample Markdown
+
+This is a sample markdown document with links and code blocks.
+
+```python
+def hello_world():
+    print("Hello, world!")
+```
+
+"""
+
+TRANSLATED_CONTENT = "Translated Content"
+TRANSLATED_DISCLAIMER = "Translated Disclaimer"
+
+@pytest.fixture
+def markdown_translator(tmp_path):
+    """
+    Fixture to provide an instance of MarkdownTranslator for each test.
+    """
+    return MarkdownTranslator(root_dir=tmp_path)
+
+@patch("co_op_translator.translators.markdown_translator.update_links")
+@patch("co_op_translator.translators.markdown_translator.restore_code_blocks_and_inline_code")
+@patch("co_op_translator.translators.markdown_translator.generate_prompt_template")
+@patch("co_op_translator.translators.markdown_translator.replace_code_blocks_and_inline_code")
+@patch("co_op_translator.translators.markdown_translator.count_links_in_markdown")
+@patch("co_op_translator.translators.markdown_translator.process_markdown_with_many_links")
+@patch("co_op_translator.translators.markdown_translator.process_markdown")
+@patch("co_op_translator.translators.markdown_translator.FontConfig.is_rtl")
+@patch("co_op_translator.translators.markdown_translator.MarkdownTranslator.generate_disclaimer")
+@patch("co_op_translator.translators.markdown_translator.MarkdownTranslator._run_prompts_sequentially")
+@pytest.mark.asyncio
+async def test_translate_markdown(
+    mock_run_prompts_sequentially,
+    mock_generate_disclaimer,
+    mock_is_rtl,
+    mock_process_markdown,
+    mock_process_markdown_with_many_links,
+    mock_count_links_in_markdown,
+    mock_replace_code_blocks,
+    mock_generate_prompt_template,
+    mock_restore_code_blocks,
+    mock_update_links,
+    markdown_translator,
+):
+    """
+    Test the translate_markdown method to ensure it translates markdown content correctly.
+    """
+
+    mock_replace_code_blocks.return_value = (TEST_MD_CONTENT, {})
+    mock_count_links_in_markdown.return_value = 5
+    mock_process_markdown.return_value = ["Chunk 1"]
+    mock_generate_prompt_template.return_value = "Generated Prompt"
+    mock_run_prompts_sequentially.return_value = ["Translated Chunk"]
+    mock_restore_code_blocks.return_value = TRANSLATED_CONTENT
+    mock_update_links.return_value = TRANSLATED_CONTENT
+    mock_generate_disclaimer.return_value = TRANSLATED_DISCLAIMER
+    mock_is_rtl.return_value = False
+
+    result = await markdown_translator.translate_markdown(
+        document=TEST_MD_CONTENT,
+        language_code="es",
+        md_file_path="test.md"
+    )
+
+    # Assertions
+    assert result == TRANSLATED_CONTENT + "\n\n" + TRANSLATED_DISCLAIMER
+
+    mock_replace_code_blocks.assert_called_once_with(TEST_MD_CONTENT)
+    mock_count_links_in_markdown.assert_called_once_with(TEST_MD_CONTENT)
+    mock_process_markdown.assert_called_once_with(TEST_MD_CONTENT)
+    mock_generate_prompt_template.assert_called_once_with("es", "Chunk 1", False)
+    mock_run_prompts_sequentially.assert_called_once_with(["Generated Prompt"])
+    mock_restore_code_blocks.assert_called_once_with("Translated Chunk", {})
+    mock_update_links.assert_called_once_with(Path("test.md"), TRANSLATED_CONTENT, "es", markdown_translator.root_dir)
+    mock_generate_disclaimer.assert_called_once_with("es")
+
+@patch("co_op_translator.translators.markdown_translator.time.time", side_effect=[0, 1])
+@patch("co_op_translator.translators.markdown_translator.asyncio.sleep", new_callable=AsyncMock)
+@patch("co_op_translator.translators.markdown_translator.Kernel.invoke", new_callable=AsyncMock)
+@patch("co_op_translator.translators.markdown_translator.Kernel.add_function")
+@patch("co_op_translator.translators.markdown_translator.PromptTemplateConfig")
+@patch("co_op_translator.translators.markdown_translator.Kernel.get_prompt_execution_settings_from_service_id")
+@pytest.mark.asyncio
+async def test_run_prompt(
+    mock_get_settings,
+    mock_prompt_config,
+    mock_add_function,
+    mock_invoke,
+    mock_sleep,
+    mock_time,
+    markdown_translator,
+):
+    """
+    Test the _run_prompt method to ensure it executes prompts correctly.
+    """
+
+    mock_get_settings.return_value = MagicMock()
+    mock_add_function.return_value = "function"
+    mock_invoke.return_value = "Prompt Result"
+
+    result = await markdown_translator._run_prompt("Test Prompt", 1, 1)
+
+    assert result == "Prompt Result"
+    mock_get_settings.assert_called_once_with("chat-gpt")
+    mock_prompt_config.assert_called_once()
+    mock_add_function.assert_called_once()
+    mock_invoke.assert_called_once_with("function")
+    mock_sleep.assert_awaited_once_with(1)
+
+@patch("co_op_translator.translators.markdown_translator.MarkdownTranslator._run_prompt")
+@pytest.mark.asyncio
+async def test_generate_disclaimer(mock_run_prompt, markdown_translator):
+    """
+    Test the generate_disclaimer method to ensure it generates the disclaimer correctly.
+    """
+
+    mock_run_prompt.return_value = TRANSLATED_DISCLAIMER
+
+    result = await markdown_translator.generate_disclaimer("es")
+
+    assert result == TRANSLATED_DISCLAIMER
+
+    expected_prompt = dedent("""
+        Translate the following text to es.
+
+        **Disclaimer**: 
+        This document has been translated using machine-based AI translation services. While we strive for accuracy, please be aware that automated translations may contain errors or inaccuracies. The original document in its native language should be considered the authoritative source. For critical information, professional human translation is recommended. We are not liable for any misunderstandings or misinterpretations arising from the use of this translation.
+    """)
+
+    expected_prompt_normalized = ''.join(expected_prompt.split())
+    actual_prompt_normalized = ''.join(mock_run_prompt.call_args[0][0].split())
+
+    assert actual_prompt_normalized == expected_prompt_normalized, f"Expected:\n{expected_prompt}\n\nActual:\n{mock_run_prompt.call_args[0][0]}"
+
+@patch("co_op_translator.translators.markdown_translator.MarkdownTranslator._run_prompt")
+@pytest.mark.asyncio
+async def test_run_prompts_sequentially(mock_run_prompt, markdown_translator):
+
+    """
+    Test the _run_prompts_sequentially method to ensure it processes prompts sequentially.
+    """
+    mock_run_prompt.side_effect = ["Result 1", "Result 2"]
+
+    prompts = ["Prompt 1", "Prompt 2"]
+    results = await markdown_translator._run_prompts_sequentially(prompts)
+
+    assert results == ["Result 1", "Result 2"]
+    assert mock_run_prompt.await_count == 2
+    mock_run_prompt.assert_any_call("Prompt 1", 1, 2)
+    mock_run_prompt.assert_any_call("Prompt 2", 2, 2)


### PR DESCRIPTION
## Purpose

- This update refactors `test_image_translator` to use a temporary path instead of a real file path, which improves test reliability by isolating test output. 

- Added new tests for `markdown_translator` 

## Description

- Updated `ImageTranslator` tests to utilize `tmp_path` fixture for temporary directories in place of hardcoded paths.
- Enhanced `test_translate_image` to assert the correct temporary path for translated images, improving isolation and ensuring that temporary data is used during test execution.
- Added new tests for `markdown_translator`.

## Related Issue


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Type of change

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (e.g., formatting, local variables)
- [x] Refactoring (no functional or API changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Checklist

Before submitting your pull request, please confirm the following:

- [x] **I have thoroughly tested my changes**: I confirm that I have run the code and manually tested all affected areas.
- [x] **All existing tests pass**: I have run all tests and confirmed that nothing is broken.
- [x] **I have added new tests** (if applicable): I have written tests that cover the new functionality introduced by my code changes.
- [x] **I have followed the Co-op Translators coding conventions**: My code adheres to the style guide and coding conventions outlined in the repository.
- [x] **I have documented my changes** (if applicable): I have updated the documentation to reflect the changes where necessary.

## Additional context
