### PR TITLE
Build, Docs: Update CONTRIBUTING.md and configuration files to align with new prefix convention

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,5 +1,5 @@
-# Apply 'translator' label for any changes in the translation-related source files
-translator:
+# Apply 'core' label for any changes in the core source files
+core:
   - src/co_op_translator/**/*
 
 # Apply 'language-support' label for changes related to font configurations or language support

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,6 +1,6 @@
 # Apply 'core' label for any changes in the core source files
 core:
-  - src/co_op_translator/**/*
+  - src/co_op_translator/core/**/*
 
 # Apply 'language-support' label for changes related to font configurations or language support
 language-support:

--- a/.github/workflows/label-title-prefix.yml
+++ b/.github/workflows/label-title-prefix.yml
@@ -23,7 +23,7 @@ jobs:
             const prefixLabels = {
               "documentation": "Docs",
               "build": "Build",
-              "translator": "Translator"
+              "core": "Core"
             };
 
             function addTitlePrefix(title, prefix) {

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to Co Op Translator
+# Contributing to Co-op Trnslator
 
 This project welcomes contributions and suggestions.  Most contributions require you to agree to a
 Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us
@@ -88,9 +88,9 @@ poetry install
 >
 >    [![Open in Dev Containers](https://img.shields.io/static/v1?style=for-the-badge&label=Dev%20Containers&message=Open&color=blue&logo=visualstudiocode)](https://vscode.dev/redirect?url=vscode://ms-vscode-remote.remote-containers/cloneInVolume?url=https://github.com/azure/co-op-translator)
 
-## Running Co Op Translator
+## Running Co-op Translator
 
-To run Co Op Translator using Poetry in your environment, follow these steps:
+To run Co-op Translator using Poetry in your environment, follow these steps:
 
 1. Navigate to the directory where you want to perform translation tests or create a temporary folder for testing purposes.
 
@@ -121,8 +121,8 @@ We use the following format for commit messages:
 
 - **type**: Specifies the category of the commit. We use the following types:
   - `Docs`: For documentation updates.
-  - `Build`: For changes to the build system or dependencies.
-  - `Core`: For changes that affect the core functionality or features of the project.
+  - `Build`: For changes related to the build system or dependencies, including updates to configuration files, CI workflows, or the Dockerfile.
+  - `Core`: For modifications to the project's core functionality or features, particularly those involving files in the `src/co_op_translator/core` directory.
 
 - **description**: A concise summary of the change.
 - **PR number**: The number of the pull request associated with the commit.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,7 +69,7 @@ poetry install
 >
 > #### GitHub Codespaces
 >
-> You can run this samples virtually by using GitHub Codespaces and no additional settings or setup are required. 
+> You can run this samples virtually by using GitHub Codespaces and no additional settings or setup are required.
 >
 > The button will open a web-based VS Code instance in your browser:
 >
@@ -122,7 +122,7 @@ We use the following format for commit messages:
 - **type**: Specifies the category of the commit. We use the following types:
   - `Docs`: For documentation updates.
   - `Build`: For changes to the build system or dependencies.
-  - `Translator`: For changes affecting the translation logic or features.
+  - `Core`: For changes that affect the core functionality or features of the project.
 
 - **description**: A concise summary of the change.
 - **PR number**: The number of the pull request associated with the commit.
@@ -130,10 +130,10 @@ We use the following format for commit messages:
 **Examples**:
 
 - `Docs: Update installation instructions for clarity (#50)`
-- `Translator: Improve handling of image translation (#60)`
+- `Core: Improve handling of image translation (#60)`
 
 > [!NOTE]
-> Currently, the Docs, Translator, and Build prefixes are automatically added to PR titles based on the labels applied to the modified source code. As long as the correct label is applied, you typically don't need to manually update the PR title. You just need to verify that everything is correct and the prefix has been generated appropriately.
+> Currently, the **`Docs`**, **`Core`**, and **`Build`** prefixes are automatically added to PR titles based on the labels applied to the modified source code. As long as the correct label is applied, you typically don't need to manually update the PR title. You just need to verify that everything is correct and the prefix has been generated appropriately.
 
 #### Merge strategy
 


### PR DESCRIPTION
## Purpose

<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
This pull request updates the `CONTRIBUTING.md` file and associated configuration files to align with the updated prefix convention for commits and labels. Specifically, it replaces the `Translator` prefix with `Core` for changes affecting the core functionality of the project.

## Description

<!-- Provide a concise summary of your changes. Why is this change necessary? -->

- Updated the `CONTRIBUTING.md` to reflect the updated prefix convention for commits.
- Modified `.github/labeler.yml` to apply the `Core` label for changes in `src/co_op_translator/**/*`.
- Adjusted `.github/workflows/label-title-prefix.yml` to use the `Core` prefix for commits instead of `Translator`.

## Related Issue

<!-- If this PR addresses an issue, please link it here (e.g., Fixes #123) -->

Fixes #33

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

- [ ] Yes
- [x] No

## Type of change

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (e.g., formatting, local variables)
- [x] Refactoring (no functional or API changes)
- [x] Documentation content changes
- [ ] Other... Please describe:

## Checklist

Before submitting your pull request, please confirm the following:

- [ ] **I have thoroughly tested my changes**: I confirm that I have run the code and manually tested all affected areas.
- [ ] **All existing tests pass**: I have run all tests and confirmed that nothing is broken.
- [ ] **I have added new tests** (if applicable): I have written tests that cover the new functionality introduced by my code changes.
- [x] **I have followed the Co-op Translators coding conventions**: My code adheres to the style guide and coding conventions outlined in the repository.
- [x] **I have documented my changes** (if applicable): I have updated the documentation to reflect the changes where necessary.

## Additional context

<!-- Add any additional context or screenshots if applicable -->
This change is part of a broader effort to standardize labels and prefixes, ensuring better clarity and consistency in the repository's commit history and pull request process.