### PR TITLE
Translator: Fix bug in translation retry process, improve language-specific handling and efficiency

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Translate your project's Markdown files effortlessly with Co-op Translator!
 - **Easy integration**: Seamlessly integrate with your existing project setup.
 
 ### How it works
----
+
 ![Architecture](/imgs/architecture_241019.png)
 
 The process begins with Markdown and image files from your project folder, which are processed by **Azure AI Services**:

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Translate your project's Markdown files effortlessly with Co-op Translator!
 - **Easy integration**: Seamlessly integrate with your existing project setup.
 
 ### How it works
-
+---
 ![Architecture](/imgs/architecture_241019.png)
 
 The process begins with Markdown and image files from your project folder, which are processed by **Azure AI Services**:


### PR DESCRIPTION
## Purpose

<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
This PR addresses an issue in the translation retry process within the `check_and_retry_translations` method. It aims to prevent infinite loop scenarios by ensuring only specific language-file pairs are retried if translation errors are detected.
## Description

<!-- Provide a concise summary of your changes. Why is this change necessary? -->
This change refines the translation retry logic to handle only mismatched files for specific language codes

- Storing both file path and language code in the mismatched_files list, allowing precise retries for the affected language-file pairs
- Removing the unnecessary nested loop during the retry phase to eliminate redundant translations and potential infinite loops
- Simplifying the collection of markdown files by generating all language-file combinations at once, improving efficiency

## Related Issue

<!-- If this PR addresses an issue, please link it here (e.g., Fixes #123) -->

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

- [ ] Yes
- [x] No

## Type of change

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (e.g., formatting, local variables)
- [ ] Refactoring (no functional or API changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Checklist

Before submitting your pull request, please confirm the following:

- [x] **I have thoroughly tested my changes**: I confirm that I have run the code and manually tested all affected areas.
- [x] **All existing tests pass**: I have run all tests and confirmed that nothing is broken.
- [x] **I have added new tests** (if applicable): I have written tests that cover the new functionality introduced by my code changes.
- [x] **I have followed the Co-op Translators coding conventions**: My code adheres to the style guide and coding conventions outlined in the repository.
- [x] **I have documented my changes** (if applicable): I have updated the documentation to reflect the changes where necessary.

## Additional context

<!-- Add any additional context or screenshots if applicable -->
