### PR TITLE
Core, Build, Docs: Add Black code formatter and apply formatting

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,6 +88,69 @@ poetry install
 >
 >    [![Open in Dev Containers](https://img.shields.io/static/v1?style=for-the-badge&label=Dev%20Containers&message=Open&color=blue&logo=visualstudiocode)](https://vscode.dev/redirect?url=vscode://ms-vscode-remote.remote-containers/cloneInVolume?url=https://github.com/azure/co-op-translator)
 
+
+### Code Style
+
+We use [Black](https://github.com/psf/black) as our Python code formatter to maintain consistent code style across the project. Black is an uncompromising code formatter that automatically reformats Python code to conform to the Black code style.
+
+#### Configuration
+
+The Black configuration is specified in our `pyproject.toml`:
+
+```toml
+[tool.black]
+line-length = 88
+target-version = ['py310']
+include = '\.pyi?$'
+```
+
+#### Installing Black
+
+You can install Black using either Poetry (recommended) or pip:
+
+##### Using Poetry
+
+Black is automatically installed when you set up the development environment:
+```bash
+poetry install
+```
+
+##### Using pip
+
+If you're using pip, you can install Black directly:
+```bash
+pip install black
+```
+
+#### Using Black
+
+##### With Poetry
+
+1. Format all Python files in the project:
+    ```bash
+    poetry run black .
+    ```
+
+2. Format a specific file or directory:
+    ```bash
+    poetry run black path/to/file_or_directory
+    ```
+
+##### With pip
+
+1. Format all Python files in the project:
+    ```bash
+    black .
+    ```
+
+2. Format a specific file or directory:
+    ```bash
+    black path/to/file_or_directory
+    ```
+
+> [!TIP]
+> We recommend setting up your editor to automatically format code with Black on save. Most modern editors support this through extensions or plugins.
+
 ## Running Co-op Translator
 
 To run Co-op Translator using Poetry in your environment, follow these steps:

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ _Easily generate multilingual translations for your project with a single comman
 [![License: MIT](https://img.shields.io/github/license/azure/co-op-translator?color=4BA3FF)](https://github.com/azure/co-op-translator/blob/main/LICENSE)
 [![Downloads](https://static.pepy.tech/badge/co-op-translator)](https://pepy.tech/project/co-op-translator)
 [![Downloads](https://static.pepy.tech/badge/co-op-translator/month)](https://pepy.tech/project/co-op-translator)
+[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 
 [![GitHub contributors](https://img.shields.io/github/contributors/azure/co-op-translator.svg)](https://GitHub.com/azure/co-op-translator/graphs/contributors/)
 [![GitHub issues](https://img.shields.io/github/issues/azure/co-op-translator.svg)](https://GitHub.com/azure/co-op-translator/issues/)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,6 +129,11 @@ disable_error_code = ["type-var"]
 namespace_packages = true
 ignore_missing_imports = true
 
+[tool.black]
+line-length = 88
+target-version = ['py310']
+include = '\.pyi?$'
+
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"

--- a/src/co_op_translator/__main__.py
+++ b/src/co_op_translator/__main__.py
@@ -9,15 +9,42 @@ from co_op_translator.config.vision_config.config import VisionConfig
 
 logger = logging.getLogger(__name__)
 
+
 @click.command()
-@click.option('--language-codes', '-l', required=True, help='Space-separated language codes for translation (e.g., "es fr de" or "all").')
-@click.option('--root-dir', '-r', default='.', help='Root directory of the project (default is current directory).')
-@click.option('--add', '-a', is_flag=True, default=True, help='Add new translations without deleting existing ones (default behavior).')
-@click.option('--update', '-u', is_flag=True, help='Update translations by deleting and recreating them (Warning: Existing translations will be lost).')
-@click.option('--images', '-img', is_flag=True, help='Only translate image files.')
-@click.option('--markdown', '-md', is_flag=True, help='Only translate markdown files.')
-@click.option('--debug', '-d', is_flag=True, help='Enable debug mode.')
-@click.option('--check', '-chk', is_flag=True, help='Check translated files for errors and retry translation if needed.')
+@click.option(
+    "--language-codes",
+    "-l",
+    required=True,
+    help='Space-separated language codes for translation (e.g., "es fr de" or "all").',
+)
+@click.option(
+    "--root-dir",
+    "-r",
+    default=".",
+    help="Root directory of the project (default is current directory).",
+)
+@click.option(
+    "--add",
+    "-a",
+    is_flag=True,
+    default=True,
+    help="Add new translations without deleting existing ones (default behavior).",
+)
+@click.option(
+    "--update",
+    "-u",
+    is_flag=True,
+    help="Update translations by deleting and recreating them (Warning: Existing translations will be lost).",
+)
+@click.option("--images", "-img", is_flag=True, help="Only translate image files.")
+@click.option("--markdown", "-md", is_flag=True, help="Only translate markdown files.")
+@click.option("--debug", "-d", is_flag=True, help="Enable debug mode.")
+@click.option(
+    "--check",
+    "-chk",
+    is_flag=True,
+    help="Check translated files for errors and retry translation if needed.",
+)
 def main(language_codes, root_dir, add, update, images, markdown, debug, check):
     """
     CLI for translating project files.
@@ -62,13 +89,18 @@ def main(language_codes, root_dir, add, update, images, markdown, debug, check):
     # Set markdown-only mode if Computer Vision is not available
     if not cv_available:
         markdown = True
-        click.echo("Computer Vision is not configured: Automatically switching to markdown-only mode.")
-        click.echo("To enable image translation, please add Computer Vision credentials to your environment variables.")
+        click.echo(
+            "Computer Vision is not configured: Automatically switching to markdown-only mode."
+        )
+        click.echo(
+            "To enable image translation, please add Computer Vision credentials to your environment variables."
+        )
         click.echo("See the .env.template file for required variables.")
     elif markdown:
         click.echo("Starting in markdown-only mode: Image translation is disabled.")
-        click.echo("To enable image translation, run without the -md flag and ensure Computer Vision is configured.")
-
+        click.echo(
+            "To enable image translation, run without the -md flag and ensure Computer Vision is configured."
+        )
 
     if debug:
         logging.basicConfig(level=logging.DEBUG)
@@ -78,12 +110,19 @@ def main(language_codes, root_dir, add, update, images, markdown, debug, check):
 
     # Show warning if 'all' is selected
     if language_codes == "all":
-        click.echo("Warning: Translating all languages at once can take a significant amount of time, especially when dealing with large markdown-based open-source projects that have many documents.")
-        click.echo("For better efficiency, it's recommended that contributors handle individual languages and upload their translations separately.")
+        click.echo(
+            "Warning: Translating all languages at once can take a significant amount of time, especially when dealing with large markdown-based open-source projects that have many documents."
+        )
+        click.echo(
+            "For better efficiency, it's recommended that contributors handle individual languages and upload their translations separately."
+        )
         # Option to proceed or not
-        confirmation_all = click.prompt("Do you still want to proceed with translating all languages? Type 'yes' to continue", type=str)
-        
-        if confirmation_all.lower() != 'yes':
+        confirmation_all = click.prompt(
+            "Do you still want to proceed with translating all languages? Type 'yes' to continue",
+            type=str,
+        )
+
+        if confirmation_all.lower() != "yes":
             click.echo("Translation for 'all' languages cancelled.")
             return
         else:
@@ -91,10 +130,14 @@ def main(language_codes, root_dir, add, update, images, markdown, debug, check):
 
     # Show warning and prompt if update is selected
     if update:
-        click.echo(f"Warning: The update command will delete all existing translations for '{language_codes}' and re-translate everything.")
-        confirmation_update = click.prompt("Do you want to continue? Type 'yes' to proceed", type=str)
-        
-        if confirmation_update.lower() != 'yes':
+        click.echo(
+            f"Warning: The update command will delete all existing translations for '{language_codes}' and re-translate everything."
+        )
+        confirmation_update = click.prompt(
+            "Do you want to continue? Type 'yes' to proceed", type=str
+        )
+
+        if confirmation_update.lower() != "yes":
             click.echo("Update cancelled by user.")
             return
         else:
@@ -102,11 +145,21 @@ def main(language_codes, root_dir, add, update, images, markdown, debug, check):
 
     # Language code parsing logic
     if language_codes == "all":
-        with importlib.resources.path('co_op_translator.fonts', 'font_language_mappings.yml') as mappings_path:
-            with open(mappings_path, 'r', encoding='utf-8') as file:
+        with importlib.resources.path(
+            "co_op_translator.fonts", "font_language_mappings.yml"
+        ) as mappings_path:
+            with open(mappings_path, "r", encoding="utf-8") as file:
                 font_mappings = yaml.safe_load(file)
-                language_codes = " ".join([lang_code for lang_code in font_mappings if isinstance(font_mappings[lang_code], dict)])
-                logging.debug(f"Loaded language codes from font mapping: {language_codes}")
+                language_codes = " ".join(
+                    [
+                        lang_code
+                        for lang_code in font_mappings
+                        if isinstance(font_mappings[lang_code], dict)
+                    ]
+                )
+                logging.debug(
+                    f"Loaded language codes from font mapping: {language_codes}"
+                )
 
     # Initialize ProjectTranslator with markdown_only flag
     translator = ProjectTranslator(language_codes, root_dir, markdown_only=markdown)
@@ -119,17 +172,20 @@ def main(language_codes, root_dir, add, update, images, markdown, debug, check):
         # Set default values for images and markdown flags
         if not images and not markdown:
             markdown = True  # Always translate markdown by default
-            images = True   # Try to translate images by default
-            
+            images = True  # Try to translate images by default
+
         # If CV is not available, disable image translation
         if not cv_available:
-            click.echo("Skipping image translation due to missing Computer Vision configuration")
+            click.echo(
+                "Skipping image translation due to missing Computer Vision configuration"
+            )
             images = False
-        
+
         # Call translate_project
         translator.translate_project(images=images, markdown=markdown, update=update)
 
     logger.info(f"Project translation completed for languages: {language_codes}")
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()

--- a/src/co_op_translator/config/base_config.py
+++ b/src/co_op_translator/config/base_config.py
@@ -7,35 +7,36 @@ from co_op_translator.config.vision_config.config import VisionConfig
 
 logger = logging.getLogger(__name__)
 
+
 class Config:
     """
     Central configuration class that combines all service-specific configurations.
     """
-    
+
     @classmethod
-    def load_environment(cls, root_dir='.'):
+    def load_environment(cls, root_dir="."):
         """
         Load environment variables from the target project's root directory.
-        
+
         Args:
             root_dir: Root directory of the target project (default is current directory).
         """
-        env_path = Path(root_dir) / '.env'
+        env_path = Path(root_dir) / ".env"
         if env_path.exists():
             load_dotenv(dotenv_path=env_path)
         else:
             logger.debug(f"No .env file found in {env_path}")
-    
+
     @staticmethod
     def check_configuration():
         """
         Check if all required services are properly configured.
-        
+
         Raises:
             ValueError: If no LLM service is properly configured
         """
 
         LLMConfig.check_configuration()
-        
+
         # Vision configuration is optional
         VisionConfig.check_configuration()

--- a/src/co_op_translator/config/constants.py
+++ b/src/co_op_translator/config/constants.py
@@ -1,5 +1,19 @@
-SUPPORTED_IMAGE_EXTENSIONS = {'.png', '.jpg', '.jpeg'}
+SUPPORTED_IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg"}
 EXCLUDED_DIRS = {
-    'translations', 'translated_images' ,'.git', '.github', '.vscode', '__pycache__', 'node_modules', 'build', 'dist', 'venv',
-    'env', 'site-packages', '.venv', '.idea', '.devcontainer', '.pytest_cache'
+    "translations",
+    "translated_images",
+    ".git",
+    ".github",
+    ".vscode",
+    "__pycache__",
+    "node_modules",
+    "build",
+    "dist",
+    "venv",
+    "env",
+    "site-packages",
+    ".venv",
+    ".idea",
+    ".devcontainer",
+    ".pytest_cache",
 }

--- a/src/co_op_translator/config/font_config.py
+++ b/src/co_op_translator/config/font_config.py
@@ -1,14 +1,17 @@
 import importlib.resources
 import yaml
 
+
 class FontConfig:
 
     def __init__(self):
         """
         Initialize the FontConfig class by loading the font mappings from a YAML file.
         """
-        with importlib.resources.path('co_op_translator.fonts', 'font_language_mappings.yml') as mappings_path:
-            with open(mappings_path, 'r', encoding='utf-8') as file:
+        with importlib.resources.path(
+            "co_op_translator.fonts", "font_language_mappings.yml"
+        ) as mappings_path:
+            with open(mappings_path, "r", encoding="utf-8") as file:
                 self.font_mappings = yaml.safe_load(file)
 
     def get_font_path(self, language_code):
@@ -24,6 +27,7 @@ class FontConfig:
         Raises:
             ValueError: If the language code or font is not found in the mappings.
         """
+
     def get_font_path(self, language_code):
         """
         Retrieve the font path for a given language code.
@@ -37,12 +41,14 @@ class FontConfig:
         Raises:
             ValueError: If the language code or font is not found in the mappings.
         """
-        font_name = self.font_mappings.get(language_code, {}).get('font')
-        
+        font_name = self.font_mappings.get(language_code, {}).get("font")
+
         if not font_name:
-            raise ValueError(f"Font for language code '{language_code}' is not supported or not found.")
-        
-        with importlib.resources.path('co_op_translator.fonts', font_name) as font_path:
+            raise ValueError(
+                f"Font for language code '{language_code}' is not supported or not found."
+            )
+
+        with importlib.resources.path("co_op_translator.fonts", font_name) as font_path:
             return str(font_path)
 
     def get_language_name(self, language_code):
@@ -60,8 +66,8 @@ class FontConfig:
         """
         if language_code not in self.font_mappings:
             raise ValueError(f"Language code '{language_code}' is not supported.")
-        
-        return self.font_mappings.get(language_code, {}).get('name', language_code)
+
+        return self.font_mappings.get(language_code, {}).get("name", language_code)
 
     def is_rtl(self, language_code):
         """
@@ -78,7 +84,6 @@ class FontConfig:
         """
         if language_code not in self.font_mappings:
             raise ValueError(f"Language code '{language_code}' is not supported.")
-        
+
         # Return RTL info if available, default to False
-        return self.font_mappings.get(language_code, {}).get('rtl', False)
-    
+        return self.font_mappings.get(language_code, {}).get("rtl", False)

--- a/src/co_op_translator/config/llm_config/azure_openai.py
+++ b/src/co_op_translator/config/llm_config/azure_openai.py
@@ -1,8 +1,9 @@
 import os
 
+
 class AzureOpenAIConfig:
     """Azure OpenAI specific configuration."""
-    
+
     @staticmethod
     def get_api_key():
         """Retrieve the Azure OpenAI API key from environment variables."""

--- a/src/co_op_translator/config/llm_config/config.py
+++ b/src/co_op_translator/config/llm_config/config.py
@@ -8,17 +8,22 @@ from co_op_translator.config.llm_config.openai import OpenAIConfig
 
 logger = logging.getLogger(__name__)
 
+
 @dataclass
 class LLMServiceConfig:
     """Configuration for a specific LLM service."""
+
     required: bool
     env_vars: Dict[str, Optional[str]]
+
 
 class LLMConfig:
     """Configuration for LLM-related services."""
 
     @classmethod
-    def validate_env_vars(cls, env_vars: Dict[str, Optional[str]], provider: LLMProvider):
+    def validate_env_vars(
+        cls, env_vars: Dict[str, Optional[str]], provider: LLMProvider
+    ):
         """
         Validate environment variables for a given provider.
         - For OpenAI, only 'OPENAI_API_KEY' is required.
@@ -37,7 +42,9 @@ class LLMConfig:
 
             # If OPENAI_API_KEY is missing or empty, it's incomplete
             if not env_vars.get("OPENAI_API_KEY"):
-                raise ValueError("Incomplete OpenAI configuration. The 'OPENAI_API_KEY' must be set.")
+                raise ValueError(
+                    "Incomplete OpenAI configuration. The 'OPENAI_API_KEY' must be set."
+                )
 
         elif provider == LLMProvider.AZURE_OPENAI:
             # If there's no environment variable filled at all

--- a/src/co_op_translator/config/llm_config/openai.py
+++ b/src/co_op_translator/config/llm_config/openai.py
@@ -1,8 +1,9 @@
 import os
 
+
 class OpenAIConfig:
     """OpenAI specific configuration."""
-    
+
     @staticmethod
     def get_api_key():
         """Retrieve the OpenAI API key from environment variables."""

--- a/src/co_op_translator/config/llm_config/provider.py
+++ b/src/co_op_translator/config/llm_config/provider.py
@@ -1,28 +1,33 @@
 """
 Provider-related configurations and enums.
 """
+
 from enum import Enum
 from dataclasses import dataclass
 from typing import Dict, Optional
 
+
 class LLMProvider(Enum):
     """LLM service providers with their configurations."""
+
     AZURE_OPENAI = "azure_openai"
     OPENAI = "openai"
-    
+
     @property
     def display_name(self) -> str:
         """Get a human-readable display name."""
-        return self.value.replace('_', ' ').title()
-    
+        return self.value.replace("_", " ").title()
+
     @property
     def env_prefix(self) -> str:
         """Get the environment variable prefix for this provider."""
         return self.value.upper() + "_"
 
+
 @dataclass
 class LLMServiceConfig:
     """Configuration for a specific LLM service."""
+
     required: bool
     priority: int
     env_vars: Dict[str, Optional[str]]

--- a/src/co_op_translator/config/vision_config/azure_computer_vision.py
+++ b/src/co_op_translator/config/vision_config/azure_computer_vision.py
@@ -1,8 +1,9 @@
 import os
 
+
 class AzureComputerVisionConfig:
     """Azure Computer Vision specific configuration."""
-    
+
     @staticmethod
     def get_subscription_key():
         """Retrieve the Azure subscription key from environment variables."""

--- a/src/co_op_translator/config/vision_config/config.py
+++ b/src/co_op_translator/config/vision_config/config.py
@@ -2,57 +2,69 @@ from dataclasses import dataclass
 from typing import Dict, Optional
 import logging
 from co_op_translator.config.vision_config.provider import VisionProvider
-from co_op_translator.config.vision_config.azure_computer_vision import AzureComputerVisionConfig
+from co_op_translator.config.vision_config.azure_computer_vision import (
+    AzureComputerVisionConfig,
+)
 
 logger = logging.getLogger(__name__)
+
 
 @dataclass
 class VisionServiceConfig:
     """Configuration for a specific Vision service"""
+
     required: bool
     env_vars: Dict[str, Optional[str]]
 
+
 class VisionConfig:
     """Configuration for Vision-related services."""
-    
+
     @classmethod
     def get_available_provider(cls) -> Optional[VisionProvider]:
         """
         Check environment variables and return the available Vision provider.
         Currently only supports Azure Computer Vision.
-        
+
         Returns:
             Optional[VisionProvider]: The available provider to use, or None if no provider is configured
         """
         for provider in VisionProvider:
             config = cls.get_service_config(provider)
-            if config and all(value and value.strip() for value in config.env_vars.values()):
+            if config and all(
+                value and value.strip() for value in config.env_vars.values()
+            ):
                 return provider
         return None
 
     @classmethod
-    def get_service_config(cls, provider: VisionProvider) -> Optional[VisionServiceConfig]:
+    def get_service_config(
+        cls, provider: VisionProvider
+    ) -> Optional[VisionServiceConfig]:
         """
         Get configuration for a specific Vision service.
-        
+
         Args:
             provider: Vision provider to get configuration for.
-            
+
         Returns:
             Optional[VisionServiceConfig]: Service configuration if available, None if not configured
         """
         if provider == VisionProvider.AZURE_COMPUTER_VISION:
             azure_config = AzureComputerVisionConfig()
             # If any required environment variable is missing, return None
-            if not azure_config.get_subscription_key() or not azure_config.get_endpoint():
+            if (
+                not azure_config.get_subscription_key()
+                or not azure_config.get_endpoint()
+            ):
                 return None
-                
+
             return VisionServiceConfig(
                 required=True,
                 env_vars={
                     "AZURE_SUBSCRIPTION_KEY": azure_config.get_subscription_key(),
                     "AZURE_AI_SERVICE_ENDPOINT": azure_config.get_endpoint(),
-                }
+                },
             )
         return None
 
@@ -60,7 +72,7 @@ class VisionConfig:
     def check_configuration() -> bool:
         """
         Check if Computer Vision service is available and properly configured.
-        
+
         Returns:
             bool: True if Computer Vision is available and configured, False otherwise
         """

--- a/src/co_op_translator/config/vision_config/provider.py
+++ b/src/co_op_translator/config/vision_config/provider.py
@@ -1,22 +1,25 @@
 """
 Defines providers for Vision-related services.
 """
+
 from enum import Enum
+
 
 class VisionProvider(Enum):
     """
     Available Vision service providers.
-    
+
     Providers are listed in order of priority.
     """
+
     AZURE_COMPUTER_VISION = "azure_computer_vision"  # Highest priority
     # Future vision services can be added here
 
     @property
     def display_name(self) -> str:
         """Get a human-readable display name."""
-        return self.value.replace('_', ' ').title()
-    
+        return self.value.replace("_", " ").title()
+
     @property
     def env_prefix(self) -> str:
         """Get the environment variable prefix for this provider."""

--- a/src/co_op_translator/core/llm/__init__.py
+++ b/src/co_op_translator/core/llm/__init__.py
@@ -1,9 +1,15 @@
-from co_op_translator.core.llm.providers.azure import AzureTextTranslator, AzureMarkdownTranslator
-from co_op_translator.core.llm.providers.openai import OpenAITextTranslator, OpenAIMarkdownTranslator
+from co_op_translator.core.llm.providers.azure import (
+    AzureTextTranslator,
+    AzureMarkdownTranslator,
+)
+from co_op_translator.core.llm.providers.openai import (
+    OpenAITextTranslator,
+    OpenAIMarkdownTranslator,
+)
 
 __all__ = [
-    'AzureTextTranslator',
-    'AzureMarkdownTranslator',
-    'OpenAITextTranslator',
-    'OpenAIMarkdownTranslator'
+    "AzureTextTranslator",
+    "AzureMarkdownTranslator",
+    "OpenAITextTranslator",
+    "OpenAIMarkdownTranslator",
 ]

--- a/src/co_op_translator/core/llm/markdown_translator.py
+++ b/src/co_op_translator/core/llm/markdown_translator.py
@@ -10,16 +10,17 @@ from co_op_translator.utils.llm.markdown_utils import (
     count_links_in_markdown,
     process_markdown_with_many_links,
     replace_code_blocks_and_inline_code,
-    restore_code_blocks_and_inline_code
+    restore_code_blocks_and_inline_code,
 )
 from co_op_translator.config.font_config import FontConfig
 from co_op_translator.config.llm_config.config import LLMConfig
 
 logger = logging.getLogger(__name__)
 
+
 class MarkdownTranslator(ABC):
     """Base class for markdown translation services."""
-    
+
     def __init__(self, root_dir: Path = None):
         """
         Initialize the MarkdownTranslator.
@@ -30,7 +31,13 @@ class MarkdownTranslator(ABC):
         self.root_dir = root_dir
         self.font_config = FontConfig()
 
-    async def translate_markdown(self, document: str, language_code: str, md_file_path: str | Path, markdown_only: bool = False) -> str:
+    async def translate_markdown(
+        self,
+        document: str,
+        language_code: str,
+        md_file_path: str | Path,
+        markdown_only: bool = False,
+    ) -> str:
         """
         Translate the markdown document to the specified language, handling documents with more than 10 links by splitting them into chunks.
 
@@ -46,27 +53,48 @@ class MarkdownTranslator(ABC):
         md_file_path = Path(md_file_path)
 
         # Step 1: Replace code blocks and inline code with placeholders
-        document_with_placeholders, placeholder_map = replace_code_blocks_and_inline_code(document)
+        document_with_placeholders, placeholder_map = (
+            replace_code_blocks_and_inline_code(document)
+        )
 
         # Step 2: Split the document into chunks and generate prompts
         link_limit = 30
         if count_links_in_markdown(document_with_placeholders) > link_limit:
-            logger.info(f"Document contains more than {link_limit} links, splitting the document into chunks.")
-            document_chunks = process_markdown_with_many_links(document_with_placeholders, link_limit)
+            logger.info(
+                f"Document contains more than {link_limit} links, splitting the document into chunks."
+            )
+            document_chunks = process_markdown_with_many_links(
+                document_with_placeholders, link_limit
+            )
         else:
-            logger.info(f"Document contains {link_limit} or fewer links, processing normally.")
+            logger.info(
+                f"Document contains {link_limit} or fewer links, processing normally."
+            )
             document_chunks = process_markdown(document_with_placeholders)
 
         # Step 3: Generate translation prompts and translate each chunk
-        prompts = [generate_prompt_template(language_code, chunk, self.font_config.is_rtl(language_code)) for chunk in document_chunks]
+        prompts = [
+            generate_prompt_template(
+                language_code, chunk, self.font_config.is_rtl(language_code)
+            )
+            for chunk in document_chunks
+        ]
         results = await self._run_prompts_sequentially(prompts)
         translated_content = "\n".join(results)
 
         # Step 4: Restore the code blocks and inline code from placeholders
-        translated_content = restore_code_blocks_and_inline_code(translated_content, placeholder_map)
+        translated_content = restore_code_blocks_and_inline_code(
+            translated_content, placeholder_map
+        )
 
         # Step 5: Update links and add disclaimer
-        updated_content = update_links(md_file_path, translated_content, language_code, self.root_dir, markdown_only=markdown_only)
+        updated_content = update_links(
+            md_file_path,
+            translated_content,
+            language_code,
+            self.root_dir,
+            markdown_only=markdown_only,
+        )
         disclaimer = await self.generate_disclaimer(language_code)
         updated_content += "\n\n" + disclaimer
 
@@ -86,15 +114,18 @@ class MarkdownTranslator(ABC):
         for index, prompt in enumerate(prompts):
             try:
                 result = await asyncio.wait_for(
-                    self._run_prompt(prompt, index + 1, len(prompts)),
-                    timeout=300
+                    self._run_prompt(prompt, index + 1, len(prompts)), timeout=300
                 )
                 results.append(result)
             except asyncio.TimeoutError:
                 logger.warning(f"Chunk {index + 1} translation timed out. Skipping...")
-                results.append(f"Translation for chunk {index + 1} skipped due to timeout.")
+                results.append(
+                    f"Translation for chunk {index + 1} skipped due to timeout."
+                )
             except Exception as e:
-                logger.error(f"Error during prompt execution for chunk {index + 1}: {e}")
+                logger.error(
+                    f"Error during prompt execution for chunk {index + 1}: {e}"
+                )
                 results.append(f"Error during translation of chunk {index + 1}")
         return results
 
@@ -129,30 +160,36 @@ class MarkdownTranslator(ABC):
         **Disclaimer**: 
         This document has been translated using machine-based AI translation services. While we strive for accuracy, please be aware that automated translations may contain errors or inaccuracies. The original document in its native language should be considered the authoritative source. For critical information, professional human translation is recommended. We are not liable for any misunderstandings or misinterpretations arising from the use of this translation."""
 
-        disclaimer = await self._run_prompt(disclaimer_prompt, 'disclaimer prompt', 1)
-        
+        disclaimer = await self._run_prompt(disclaimer_prompt, "disclaimer prompt", 1)
+
         return disclaimer
 
     @classmethod
-    def create(cls, root_dir: Path = None) -> 'MarkdownTranslator':
+    def create(cls, root_dir: Path = None) -> "MarkdownTranslator":
         """
         Factory method to create appropriate markdown translator based on available provider.
-        
+
         Args:
             root_dir: Optional root directory for the project
-            
+
         Returns:
             MarkdownTranslator: An instance of the appropriate markdown translator.
         """
         provider = LLMConfig.get_available_provider()
         if provider is None:
             raise ValueError("No valid LLM provider configured")
-            
+
         if provider == LLMProvider.AZURE_OPENAI:
-            from co_op_translator.core.llm.providers.azure.markdown_translator import AzureMarkdownTranslator
+            from co_op_translator.core.llm.providers.azure.markdown_translator import (
+                AzureMarkdownTranslator,
+            )
+
             return AzureMarkdownTranslator(root_dir)
         elif provider == LLMProvider.OPENAI:
-            from co_op_translator.core.llm.providers.openai.markdown_translator import OpenAIMarkdownTranslator
+            from co_op_translator.core.llm.providers.openai.markdown_translator import (
+                OpenAIMarkdownTranslator,
+            )
+
             return OpenAIMarkdownTranslator(root_dir)
         else:
             raise ValueError(f"Unsupported provider: {provider}")

--- a/src/co_op_translator/core/llm/providers/azure/__init__.py
+++ b/src/co_op_translator/core/llm/providers/azure/__init__.py
@@ -1,4 +1,8 @@
-from co_op_translator.core.llm.providers.azure.text_translator import AzureTextTranslator
-from co_op_translator.core.llm.providers.azure.markdown_translator import AzureMarkdownTranslator
+from co_op_translator.core.llm.providers.azure.text_translator import (
+    AzureTextTranslator,
+)
+from co_op_translator.core.llm.providers.azure.markdown_translator import (
+    AzureMarkdownTranslator,
+)
 
-__all__ = ['AzureTextTranslator', 'AzureMarkdownTranslator']
+__all__ = ["AzureTextTranslator", "AzureMarkdownTranslator"]

--- a/src/co_op_translator/core/llm/providers/azure/markdown_translator.py
+++ b/src/co_op_translator/core/llm/providers/azure/markdown_translator.py
@@ -11,13 +11,14 @@ from co_op_translator.core.llm.markdown_translator import MarkdownTranslator
 
 logger = logging.getLogger(__name__)
 
+
 class AzureMarkdownTranslator(MarkdownTranslator):
     """Azure OpenAI implementation for markdown translation."""
-    
+
     def __init__(self, root_dir: Path = None):
         """
         Initialize Azure Markdown Translator.
-        
+
         Args:
             root_dir: Optional root directory for the project
         """
@@ -39,7 +40,7 @@ class AzureMarkdownTranslator(MarkdownTranslator):
                 service_id=service_id,
                 deployment_name=AzureOpenAIConfig.get_chat_deployment_name(),
                 endpoint=AzureOpenAIConfig.get_endpoint(),
-                api_key=AzureOpenAIConfig.get_api_key()
+                api_key=AzureOpenAIConfig.get_api_key(),
             )
         )
         return kernel
@@ -47,28 +48,30 @@ class AzureMarkdownTranslator(MarkdownTranslator):
     async def _run_prompt(self, prompt: str, index: int, total: int) -> str:
         """
         Execute a single translation prompt using Azure OpenAI.
-        
+
         Args:
             prompt: The translation prompt
             index: Current chunk index
             total: Total number of chunks
-            
+
         Returns:
             str: Translated text
         """
         try:
             # Initialize settings for all prompts
-            req_settings = self.kernel.get_prompt_execution_settings_from_service_id(LLMProvider.AZURE_OPENAI.value)
+            req_settings = self.kernel.get_prompt_execution_settings_from_service_id(
+                LLMProvider.AZURE_OPENAI.value
+            )
             req_settings.max_tokens = 4096
             req_settings.temperature = 0.7
             req_settings.top_p = 0.8
 
             # Log appropriate message based on prompt type
-            if index == 'disclaimer' or isinstance(index, str):
+            if index == "disclaimer" or isinstance(index, str):
                 logger.info(f"Running system prompt: {index}")
             else:
                 logger.info(f"Running translation prompt {index}/{total}")
-            
+
             start_time = time.time()
 
             prompt_template_config = PromptTemplateConfig(
@@ -87,7 +90,9 @@ class AzureMarkdownTranslator(MarkdownTranslator):
 
             result = await self.kernel.invoke(function)
             end_time = time.time()
-            logger.info(f"Prompt {index}/{total} completed in {end_time - start_time} seconds")
+            logger.info(
+                f"Prompt {index}/{total} completed in {end_time - start_time} seconds"
+            )
 
             await asyncio.sleep(1)
             return str(result)

--- a/src/co_op_translator/core/llm/providers/azure/text_translator.py
+++ b/src/co_op_translator/core/llm/providers/azure/text_translator.py
@@ -2,9 +2,10 @@ from openai import AzureOpenAI
 from co_op_translator.core.llm.text_translator import TextTranslator
 from co_op_translator.config.llm_config.azure_openai import AzureOpenAIConfig
 
+
 class AzureTextTranslator(TextTranslator):
     """Azure OpenAI implementation for text translation."""
-    
+
     def __init__(self):
         """Initialize Azure Text Translator."""
         self.client = self.get_openai_client()
@@ -19,7 +20,7 @@ class AzureTextTranslator(TextTranslator):
         return AzureOpenAI(
             api_key=AzureOpenAIConfig.get_api_key(),
             api_version=AzureOpenAIConfig.get_api_version(),
-            base_url=f"{AzureOpenAIConfig.get_endpoint()}/openai/deployments/{AzureOpenAIConfig.get_chat_deployment_name()}"
+            base_url=f"{AzureOpenAIConfig.get_endpoint()}/openai/deployments/{AzureOpenAIConfig.get_chat_deployment_name()}",
         )
 
     def get_model_name(self):

--- a/src/co_op_translator/core/llm/providers/openai/__init__.py
+++ b/src/co_op_translator/core/llm/providers/openai/__init__.py
@@ -1,4 +1,8 @@
-from co_op_translator.core.llm.providers.openai.text_translator import OpenAITextTranslator
-from co_op_translator.core.llm.providers.openai.markdown_translator import OpenAIMarkdownTranslator
+from co_op_translator.core.llm.providers.openai.text_translator import (
+    OpenAITextTranslator,
+)
+from co_op_translator.core.llm.providers.openai.markdown_translator import (
+    OpenAIMarkdownTranslator,
+)
 
-__all__ = ['OpenAITextTranslator', 'OpenAIMarkdownTranslator']
+__all__ = ["OpenAITextTranslator", "OpenAIMarkdownTranslator"]

--- a/src/co_op_translator/core/llm/providers/openai/markdown_translator.py
+++ b/src/co_op_translator/core/llm/providers/openai/markdown_translator.py
@@ -11,13 +11,14 @@ import asyncio
 
 logger = logging.getLogger(__name__)
 
+
 class OpenAIMarkdownTranslator(MarkdownTranslator):
     """OpenAI implementation for markdown translation."""
-    
+
     def __init__(self, root_dir: Path = None):
         """
         Initialize OpenAI Markdown Translator.
-        
+
         Args:
             root_dir: Optional root directory for the project
         """
@@ -39,7 +40,7 @@ class OpenAIMarkdownTranslator(MarkdownTranslator):
                 service_id=service_id,
                 ai_model_id=OpenAIConfig.get_chat_model_id(),
                 org_id=OpenAIConfig.get_org_id(),
-                api_key=OpenAIConfig.get_api_key()
+                api_key=OpenAIConfig.get_api_key(),
             )
         )
         return kernel
@@ -47,28 +48,30 @@ class OpenAIMarkdownTranslator(MarkdownTranslator):
     async def _run_prompt(self, prompt: str, index: int, total: int) -> str:
         """
         Execute a single translation prompt using OpenAI.
-        
+
         Args:
             prompt: The translation prompt
             index: Current chunk index
             total: Total number of chunks
-            
+
         Returns:
             str: Translated text
         """
         try:
             # Initialize settings for all prompts
-            req_settings = self.kernel.get_prompt_execution_settings_from_service_id(LLMProvider.OPENAI.value)
+            req_settings = self.kernel.get_prompt_execution_settings_from_service_id(
+                LLMProvider.OPENAI.value
+            )
             req_settings.max_tokens = 4096
             req_settings.temperature = 0.7
             req_settings.top_p = 0.8
 
             # Log appropriate message based on prompt type
-            if index == 'disclaimer' or isinstance(index, str):
+            if index == "disclaimer" or isinstance(index, str):
                 logger.info(f"Running system prompt: {index}")
             else:
                 logger.info(f"Running translation prompt {index}/{total}")
-            
+
             start_time = time.time()
 
             prompt_template_config = PromptTemplateConfig(
@@ -87,7 +90,9 @@ class OpenAIMarkdownTranslator(MarkdownTranslator):
 
             result = await self.kernel.invoke(function)
             end_time = time.time()
-            logger.info(f"Prompt {index}/{total} completed in {end_time - start_time} seconds")
+            logger.info(
+                f"Prompt {index}/{total} completed in {end_time - start_time} seconds"
+            )
 
             await asyncio.sleep(1)
             return str(result)

--- a/src/co_op_translator/core/llm/providers/openai/text_translator.py
+++ b/src/co_op_translator/core/llm/providers/openai/text_translator.py
@@ -2,9 +2,10 @@ from openai import OpenAI
 from co_op_translator.core.llm.text_translator import TextTranslator
 from co_op_translator.config.llm_config.openai import OpenAIConfig
 
+
 class OpenAITextTranslator(TextTranslator):
     """OpenAI implementation for text translation."""
-    
+
     def __init__(self):
         """Initialize OpenAI Text Translator."""
         self.client = self.get_openai_client()
@@ -19,7 +20,7 @@ class OpenAITextTranslator(TextTranslator):
         return OpenAI(
             api_key=OpenAIConfig.get_api_key(),
             organization=OpenAIConfig.get_org_id(),
-            base_url=OpenAIConfig.get_base_url()
+            base_url=OpenAIConfig.get_base_url(),
         )
 
     def get_model_name(self):

--- a/src/co_op_translator/core/llm/text_translator.py
+++ b/src/co_op_translator/core/llm/text_translator.py
@@ -1,10 +1,15 @@
 from abc import ABC, abstractmethod
 import logging
-from co_op_translator.utils.llm.text_utils import gen_image_translation_prompt, remove_code_backticks, extract_yaml_lines
+from co_op_translator.utils.llm.text_utils import (
+    gen_image_translation_prompt,
+    remove_code_backticks,
+    extract_yaml_lines,
+)
 from co_op_translator.config.llm_config.config import LLMConfig
 from co_op_translator.config.llm_config.provider import LLMProvider
 
 logger = logging.getLogger(__name__)
+
 
 class TextTranslator(ABC):
     def __init__(self):
@@ -41,11 +46,13 @@ class TextTranslator(ABC):
             model=self.get_model_name(),
             messages=[
                 {"role": "system", "content": "You are a helpful assistant."},
-                {"role": "user", "content": prompt}
+                {"role": "user", "content": prompt},
             ],
-            max_tokens=2000
+            max_tokens=2000,
         )
-        return extract_yaml_lines(remove_code_backticks(response.choices[0].message.content))
+        return extract_yaml_lines(
+            remove_code_backticks(response.choices[0].message.content)
+        )
 
     def translate_text(self, text, target_language):
         """
@@ -63,9 +70,9 @@ class TextTranslator(ABC):
             model=self.get_model_name(),
             messages=[
                 {"role": "system", "content": "You are a helpful assistant."},
-                {"role": "user", "content": prompt}
+                {"role": "user", "content": prompt},
             ],
-            max_tokens=2000
+            max_tokens=2000,
         )
         translated_text = remove_code_backticks(response.choices[0].message.content)
         return translated_text
@@ -75,10 +82,16 @@ class TextTranslator(ABC):
         """Factory method to create appropriate translator based on available provider."""
         provider = LLMConfig.get_available_provider()
         if provider == LLMProvider.AZURE_OPENAI:
-            from co_op_translator.core.llm.providers.azure.text_translator import AzureTextTranslator
+            from co_op_translator.core.llm.providers.azure.text_translator import (
+                AzureTextTranslator,
+            )
+
             return AzureTextTranslator()
         elif provider == LLMProvider.OPENAI:
-            from co_op_translator.core.llm.providers.openai.text_translator import OpenAITextTranslator
+            from co_op_translator.core.llm.providers.openai.text_translator import (
+                OpenAITextTranslator,
+            )
+
             return OpenAITextTranslator()
         else:
             raise ValueError("No valid LLM provider configured")

--- a/src/co_op_translator/core/project/__init__.py
+++ b/src/co_op_translator/core/project/__init__.py
@@ -1,5 +1,3 @@
 from co_op_translator.core.project.project_translator import ProjectTranslator
 
-__all__ = [
-    'ProjectTranslator'
-]
+__all__ = ["ProjectTranslator"]

--- a/src/co_op_translator/core/vision/__init__.py
+++ b/src/co_op_translator/core/vision/__init__.py
@@ -1,5 +1,5 @@
-from co_op_translator.core.vision.providers.azure.image_translator import AzureImageTranslator
+from co_op_translator.core.vision.providers.azure.image_translator import (
+    AzureImageTranslator,
+)
 
-__all__ = [
-    'AzureImageTranslator'
-]
+__all__ = ["AzureImageTranslator"]

--- a/src/co_op_translator/core/vision/providers/azure/__init__.py
+++ b/src/co_op_translator/core/vision/providers/azure/__init__.py
@@ -1,3 +1,5 @@
-from co_op_translator.core.vision.providers.azure.image_translator import AzureImageTranslator
+from co_op_translator.core.vision.providers.azure.image_translator import (
+    AzureImageTranslator,
+)
 
-__all__ = ['AzureImageTranslator']
+__all__ = ["AzureImageTranslator"]

--- a/src/co_op_translator/core/vision/providers/azure/image_translator.py
+++ b/src/co_op_translator/core/vision/providers/azure/image_translator.py
@@ -2,18 +2,21 @@ import logging
 from azure.ai.vision.imageanalysis import ImageAnalysisClient
 from azure.core.credentials import AzureKeyCredential
 from co_op_translator.core.vision.image_translator import ImageTranslator
-from co_op_translator.config.vision_config.azure_computer_vision import AzureComputerVisionConfig
+from co_op_translator.config.vision_config.azure_computer_vision import (
+    AzureComputerVisionConfig,
+)
 
 logger = logging.getLogger(__name__)
 
+
 class AzureImageTranslator(ImageTranslator):
     """Azure implementation for image translation using Computer Vision API.
-    
+
     This class provides image translation capabilities using Azure's Computer Vision
     service for text extraction, combined
     with translation services to convert text within images to different languages.
     """
-    
+
     def get_image_analysis_client(self):
         """
         Initialize and return an Image Analysis Client.

--- a/src/co_op_translator/utils/common/file_utils.py
+++ b/src/co_op_translator/utils/common/file_utils.py
@@ -11,6 +11,7 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+
 def read_input_file(input_file: str | Path) -> str:
     """
     Read the content of an input file and return it as a stripped string.
@@ -22,8 +23,9 @@ def read_input_file(input_file: str | Path) -> str:
         str: The stripped content of the file.
     """
     input_file = Path(input_file)
-    with input_file.open('r', encoding='utf-8') as file:
+    with input_file.open("r", encoding="utf-8") as file:
         return file.read().strip()
+
 
 def handle_empty_document(input_file: str | Path, output_file: str | Path) -> None:
     """
@@ -37,6 +39,7 @@ def handle_empty_document(input_file: str | Path, output_file: str | Path) -> No
     output_file = Path(output_file)
     shutil.copyfile(input_file, output_file)
 
+
 def write_output_file(output_file: str | Path, results: list) -> None:
     """
     Write a list of results to the output file, each on a new line.
@@ -46,12 +49,15 @@ def write_output_file(output_file: str | Path, results: list) -> None:
         results (list): A list of strings to write to the file.
     """
     output_file = Path(output_file)
-    with output_file.open('w', encoding='utf-8') as text_file:
+    with output_file.open("w", encoding="utf-8") as text_file:
         for result in results:
             text_file.write(result)
             text_file.write("\n")
 
-def get_actual_image_path(image_relative_path: str | Path, markdown_file_path: str | Path) -> Path:
+
+def get_actual_image_path(
+    image_relative_path: str | Path, markdown_file_path: str | Path
+) -> Path:
     """
     Given an image's relative path from the markdown file, return the actual file path
     by resolving the relative path against the markdown file's location.
@@ -71,14 +77,15 @@ def get_actual_image_path(image_relative_path: str | Path, markdown_file_path: s
 
     return actual_image_path
 
+
 def get_unique_id(file_path: str | Path, root_dir: Path) -> str:
     """
     Generate a unique identifier (hash) for the given file path, based on the relative path to the root directory.
-    
+
     Args:
         file_path (str | Path): The file path to hash.
         root_dir (Path): The root directory to which the file path should be relative.
-    
+
     Returns:
         str: A SHA-256 hash of the relative file path.
     """
@@ -86,15 +93,20 @@ def get_unique_id(file_path: str | Path, root_dir: Path) -> str:
     relative_path = file_path.relative_to(root_dir)
 
     # Convert the relative path to bytes and hash it
-    relative_path_bytes = str(relative_path).encode('utf-8')
+    relative_path_bytes = str(relative_path).encode("utf-8")
     hash_object = hashlib.sha256(relative_path_bytes)
     unique_identifier = hash_object.hexdigest()
 
-    logger.info(f"HASH for relative file path: {relative_path} HASH={unique_identifier}")
+    logger.info(
+        f"HASH for relative file path: {relative_path} HASH={unique_identifier}"
+    )
 
     return unique_identifier
 
-def generate_translated_filename(original_filepath: str | Path, language_code: str, root_dir: Path) -> str:
+
+def generate_translated_filename(
+    original_filepath: str | Path, language_code: str, root_dir: Path
+) -> str:
     """
     Generate a filename for a translated file, including a unique hash and language code.
 
@@ -123,6 +135,7 @@ def generate_translated_filename(original_filepath: str | Path, language_code: s
 
     return new_filename
 
+
 def get_filename_and_extension(file_path: str | Path) -> tuple[str, str]:
     """
     Extract the filename without extension and the file extension from the given file path.
@@ -142,6 +155,7 @@ def get_filename_and_extension(file_path: str | Path) -> tuple[str, str]:
     # Return the filename without extension and the file extension in lowercase
     return original_filename, file_ext.lower()
 
+
 def filter_files(directory: str | Path, excluded_dirs) -> list:
     """
     Filter and return only the files in the given directory, excluding specified directories.
@@ -157,18 +171,23 @@ def filter_files(directory: str | Path, excluded_dirs) -> list:
     files = []
 
     # Recursively traverse the directory
-    for path in directory.rglob('*'):
+    for path in directory.rglob("*"):
         # Check if the path is a file and does not contain any excluded directories
-        if path.is_file() and not any(excluded_dir in path.parts for excluded_dir in excluded_dirs):
+        if path.is_file() and not any(
+            excluded_dir in path.parts for excluded_dir in excluded_dirs
+        ):
             files.append(path)
 
     return files
 
-def reset_translation_directories(translations_dir: Path, image_dir: Path, language_codes: list):
+
+def reset_translation_directories(
+    translations_dir: Path, image_dir: Path, language_codes: list
+):
     """
     Remove existing translation and translated_images directories if they exist,
     and then create new ones.
-    
+
     Args:
         translations_dir (Path): The directory where translations are stored.
         image_dir (Path): The directory where translated images are stored.
@@ -178,7 +197,7 @@ def reset_translation_directories(translations_dir: Path, image_dir: Path, langu
     if translations_dir.exists():
         shutil.rmtree(translations_dir)
         logger.info(f"Removed existing translations directory: {translations_dir}")
-    
+
     if image_dir.exists():
         shutil.rmtree(image_dir)
         logger.info(f"Removed existing translated_images directory: {image_dir}")
@@ -188,9 +207,10 @@ def reset_translation_directories(translations_dir: Path, image_dir: Path, langu
         lang_dir = translations_dir / lang_code
         lang_dir.mkdir(parents=True, exist_ok=True)
         logger.info(f"Created directory for {lang_code}: {lang_dir}")
-    
+
     image_dir.mkdir(parents=True, exist_ok=True)
     logger.info(f"Created translated_images directory: {image_dir}")
+
 
 def delete_translated_images_by_language_code(language_code: str, image_dir: Path):
     """
@@ -201,11 +221,11 @@ def delete_translated_images_by_language_code(language_code: str, image_dir: Pat
         image_dir (Path): The directory where translated images are stored (e.g., './translated_images').
     """
     image_dir = Path(image_dir)
-    
+
     if not image_dir.exists():
         logger.warning(f"Directory {image_dir} does not exist. No images to delete.")
         return
-    
+
     # Iterate through all files in the directory
     for image_file in image_dir.iterdir():
         # Check if the language code is part of the filename
@@ -213,7 +233,10 @@ def delete_translated_images_by_language_code(language_code: str, image_dir: Pat
             logger.info(f"Deleting image file: {image_file}")
             image_file.unlink()
 
-def delete_translated_markdown_files_by_language_code(language_code: str, translations_dir: Path):
+
+def delete_translated_markdown_files_by_language_code(
+    language_code: str, translations_dir: Path
+):
     """
     Delete the entire directory for the specified language code, including all its contents.
 
@@ -225,7 +248,9 @@ def delete_translated_markdown_files_by_language_code(language_code: str, transl
     language_dir = translations_dir / language_code
 
     if not language_dir.exists():
-        logger.warning(f"Directory {language_dir} does not exist. No markdown files to delete.")
+        logger.warning(
+            f"Directory {language_dir} does not exist. No markdown files to delete."
+        )
         return
 
     # Remove the entire directory and its contents

--- a/src/co_op_translator/utils/common/task_utils.py
+++ b/src/co_op_translator/utils/common/task_utils.py
@@ -4,6 +4,7 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+
 async def worker(task_queue: asyncio.Queue, progress_bar=None):
     """
     Worker function that processes tasks from the task queue, with optional progress bar updates.
@@ -41,7 +42,10 @@ async def worker(task_queue: asyncio.Queue, progress_bar=None):
             # No matter what happens, mark the task as done
             task_queue.task_done()
 
-async def queue_tasks(tasks: list, max_concurrent_tasks=4, task_desc: str = "Processing tasks"):
+
+async def queue_tasks(
+    tasks: list, max_concurrent_tasks=4, task_desc: str = "Processing tasks"
+):
     """
     Queue tasks into an asyncio.Queue and process them using a limited number of concurrent workers.
 
@@ -63,7 +67,10 @@ async def queue_tasks(tasks: list, max_concurrent_tasks=4, task_desc: str = "Pro
     # 3) Create a progress bar with total == number of real tasks
     with tqdm_asyncio.tqdm_asyncio(total=len(tasks), desc=task_desc) as progress_bar:
         # Start workers
-        workers = [asyncio.create_task(worker(task_queue, progress_bar)) for _ in range(max_concurrent_tasks)]
+        workers = [
+            asyncio.create_task(worker(task_queue, progress_bar))
+            for _ in range(max_concurrent_tasks)
+        ]
 
         # Wait for the queue to empty
         await task_queue.join()

--- a/src/co_op_translator/utils/llm/markdown_utils.py
+++ b/src/co_op_translator/utils/llm/markdown_utils.py
@@ -3,6 +3,7 @@ This module contains utility functions for handling Markdown content.
 Functions include loading language mappings, generating translation prompts,
 and processing specific Markdown structures such as comments and URLs.
 """
+
 import os
 import re
 import tiktoken
@@ -10,11 +11,18 @@ from pathlib import Path
 from urllib.parse import urlparse
 import logging
 from co_op_translator.config.constants import SUPPORTED_IMAGE_EXTENSIONS
-from co_op_translator.utils.common.file_utils import generate_translated_filename, get_actual_image_path, get_filename_and_extension
+from co_op_translator.utils.common.file_utils import (
+    generate_translated_filename,
+    get_actual_image_path,
+    get_filename_and_extension,
+)
 
 logger = logging.getLogger(__name__)
 
-def generate_prompt_template(output_lang: str, document_chunk: str, is_rtl: bool) -> str:
+
+def generate_prompt_template(
+    output_lang: str, document_chunk: str, is_rtl: bool
+) -> str:
     """
     Generate a translation prompt for a document chunk, considering language direction.
 
@@ -48,6 +56,7 @@ def generate_prompt_template(output_lang: str, document_chunk: str, is_rtl: bool
 
     return prompt
 
+
 def get_tokenizer(encoding_name: str):
     """
     Get the tokenizer based on the encoding name.
@@ -59,6 +68,7 @@ def get_tokenizer(encoding_name: str):
         tiktoken.Encoding: The tokenizer for the given encoding.
     """
     return tiktoken.get_encoding(encoding_name)
+
 
 def count_tokens(text: str, tokenizer) -> int:
     """
@@ -73,6 +83,7 @@ def count_tokens(text: str, tokenizer) -> int:
     """
     return len(tokenizer.encode(text))
 
+
 def split_markdown_content(content: str, max_tokens: int, tokenizer) -> list:
     """
     Split the markdown content into smaller chunks based on code blocks, blockquotes, or HTML.
@@ -86,43 +97,48 @@ def split_markdown_content(content: str, max_tokens: int, tokenizer) -> list:
         list: A list of markdown chunks.
     """
     chunks = []
-    block_pattern = re.compile(r'(```[\s\S]*?```|<.*?>|(?:>\s+.*(?:\n>.*|\n(?!\n))*\n?)+)')
+    block_pattern = re.compile(
+        r"(```[\s\S]*?```|<.*?>|(?:>\s+.*(?:\n>.*|\n(?!\n))*\n?)+)"
+    )
     parts = block_pattern.split(content)
-    
+
     current_chunk = []
     current_length = 0
 
     for part in parts:
         part_tokens = count_tokens(part, tokenizer)
-        
+
         if current_length + part_tokens <= max_tokens:
             current_chunk.append(part)
             current_length += part_tokens
         else:
             if block_pattern.match(part):
                 if current_chunk:
-                    chunks.append(''.join(current_chunk))
+                    chunks.append("".join(current_chunk))
                 chunks.append(part)
                 current_chunk = []
                 current_length = 0
             else:
                 words = part.split()
                 for word in words:
-                    word_tokens = count_tokens(word + ' ', tokenizer)
+                    word_tokens = count_tokens(word + " ", tokenizer)
                     if current_length + word_tokens > max_tokens:
-                        chunks.append(''.join(current_chunk))
-                        current_chunk = [word + ' ']
+                        chunks.append("".join(current_chunk))
+                        current_chunk = [word + " "]
                         current_length = word_tokens
                     else:
-                        current_chunk.append(word + ' ')
+                        current_chunk.append(word + " ")
                         current_length += word_tokens
 
     if current_chunk:
-        chunks.append(''.join(current_chunk))
+        chunks.append("".join(current_chunk))
 
     return chunks
 
-def process_markdown(content: str, max_tokens=4096, encoding='o200k_base') -> list: # o200k_base is for GPT-4o, cl100k_base is for GPT-4 and GPT-3.5
+
+def process_markdown(
+    content: str, max_tokens=4096, encoding="o200k_base"
+) -> list:  # o200k_base is for GPT-4o, cl100k_base is for GPT-4 and GPT-3.5
     """
     Process the markdown content to split it into smaller chunks.
 
@@ -145,6 +161,7 @@ def process_markdown(content: str, max_tokens=4096, encoding='o200k_base') -> li
 
     return chunks
 
+
 def process_markdown_with_many_links(content: str, max_links) -> list:
     """
     Process markdown document by splitting it into chunks where each chunk contains max_links or fewer links.
@@ -164,7 +181,7 @@ def process_markdown_with_many_links(content: str, max_links) -> list:
     for line in lines:
 
         line_links = count_links_in_markdown(line)
-        
+
         if current_links + line_links > max_links:
             chunks.append(current_chunk.strip())
             current_chunk = line + "\n"
@@ -178,27 +195,55 @@ def process_markdown_with_many_links(content: str, max_links) -> list:
 
     return chunks
 
-def update_links(md_file_path: Path, markdown_string: str, language_code: str, root_dir: Path, markdown_only: bool = False) -> str:
+
+def update_links(
+    md_file_path: Path,
+    markdown_string: str,
+    language_code: str,
+    root_dir: Path,
+    markdown_only: bool = False,
+) -> str:
     logger.info("Updating links in the markdown file")
 
-    translations_dir = root_dir / 'translations'
-    translated_images_dir = root_dir / 'translated_images'
+    translations_dir = root_dir / "translations"
+    translated_images_dir = root_dir / "translated_images"
 
     # Update image links
-    markdown_string = update_image_links(markdown_string, md_file_path, language_code, translations_dir, translated_images_dir, root_dir, markdown_only=markdown_only)
+    markdown_string = update_image_links(
+        markdown_string,
+        md_file_path,
+        language_code,
+        translations_dir,
+        translated_images_dir,
+        root_dir,
+        markdown_only=markdown_only,
+    )
 
     # Update non-image file links
-    markdown_string = update_file_links(markdown_string, md_file_path, language_code, translations_dir, root_dir)
+    markdown_string = update_file_links(
+        markdown_string, md_file_path, language_code, translations_dir, root_dir
+    )
 
     # Update translation links
-    markdown_string = update_translation_links(markdown_string, md_file_path, language_code, translations_dir, root_dir)
+    markdown_string = update_translation_links(
+        markdown_string, md_file_path, language_code, translations_dir, root_dir
+    )
 
     return markdown_string
 
-def update_image_links(markdown_string: str, md_file_path: Path, language_code: str, translations_dir: Path, translated_images_dir: Path, root_dir: Path, markdown_only: bool = False) -> str:
+
+def update_image_links(
+    markdown_string: str,
+    md_file_path: Path,
+    language_code: str,
+    translations_dir: Path,
+    translated_images_dir: Path,
+    root_dir: Path,
+    markdown_only: bool = False,
+) -> str:
     """
     Update image links in markdown content based on mode and Azure Computer Vision availability.
-    
+
     Args:
         markdown_string (str): The markdown content to process
         md_file_path (Path): Path to the markdown file being processed
@@ -207,16 +252,16 @@ def update_image_links(markdown_string: str, md_file_path: Path, language_code: 
         translated_images_dir (Path): Directory containing translated images
         root_dir (Path): Root directory of the project
         markdown_only (bool): Whether we're in markdown-only mode
-        
+
     Returns:
         str: Updated markdown content with modified image links
     """
-    image_pattern = r'!\[(.*?)\]\((.*?)\)'
+    image_pattern = r"!\[(.*?)\]\((.*?)\)"
     image_matches = re.findall(image_pattern, markdown_string)
 
     # Use original image links if in markdown-only mode
     use_original_images = markdown_only
-    
+
     if use_original_images:
         logger.info("Using original image links (markdown-only mode)")
     else:
@@ -224,7 +269,11 @@ def update_image_links(markdown_string: str, md_file_path: Path, language_code: 
 
     for alt_text, link in image_matches:
         parsed_url = urlparse(link)
-        if parsed_url.scheme in ('mailto', 'http', 'https') or '@' in link or link.endswith(('.com', '.org', '.net')):
+        if (
+            parsed_url.scheme in ("mailto", "http", "https")
+            or "@" in link
+            or link.endswith((".com", ".org", ".net"))
+        ):
             logger.info(f"Skipped {link} as it is an email or web URL")
             continue
 
@@ -236,23 +285,35 @@ def update_image_links(markdown_string: str, md_file_path: Path, language_code: 
 
             try:
                 actual_image_path = get_actual_image_path(link, md_file_path)
-                translated_md_dir = translations_dir / language_code / md_file_path.relative_to(root_dir).parent
+                translated_md_dir = (
+                    translations_dir
+                    / language_code
+                    / md_file_path.relative_to(root_dir).parent
+                )
 
                 if use_original_images:
                     # Link to original image when in markdown-only mode
                     original_linked_file_path = (md_file_path.parent / path).resolve()
-                    updated_link = os.path.relpath(original_linked_file_path, translated_md_dir).replace(os.path.sep, '/')
+                    updated_link = os.path.relpath(
+                        original_linked_file_path, translated_md_dir
+                    ).replace(os.path.sep, "/")
                     logger.info(f"Using original image link: {updated_link}")
                 else:
                     # Link to translated image when not in markdown-only mode
                     rel_path = os.path.relpath(translated_images_dir, translated_md_dir)
-                    new_filename = generate_translated_filename(actual_image_path, language_code, root_dir)
-                    updated_link = os.path.join(rel_path, new_filename).replace(os.path.sep, '/')
+                    new_filename = generate_translated_filename(
+                        actual_image_path, language_code, root_dir
+                    )
+                    updated_link = os.path.join(rel_path, new_filename).replace(
+                        os.path.sep, "/"
+                    )
                     logger.info(f"Using translated image link: {updated_link}")
 
-                old_image_markup = f'![{alt_text}]({link})'
-                new_image_markup = f'![{alt_text}]({updated_link})'
-                markdown_string = markdown_string.replace(old_image_markup, new_image_markup)
+                old_image_markup = f"![{alt_text}]({link})"
+                new_image_markup = f"![{alt_text}]({updated_link})"
+                markdown_string = markdown_string.replace(
+                    old_image_markup, new_image_markup
+                )
 
             except Exception as e:
                 logger.error(f"Error processing image {link}: {e}")
@@ -261,13 +322,24 @@ def update_image_links(markdown_string: str, md_file_path: Path, language_code: 
 
     return markdown_string
 
-def update_file_links(markdown_string: str, md_file_path: Path, language_code: str, translations_dir: Path, root_dir: Path) -> str:
-    file_pattern = r'\[(.*?)\]\((.*?)\)'
+
+def update_file_links(
+    markdown_string: str,
+    md_file_path: Path,
+    language_code: str,
+    translations_dir: Path,
+    root_dir: Path,
+) -> str:
+    file_pattern = r"\[(.*?)\]\((.*?)\)"
     file_matches = re.findall(file_pattern, markdown_string)
 
     for alt_text, link in file_matches:
         parsed_url = urlparse(link)
-        if parsed_url.scheme in ('mailto', 'http', 'https') or '@' in link or link.endswith(('.com', '.org', '.net')):
+        if (
+            parsed_url.scheme in ("mailto", "http", "https")
+            or "@" in link
+            or link.endswith((".com", ".org", ".net"))
+        ):
             logger.info(f"Skipped {link} as it is an email or web URL")
             continue
 
@@ -284,13 +356,19 @@ def update_file_links(markdown_string: str, md_file_path: Path, language_code: s
 
         logger.info(f"Processing non-image, non-markdown file {link}")
         try:
-            translated_md_dir = translations_dir / language_code / md_file_path.relative_to(root_dir).parent
+            translated_md_dir = (
+                translations_dir
+                / language_code
+                / md_file_path.relative_to(root_dir).parent
+            )
             original_linked_file_path = (md_file_path.parent / path).resolve()
 
-            updated_link = os.path.relpath(original_linked_file_path, translated_md_dir).replace(os.path.sep, '/')
+            updated_link = os.path.relpath(
+                original_linked_file_path, translated_md_dir
+            ).replace(os.path.sep, "/")
 
-            old_file_markup = f'[{alt_text}]({link})'
-            new_file_markup = f'[{alt_text}]({updated_link})'
+            old_file_markup = f"[{alt_text}]({link})"
+            new_file_markup = f"[{alt_text}]({updated_link})"
             markdown_string = markdown_string.replace(old_file_markup, new_file_markup)
 
             logger.info(f"Updated non-image file markdown: {new_file_markup}")
@@ -301,50 +379,81 @@ def update_file_links(markdown_string: str, md_file_path: Path, language_code: s
 
     return markdown_string
 
-def update_translation_links(markdown_string: str, md_file_path: Path, language_code: str, translations_dir: Path, root_dir: Path) -> str:
+
+def update_translation_links(
+    markdown_string: str,
+    md_file_path: Path,
+    language_code: str,
+    translations_dir: Path,
+    root_dir: Path,
+) -> str:
     logger.info("Updating translation links in the markdown file")
 
-    translation_link_pattern = r'(\[.*?\])\((?:\.?/)?translations/([a-zA-Z\-]+)/README\.md\)'
+    translation_link_pattern = (
+        r"(\[.*?\])\((?:\.?/)?translations/([a-zA-Z\-]+)/README\.md\)"
+    )
 
     def replace_link(match):
         alt_text_with_brackets = match.group(1)
         other_language_code = match.group(2)
-        logger.info(f"Found language code in link: {other_language_code} with alt text '{alt_text_with_brackets}'")
+        logger.info(
+            f"Found language code in link: {other_language_code} with alt text '{alt_text_with_brackets}'"
+        )
 
-        other_translated_md_path = (translations_dir / other_language_code / 'README.md').resolve()
-        logger.debug(f"Other translated markdown path (absolute): {other_translated_md_path}")
+        other_translated_md_path = (
+            translations_dir / other_language_code / "README.md"
+        ).resolve()
+        logger.debug(
+            f"Other translated markdown path (absolute): {other_translated_md_path}"
+        )
 
-        current_translated_md_path = (translations_dir / language_code / 'README.md').resolve()
+        current_translated_md_path = (
+            translations_dir / language_code / "README.md"
+        ).resolve()
         current_md_dir = current_translated_md_path.parent
         logger.debug(f"Current markdown directory (current_md_dir): {current_md_dir}")
 
         try:
-            relative_dir = os.path.relpath(other_translated_md_path.parent, current_md_dir).replace(os.path.sep, '/')
+            relative_dir = os.path.relpath(
+                other_translated_md_path.parent, current_md_dir
+            ).replace(os.path.sep, "/")
             relative_path_to_translation = f"{relative_dir}/README.md"
-            logger.info(f"Relative path to {other_language_code} translation: {relative_path_to_translation}")
+            logger.info(
+                f"Relative path to {other_language_code} translation: {relative_path_to_translation}"
+            )
 
-            new_translation_link_markup = f'{alt_text_with_brackets}({relative_path_to_translation})'
-            logger.info(f"Updated translation link markdown: {new_translation_link_markup}")
+            new_translation_link_markup = (
+                f"{alt_text_with_brackets}({relative_path_to_translation})"
+            )
+            logger.info(
+                f"Updated translation link markdown: {new_translation_link_markup}"
+            )
             return new_translation_link_markup
         except Exception as e:
-            logger.error(f"Error updating translation links for {other_language_code}: {e}")
+            logger.error(
+                f"Error updating translation links for {other_language_code}: {e}"
+            )
             return match.group(0)
 
     markdown_string = re.sub(translation_link_pattern, replace_link, markdown_string)
 
     return markdown_string
 
+
 def compare_line_breaks(original_text, translated_text):
     """
     Compare the number of line breaks in the original and translated text
     to determine if the format is broken.
     """
-    original_line_breaks = original_text.count('\n')
-    translated_line_breaks = translated_text.count('\n')
+    original_line_breaks = original_text.count("\n")
+    translated_line_breaks = translated_text.count("\n")
 
-    if abs(original_line_breaks - translated_line_breaks) > 5:  # Allow a margin for disclaimer
+    if (
+        abs(original_line_breaks - translated_line_breaks) > 5
+    ):  # Allow a margin for disclaimer
         return True
     return False
+
 
 def count_links_in_markdown(content: str) -> int:
     """
@@ -358,10 +467,11 @@ def count_links_in_markdown(content: str) -> int:
     link_pattern = re.compile(r"\[.*?\]\(.*?\)")
     return len(link_pattern.findall(content))
 
+
 def replace_code_blocks_and_inline_code(document: str):
     """
     Replace code blocks and inline code in the document with placeholders.
-    
+
     Args:
         document (str): The markdown document to process.
 
@@ -370,8 +480,8 @@ def replace_code_blocks_and_inline_code(document: str):
             - The document with placeholders.
             - A dictionary mapping placeholders to their original code.
     """
-    code_block_pattern = r'```[\s\S]*?```'
-    inline_code_pattern = r'`[^`]+`'
+    code_block_pattern = r"```[\s\S]*?```"
+    inline_code_pattern = r"`[^`]+`"
 
     # Replace code blocks
     code_blocks = re.findall(code_block_pattern, document)
@@ -393,7 +503,10 @@ def replace_code_blocks_and_inline_code(document: str):
 
     return document, placeholder_map
 
-def restore_code_blocks_and_inline_code(translated_document: str, placeholder_map: dict):
+
+def restore_code_blocks_and_inline_code(
+    translated_document: str, placeholder_map: dict
+):
     """
     Restore code blocks and inline code into the translated document from the placeholders.
 

--- a/src/co_op_translator/utils/llm/text_utils.py
+++ b/src/co_op_translator/utils/llm/text_utils.py
@@ -6,51 +6,54 @@ Functions include generating translation prompts and processing responses from O
 import re
 import logging
 
-logger = logging.getLogger(__name__) 
+logger = logging.getLogger(__name__)
+
 
 def gen_image_translation_prompt(text_data, language):
     """
     Generate a translation prompt for the given text data.
-    
+
     Args:
         text_data (list): List of text lines to be translated.
         language (str): Target language for translation.
-    
+
     Returns:
         str: Generated translation prompt.
     """
-    prompt = f'''
+    prompt = f"""
     You are a translator that receives a batch of lines in an image. Given the following yaml file, please translate each line into {language}.
     For each line, fill it in with the translation, respecting the context of the text.
     Return only the yaml file, fully filled in.
-    '''
+    """
     for line in text_data:
         prompt += f"- {line}\n"
     return prompt
 
+
 def remove_code_backticks(message):
     """
     Remove code block backticks from a message.
-    
+
     Args:
         message (str): The message containing code block backticks.
-    
+
     Returns:
         str: The message without code block backticks.
     """
-    match = re.match(r'```(?:\w+)?\n(.*?)\n```', message, re.DOTALL)
+    match = re.match(r"```(?:\w+)?\n(.*?)\n```", message, re.DOTALL)
     return match.group(1) if match else message
+
 
 def extract_yaml_lines(message):
     """
     Extract YAML lines from a message.
-    
+
     Args:
         message (str): The message containing YAML lines.
-    
+
     Returns:
         list: List of extracted YAML lines.
     """
-    lines = message.split('\n')
-    yaml_lines = [line[2:] for line in lines if line.startswith('- ')]
+    lines = message.split("\n")
+    yaml_lines = [line[2:] for line in lines if line.startswith("- ")]
     return yaml_lines

--- a/src/co_op_translator/utils/vision/image_utils.py
+++ b/src/co_op_translator/utils/vision/image_utils.py
@@ -15,10 +15,11 @@ from co_op_translator.utils.common.file_utils import get_filename_and_extension
 
 logger = logging.getLogger(__name__)
 
+
 def save_bounding_boxes(image_path, bounding_boxes):
     """
     Save bounding boxes and confidence scores to a JSON file.
-    
+
     Args:
         image_path (str): Path to the image file.
         bounding_boxes (list): List of bounding boxes and text data.
@@ -28,135 +29,153 @@ def save_bounding_boxes(image_path, bounding_boxes):
     output_dir = "./bounding_boxes"
     os.makedirs(output_dir, exist_ok=True)
     output_path = os.path.join(output_dir, f"{name}.json")
-    
+
     with open(output_path, "w", encoding="utf-8") as json_file:
         json.dump(bounding_boxes, json_file, ensure_ascii=False, indent=4)
+
 
 def load_bounding_boxes(json_path):
     """
     Load bounding boxes and confidence scores from a JSON file.
-    
+
     Args:
         json_path (str): Path to the JSON file.
-        
+
     Returns:
         list: List of bounding boxes and text data.
     """
     with open(json_path, "r", encoding="utf-8") as json_file:
         return json.load(json_file)
 
+
 def get_average_color(image, bounding_box):
     """
     Get the average color of a bounding box area in the image.
-    
+
     Args:
         image (PIL.Image.Image): The image object.
         bounding_box (list): The bounding box coordinates.
-        
+
     Returns:
         tuple: The average color (R, G, B).
     """
     mask = Image.new("L", image.size, 0)
     draw = ImageDraw.Draw(mask)
-    pts = [(bounding_box[i], bounding_box[i+1]) for i in range(0, len(bounding_box), 2)]
+    pts = [
+        (bounding_box[i], bounding_box[i + 1]) for i in range(0, len(bounding_box), 2)
+    ]
     draw.polygon(pts, fill=255)
     stat = ImageStat.Stat(image, mask)
     avg_color = tuple(int(x) for x in stat.mean[:3])
     return avg_color
 
+
 def get_text_color(bg_color):
     """
     Determine the grayscale color for text based on background color.
-    
+
     Args:
         bg_color (tuple): Background color (R, G, B).
-        
+
     Returns:
         tuple: Text color (R, G, B).
     """
     luminance = (0.299 * bg_color[0] + 0.587 * bg_color[1] + 0.114 * bg_color[2]) / 255
     return (0, 0, 0) if luminance > 0.5 else (255, 255, 255)
 
+
 def warp_image_to_bounding_box(image, bounding_box, image_width, image_height):
     """
     Apply perspective warp to a text image to fit the bounding box.
-    
+
     Args:
         image (numpy.ndarray): The text image array.
         bounding_box (list): The bounding box coordinates.
         image_width (int): The width of the output image.
         image_height (int): The height of the output image.
-        
+
     Returns:
         numpy.ndarray: The warped image array.
     """
     h, w = image.shape[:2]
     src_pts = np.float32([[0, 0], [w, 0], [w, h], [0, h]])
-    dst_pts = np.float32([(bounding_box[i], bounding_box[i+1]) for i in range(0, len(bounding_box), 2)])
+    dst_pts = np.float32(
+        [(bounding_box[i], bounding_box[i + 1]) for i in range(0, len(bounding_box), 2)]
+    )
     matrix = cv2.getPerspectiveTransform(src_pts, dst_pts)
     warped = cv2.warpPerspective(image, matrix, (image_width, image_height))
     return warped
 
+
 def draw_text_on_image(text, font, text_color):
     """
     Draw text onto an image with a transparent background.
-    
+
     Args:
         text (str): The text to draw.
         font (PIL.ImageFont.ImageFont): The font object.
         text_color (tuple): The text color (R, G, B).
-        
+
     Returns:
         PIL.Image.Image: The image with text.
     """
     size = tuple(font.getbbox(text)[2:])  # width and height of the text
-    text_image = Image.new('RGBA', size, (255, 255, 255, 0))
+    text_image = Image.new("RGBA", size, (255, 255, 255, 0))
     draw = ImageDraw.Draw(text_image)
     draw.text((0, 0), text, font=font, fill=text_color)
     return text_image
 
+
 def create_filled_polygon_mask(bounding_box, image_size, fill_color):
     """
     Create a filled polygon mask for the bounding box area.
-    
+
     Args:
         bounding_box (list): The bounding box coordinates.
         image_size (tuple): The size of the image (width, height).
         fill_color (tuple): The fill color (R, G, B, A).
-        
+
     Returns:
         PIL.Image.Image: The mask image.
     """
-    mask_image = Image.new('RGBA', image_size, (255, 255, 255, 0))
+    mask_image = Image.new("RGBA", image_size, (255, 255, 255, 0))
     mask_draw = ImageDraw.Draw(mask_image)
-    pts = [(bounding_box[i], bounding_box[i+1]) for i in range(0, len(bounding_box), 2)]
+    pts = [
+        (bounding_box[i], bounding_box[i + 1]) for i in range(0, len(bounding_box), 2)
+    ]
     mask_draw.polygon(pts, fill=fill_color)
     return mask_image
 
+
 # Function to Plot Bounding Boxes on Image. Set display=True to display the image in a notebook.
 # Saves images to ./analyzed_images
-def plot_bounding_boxes(image_path, line_bounding_boxes, language_code="en", display=True):
+def plot_bounding_boxes(
+    image_path, line_bounding_boxes, language_code="en", display=True
+):
     # Create output directory if it doesn't exist
-    os.makedirs('./analyzed_images', exist_ok=True)
-    
+    os.makedirs("./analyzed_images", exist_ok=True)
+
     image = Image.open(image_path)
     draw = ImageDraw.Draw(image)
-    
+
     font_size = 20
     # Load the font using FontConfig
     font_config = FontConfig()
     font_path = font_config.get_font_path(language_code)
     font = ImageFont.truetype(font_path, font_size)
-    
+
     for line_info in line_bounding_boxes:
         print(line_info)
-        bounding_box = line_info['bounding_box']
-        confidence = line_info['confidence']
-        pts = [(bounding_box[i], bounding_box[i+1]) for i in range(0, len(bounding_box), 2)]
-        
+        bounding_box = line_info["bounding_box"]
+        confidence = line_info["confidence"]
+        pts = [
+            (bounding_box[i], bounding_box[i + 1])
+            for i in range(0, len(bounding_box), 2)
+        ]
+
         # Draw thicker polygon for bounding box with width parameter
         draw.line(pts + [pts[0]], fill="yellow", width=4)
-        
+
         # Coordinates for the text
         x, y = bounding_box[0], bounding_box[1] - font_size
 
@@ -165,15 +184,22 @@ def plot_bounding_boxes(image_path, line_bounding_boxes, language_code="en", dis
         for dx in range(-outline_range, outline_range + 1):
             for dy in range(-outline_range, outline_range + 1):
                 if dx != 0 or dy != 0:
-                    draw.text((x + dx, y + dy), f"{line_info['text']} ({confidence:.2f})", font=font, fill="white")
+                    draw.text(
+                        (x + dx, y + dy),
+                        f"{line_info['text']} ({confidence:.2f})",
+                        font=font,
+                        fill="white",
+                    )
 
         # Draw black text
-        draw.text((x, y), f"{line_info['text']} ({confidence:.2f})", font=font, fill="black")
-    
+        draw.text(
+            (x, y), f"{line_info['text']} ({confidence:.2f})", font=font, fill="black"
+        )
+
     # Save the annotated image
-    output_path = os.path.join('./analyzed_images', os.path.basename(image_path))
+    output_path = os.path.join("./analyzed_images", os.path.basename(image_path))
     image.save(output_path)
-    
+
     if display:
         # Display the image
         plt.figure(figsize=(20, 10))
@@ -181,40 +207,42 @@ def plot_bounding_boxes(image_path, line_bounding_boxes, language_code="en", dis
         plt.imshow(np.array(image))
         plt.title("Image with Bounding Boxes")
         plt.axis("off")
-        
+
         original_image = Image.open(image_path)
         plt.subplot(1, 2, 2)
         plt.imshow(np.array(original_image))
         plt.title("Original Image")
         plt.axis("off")
-        
+
         plt.show()
+
 
 def display_image(image_path, annotated_image_path):
     """
     Display the original image and the annotated image side by side.
-    
+
     Args:
         image_path (str): Path to the original image file.
         annotated_image (PIL.Image.Image): The image annotated with translated text.
     """
     plt.figure(figsize=(20, 10))
-    
+
     # Display the annotated image
     annotated_image = Image.open(annotated_image_path)
     plt.subplot(1, 2, 1)
     plt.imshow(annotated_image)
     plt.title("Annotated Image with Translated Text")
     plt.axis("off")
-    
+
     # Display the original image
     original_image = Image.open(image_path)
     plt.subplot(1, 2, 2)
     plt.imshow(original_image)
     plt.title("Original Image")
     plt.axis("off")
-    
+
     plt.show()
+
 
 def retrieve_bounding_boxes_by_image_path(image_path):
     image_name = os.path.basename(image_path).split(".")[0]
@@ -228,6 +256,7 @@ def retrieve_bounding_boxes_by_image_path(image_path):
     else:
         print(f"Bounding box data {json_path} does not exist.")
 
+
 def get_image_mode(image_path):
     """
     Determine the appropriate image mode (RGBA or RGB) based on the file extension.
@@ -239,9 +268,9 @@ def get_image_mode(image_path):
         str: 'RGBA' for PNG files, 'RGB' for JPG/JPEG files.
     """
     extension = get_filename_and_extension(image_path)[1]
-    if extension in ['.png']:
-        return 'RGBA'
-    elif extension in ['.jpg', '.jpeg']:
-        return 'RGB'
+    if extension in [".png"]:
+        return "RGBA"
+    elif extension in [".jpg", ".jpeg"]:
+        return "RGB"
     else:
         raise ValueError(f"Unsupported image format: {extension}")

--- a/tests/co_op_translator/config/test_base_config.py
+++ b/tests/co_op_translator/config/test_base_config.py
@@ -6,35 +6,40 @@ from co_op_translator.config.base_config import Config
 from co_op_translator.config.llm_config.config import LLMConfig
 from co_op_translator.config.vision_config.config import VisionConfig
 
+
 @pytest.fixture
 def azure_openai_env_vars():
     return {
-        'AZURE_OPENAI_API_KEY': 'fake_openai_key',
-        'AZURE_OPENAI_ENDPOINT': 'https://fake-openai-endpoint.com',
-        'AZURE_OPENAI_MODEL_NAME': 'gpt',
-        'AZURE_OPENAI_CHAT_DEPLOYMENT_NAME': 'chat-deployment',
-        'AZURE_OPENAI_API_VERSION': 'v1'
+        "AZURE_OPENAI_API_KEY": "fake_openai_key",
+        "AZURE_OPENAI_ENDPOINT": "https://fake-openai-endpoint.com",
+        "AZURE_OPENAI_MODEL_NAME": "gpt",
+        "AZURE_OPENAI_CHAT_DEPLOYMENT_NAME": "chat-deployment",
+        "AZURE_OPENAI_API_VERSION": "v1",
     }
+
 
 @pytest.fixture
 def openai_env_vars():
-    return {
-        'OPENAI_API_KEY': 'fake_openai_key'
-    }
+    return {"OPENAI_API_KEY": "fake_openai_key"}
+
 
 @pytest.fixture
 def vision_env_vars():
     return {
-        'AZURE_SUBSCRIPTION_KEY': 'fake_subscription_key',
-        'AZURE_AI_SERVICE_ENDPOINT': 'https://fake-ai-service-endpoint.com'
+        "AZURE_SUBSCRIPTION_KEY": "fake_subscription_key",
+        "AZURE_AI_SERVICE_ENDPOINT": "https://fake-ai-service-endpoint.com",
     }
+
 
 def test_config_with_azure_openai_and_vision(azure_openai_env_vars, vision_env_vars):
     """Test configuration with Azure OpenAI and Vision services"""
-    with patch.dict(os.environ, {**azure_openai_env_vars, **vision_env_vars}, clear=True):
+    with patch.dict(
+        os.environ, {**azure_openai_env_vars, **vision_env_vars}, clear=True
+    ):
         Config.check_configuration()
         assert LLMConfig.get_available_provider() is not None
         assert VisionConfig.check_configuration() is True
+
 
 def test_config_with_openai_and_vision(openai_env_vars, vision_env_vars):
     """Test configuration with OpenAI and Vision services"""
@@ -43,12 +48,14 @@ def test_config_with_openai_and_vision(openai_env_vars, vision_env_vars):
         assert LLMConfig.get_available_provider() is not None
         assert VisionConfig.check_configuration() is True
 
+
 def test_config_with_azure_openai_only(azure_openai_env_vars):
     """Test configuration with only Azure OpenAI (markdown-only mode)"""
     with patch.dict(os.environ, azure_openai_env_vars, clear=True):
         Config.check_configuration()
         assert LLMConfig.get_available_provider() is not None
         assert VisionConfig.check_configuration() is False
+
 
 def test_config_with_openai_only(openai_env_vars):
     """Test configuration with only OpenAI (markdown-only mode)"""
@@ -57,6 +64,7 @@ def test_config_with_openai_only(openai_env_vars):
         assert LLMConfig.get_available_provider() is not None
         assert VisionConfig.check_configuration() is False
 
+
 def test_config_with_no_llm_service():
     """Test configuration with no LLM service available"""
     with patch.dict(os.environ, {}, clear=True):
@@ -64,25 +72,32 @@ def test_config_with_no_llm_service():
             Config.check_configuration()
         assert "No LLM service is properly configured" in str(excinfo.value)
 
+
 def test_config_with_partial_azure_openai():
     """Test configuration with incomplete Azure OpenAI setup"""
     partial_vars = {
-        'AZURE_OPENAI_API_KEY': 'fake_key',  # Other required fields are missing
-        'AZURE_OPENAI_ENDPOINT': ''  # Missing required endpoint
+        "AZURE_OPENAI_API_KEY": "fake_key",  # Other required fields are missing
+        "AZURE_OPENAI_ENDPOINT": "",  # Missing required endpoint
     }
     with patch.dict(os.environ, partial_vars, clear=True):
         with pytest.raises(ValueError) as excinfo:
             Config.check_configuration()
-        assert "Incomplete AZURE_OPENAI configuration. Ensure all required environment variables are set." in str(excinfo.value)
+        assert (
+            "Incomplete AZURE_OPENAI configuration. Ensure all required environment variables are set."
+            in str(excinfo.value)
+        )
 
 
 def test_config_with_partial_openai():
     """Test configuration with incomplete OpenAI setup"""
     partial_vars = {
-        'OPENAI_API_KEY': '',  # Missing required API key
-        'OPENAI_ORG_ID': 'fake_org_id'
+        "OPENAI_API_KEY": "",  # Missing required API key
+        "OPENAI_ORG_ID": "fake_org_id",
     }
     with patch.dict(os.environ, partial_vars, clear=True):
         with pytest.raises(ValueError) as excinfo:
             Config.check_configuration()
-        assert "Incomplete OpenAI configuration. The 'OPENAI_API_KEY' must be set." in str(excinfo.value)
+        assert (
+            "Incomplete OpenAI configuration. The 'OPENAI_API_KEY' must be set."
+            in str(excinfo.value)
+        )

--- a/tests/co_op_translator/config/test_font_config.py
+++ b/tests/co_op_translator/config/test_font_config.py
@@ -15,27 +15,36 @@ ar:
   rtl: True
 """
 
+
 @pytest.fixture
 def mock_font_mappings():
     """
     Fixture that provides an instance of FontConfig with mocked font mappings.
     Mocks the loading of 'font_language_mappings.yml'.
     """
-    with patch('importlib.resources.path') as mock_path, \
-         patch('builtins.open', mock_open(read_data=sample_yaml)):
-        mock_path.return_value = Path('fake_path/font_language_mappings.yml')
+    with (
+        patch("importlib.resources.path") as mock_path,
+        patch("builtins.open", mock_open(read_data=sample_yaml)),
+    ):
+        mock_path.return_value = Path("fake_path/font_language_mappings.yml")
         return FontConfig()
+
 
 def test_get_font_path(mock_font_mappings):
     """
     Test retrieving the font path for a valid language code.
     Ensures the correct path is returned for a valid language code.
     """
-    with patch('importlib.resources.path', return_value=Path('fake_font_path/Arial.ttf')) as mock_path:
-        font_path = mock_font_mappings.get_font_path('en')
+    with patch(
+        "importlib.resources.path", return_value=Path("fake_font_path/Arial.ttf")
+    ) as mock_path:
+        font_path = mock_font_mappings.get_font_path("en")
 
-        assert Path(font_path) == Path('fake_font_path/Arial.ttf'), "Font path for 'en' should return the correct path"
-        mock_path.assert_called_once_with('co_op_translator.fonts', 'Arial.ttf')
+        assert Path(font_path) == Path(
+            "fake_font_path/Arial.ttf"
+        ), "Font path for 'en' should return the correct path"
+        mock_path.assert_called_once_with("co_op_translator.fonts", "Arial.ttf")
+
 
 def test_get_font_path_invalid(mock_font_mappings):
     """
@@ -43,16 +52,20 @@ def test_get_font_path_invalid(mock_font_mappings):
     Ensures that requesting a font for an unsupported language code raises the appropriate error.
     """
     with pytest.raises(ValueError) as excinfo:
-        mock_font_mappings.get_font_path('xx')
-    assert "Font for language code 'xx' is not supported or not found." in str(excinfo.value)
+        mock_font_mappings.get_font_path("xx")
+    assert "Font for language code 'xx' is not supported or not found." in str(
+        excinfo.value
+    )
+
 
 def test_get_language_name(mock_font_mappings):
     """
     Test retrieving the language name for a valid language code.
     Ensures the correct language name is returned for a valid language code.
     """
-    language_name = mock_font_mappings.get_language_name('en')
-    assert language_name == 'English', "Language name for 'en' should be 'English'"
+    language_name = mock_font_mappings.get_language_name("en")
+    assert language_name == "English", "Language name for 'en' should be 'English'"
+
 
 def test_get_language_name_invalid(mock_font_mappings):
     """
@@ -60,24 +73,27 @@ def test_get_language_name_invalid(mock_font_mappings):
     Ensures that requesting a language name for an unsupported language code raises an error.
     """
     with pytest.raises(ValueError) as excinfo:
-        mock_font_mappings.get_language_name('xx')
+        mock_font_mappings.get_language_name("xx")
     assert "Language code 'xx' is not supported." in str(excinfo.value)
+
 
 def test_is_rtl(mock_font_mappings):
     """
     Test if the language is RTL (Right-to-Left) for a valid language code.
     Ensures that the RTL value is correctly returned for RTL languages like Arabic.
     """
-    is_rtl = mock_font_mappings.is_rtl('ar')
+    is_rtl = mock_font_mappings.is_rtl("ar")
     assert is_rtl is True, "The 'ar' language code should return True for RTL"
+
 
 def test_is_rtl_false(mock_font_mappings):
     """
     Test if the language is not RTL (Left-to-Right) for a valid language code.
     Ensures that the RTL value is correctly returned as False for non-RTL languages like English.
     """
-    is_rtl = mock_font_mappings.is_rtl('en')
+    is_rtl = mock_font_mappings.is_rtl("en")
     assert is_rtl is False, "The 'en' language code should return False for RTL"
+
 
 def test_is_rtl_invalid(mock_font_mappings):
     """
@@ -85,5 +101,5 @@ def test_is_rtl_invalid(mock_font_mappings):
     Ensures that requesting RTL info for an unsupported language code raises an error.
     """
     with pytest.raises(ValueError) as excinfo:
-        mock_font_mappings.is_rtl('xx')
+        mock_font_mappings.is_rtl("xx")
     assert "Language code 'xx' is not supported." in str(excinfo.value)

--- a/tests/co_op_translator/core/llm/test_markdown_translator.py
+++ b/tests/co_op_translator/core/llm/test_markdown_translator.py
@@ -12,16 +12,20 @@ TEST_MD_CONTENT = """
 print("Hello, world!")
 ```"""
 
+
 class ConcreteMarkdownTranslator(MarkdownTranslator):
     """A concrete implementation of MarkdownTranslator for testing."""
+
     async def _run_prompt(self, prompt, index, total):
         # This implementation should be replaced by the mock in tests
         return f"[Default Translation] {prompt}"
+
 
 @pytest.fixture
 def real_markdown_translator(tmp_path):
     """Creates a concrete instance of MarkdownTranslator for testing."""
     return ConcreteMarkdownTranslator(root_dir=tmp_path)
+
 
 @pytest.mark.asyncio
 async def test_translate_markdown_partial_mock(real_markdown_translator):
@@ -34,12 +38,13 @@ async def test_translate_markdown_partial_mock(real_markdown_translator):
     This ensures we verify the actual internal workflow,
     while controlling the translation 'results' in _run_prompt.
     """
+
     async def fake_prompt(prompt, index, total):
         # Return a translation that preserves markdown structure and placeholders
         # This simulates what a real translator would do with the prompt template
         if "Sample Markdown" in prompt:
             # Keep any code block placeholders in the translation
-            placeholder_match = re.search(r'@@CODE_BLOCK_\d+@@', prompt)
+            placeholder_match = re.search(r"@@CODE_BLOCK_\d+@@", prompt)
             code_placeholder = placeholder_match.group(0) if placeholder_match else ""
             return f"# Ejemplo de Markdown\n\n{code_placeholder}"
         elif "Disclaimer" in prompt.lower():
@@ -47,30 +52,31 @@ async def test_translate_markdown_partial_mock(real_markdown_translator):
         return prompt  # Return the original prompt for any other content
 
     # Apply the mock directly to the instance
-    with patch.object(real_markdown_translator, '_run_prompt', new_callable=AsyncMock) as mock_run_prompt:
+    with patch.object(
+        real_markdown_translator, "_run_prompt", new_callable=AsyncMock
+    ) as mock_run_prompt:
         mock_run_prompt.side_effect = fake_prompt
 
         # Execute the markdown translation
         result = await real_markdown_translator.translate_markdown(
-            document=TEST_MD_CONTENT,
-            language_code="es",
-            md_file_path="example.md"
+            document=TEST_MD_CONTENT, language_code="es", md_file_path="example.md"
         )
 
         # Verify that the code block content is still present in the final output
-        assert "print(\"Hello, world!\")" in result, (
-            "Expected the code block to remain after the placeholder/restore cycle."
-        )
+        assert (
+            'print("Hello, world!")' in result
+        ), "Expected the code block to remain after the placeholder/restore cycle."
 
         # Verify that our translation appears (in Spanish)
-        assert "Ejemplo de Markdown" in result, (
-            "The mocked _run_prompt response should appear in the final output."
-        )
+        assert (
+            "Ejemplo de Markdown" in result
+        ), "The mocked _run_prompt response should appear in the final output."
 
         # Verify that _run_prompt was called at least once
-        assert mock_run_prompt.call_count > 0, (
-            "Expected at least one call to _run_prompt for the translation process."
-        )
+        assert (
+            mock_run_prompt.call_count > 0
+        ), "Expected at least one call to _run_prompt for the translation process."
+
 
 @pytest.mark.asyncio
 async def test_translate_markdown_full_integration(real_markdown_translator):
@@ -79,16 +85,16 @@ async def test_translate_markdown_full_integration(real_markdown_translator):
     or if real_markdown_translator is a fully realized subclass."""
     try:
         result = await real_markdown_translator.translate_markdown(
-            document=TEST_MD_CONTENT,
-            language_code="es",
-            md_file_path="example_full.md"
+            document=TEST_MD_CONTENT, language_code="es", md_file_path="example_full.md"
         )
     except NotImplementedError:
-        pytest.skip("Skipping because _run_prompt is not implemented in the base class.")
+        pytest.skip(
+            "Skipping because _run_prompt is not implemented in the base class."
+        )
 
-    assert "print(\"Hello, world!\")" in result, (
-        "Even in a full integration scenario, the code block should remain."
-    )
-    assert "[Default Translation]" in result, (
-        "Expected the default translation text in the output."
-    )
+    assert (
+        'print("Hello, world!")' in result
+    ), "Even in a full integration scenario, the code block should remain."
+    assert (
+        "[Default Translation]" in result
+    ), "Expected the default translation text in the output."

--- a/tests/co_op_translator/core/llm/test_text_translator.py
+++ b/tests/co_op_translator/core/llm/test_text_translator.py
@@ -3,28 +3,33 @@ from unittest.mock import patch, MagicMock, AsyncMock
 from co_op_translator.core.llm.text_translator import TextTranslator
 from co_op_translator.utils.llm.text_utils import remove_code_backticks
 
+
 class MockTextTranslator(TextTranslator):
     """Mock implementation of TextTranslator for testing."""
+
     def __init__(self):
         self.client = self.get_openai_client()
 
     def get_openai_client(self):
         mock_client = MagicMock()
         mock_response = MagicMock()
-        mock_response.choices = [MagicMock(message=MagicMock(content="```\nTranslated Text\n```"))]
+        mock_response.choices = [
+            MagicMock(message=MagicMock(content="```\nTranslated Text\n```"))
+        ]
         mock_client.chat.completions.create.return_value = mock_response
         return mock_client
-    
+
     def get_model_name(self):
         return "gpt-4"
 
     def translate_batch(self, texts, target_language):
         """Mock implementation of translate_batch."""
         return [f"Translated: {text}" for text in texts]
-    
+
     def translate_text(self, text, target_language):
         """Mock implementation of translate_text."""
         return f"Translated: {text}"
+
 
 @pytest.fixture
 def text_translator():
@@ -32,6 +37,7 @@ def text_translator():
     Fixture to provide an instance of MockTextTranslator for each test.
     """
     return MockTextTranslator()
+
 
 def test_translate_text(text_translator):
     """
@@ -42,6 +48,7 @@ def test_translate_text(text_translator):
     result = text_translator.translate_text(text, target_language)
 
     assert result == "Translated: Text to translate"
+
 
 def test_translate_batch(text_translator):
     """

--- a/tests/co_op_translator/core/project/test_project_translator.py
+++ b/tests/co_op_translator/core/project/test_project_translator.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from co_op_translator.core.project.project_translator import ProjectTranslator
 from unittest.mock import ANY
 
+
 @pytest.fixture
 def temp_project_dir(tmp_path):
     """Create a temporary project directory structure."""
@@ -12,32 +13,44 @@ def temp_project_dir(tmp_path):
     docs_dir = tmp_path / "docs"
     docs_dir.mkdir()
     (docs_dir / "test.md").write_text("# Test Document\nThis is a test.")
-    
+
     images_dir = tmp_path / "images"
     images_dir.mkdir()
     (images_dir / "test.png").touch()
-    
+
     translations_dir = tmp_path / "translations"
     translations_dir.mkdir()
-    
+
     return tmp_path
+
 
 @pytest.fixture
 def project_translator(temp_project_dir):
     """Create a ProjectTranslator instance with mocked dependencies."""
-    with patch("co_op_translator.core.llm.text_translator.TextTranslator") as mock_text_translator, \
-         patch("co_op_translator.core.llm.markdown_translator.MarkdownTranslator") as mock_markdown_translator, \
-         patch("co_op_translator.core.vision.image_translator.ImageTranslator") as mock_image_translator, \
-         patch("co_op_translator.config.llm_config.config.LLMConfig.get_available_provider") as mock_get_provider:
-        
+    with (
+        patch(
+            "co_op_translator.core.llm.text_translator.TextTranslator"
+        ) as mock_text_translator,
+        patch(
+            "co_op_translator.core.llm.markdown_translator.MarkdownTranslator"
+        ) as mock_markdown_translator,
+        patch(
+            "co_op_translator.core.vision.image_translator.ImageTranslator"
+        ) as mock_image_translator,
+        patch(
+            "co_op_translator.config.llm_config.config.LLMConfig.get_available_provider"
+        ) as mock_get_provider,
+    ):
+
         # Setup mock translators and config
         mock_text_translator.create.return_value = MagicMock()
         mock_markdown_translator.create.return_value = MagicMock()
         mock_image_translator.create.return_value = MagicMock()
         mock_get_provider.return_value = "azure"  # Mock LLM provider
-        
+
         translator = ProjectTranslator("ko ja", root_dir=temp_project_dir)
         return translator
+
 
 @pytest.mark.asyncio
 async def test_translate_markdown(project_translator, temp_project_dir):
@@ -47,15 +60,16 @@ async def test_translate_markdown(project_translator, temp_project_dir):
     project_translator.markdown_translator.translate_markdown = AsyncMock(
         return_value="# Test Document\nThis is a test in Korean."
     )
-    
+
     # Execute
     await project_translator.translate_markdown(md_file, "ko")
-    
+
     # Verify
     translated_file = temp_project_dir / "translations" / "ko" / "docs" / "test.md"
     assert translated_file.exists()
-    content = translated_file.read_text(encoding='utf-8')
+    content = translated_file.read_text(encoding="utf-8")
     assert "Test Document" in content
+
 
 @pytest.mark.asyncio
 async def test_translate_image(project_translator, temp_project_dir):
@@ -65,12 +79,13 @@ async def test_translate_image(project_translator, temp_project_dir):
     project_translator.image_translator.translate_image = MagicMock(
         return_value=str(temp_project_dir / "translated_images" / "ko_test.png")
     )
-    
+
     # Execute
     await project_translator.translate_image(image_file, "ko")
-    
+
     # Verify
     project_translator.image_translator.translate_image.assert_called_once()
+
 
 @pytest.mark.asyncio
 async def test_translate_all_markdown_files(project_translator, temp_project_dir):
@@ -79,14 +94,15 @@ async def test_translate_all_markdown_files(project_translator, temp_project_dir
     project_translator.markdown_translator.translate_markdown = AsyncMock(
         return_value="# 테스트 문서\n이것은 테스트입니다."
     )
-    
+
     # Execute
     await project_translator.translate_all_markdown_files()
-    
+
     # Verify
     for lang in ["ko", "ja"]:
         translated_file = temp_project_dir / "translations" / lang / "docs" / "test.md"
         assert translated_file.exists()
+
 
 @pytest.mark.asyncio
 async def test_translate_all_image_files(project_translator, temp_project_dir):
@@ -99,15 +115,24 @@ async def test_translate_all_image_files(project_translator, temp_project_dir):
     async def mock_translate_image(path, lang, _):
         return str(temp_project_dir / "translated_images" / f"{lang}_test.png")
 
-    project_translator.image_translator.translate_image = AsyncMock(side_effect=mock_translate_image)
+    project_translator.image_translator.translate_image = AsyncMock(
+        side_effect=mock_translate_image
+    )
 
     # Execute
     await asyncio.wait_for(project_translator.translate_all_image_files(), timeout=10)
 
     # Verify
-    assert project_translator.image_translator.translate_image.call_count == 2  # Called for "ko" and "ja"
-    project_translator.image_translator.translate_image.assert_any_call(image_file, "ko", ANY)
-    project_translator.image_translator.translate_image.assert_any_call(image_file, "ja", ANY)
+    assert (
+        project_translator.image_translator.translate_image.call_count == 2
+    )  # Called for "ko" and "ja"
+    project_translator.image_translator.translate_image.assert_any_call(
+        image_file, "ko", ANY
+    )
+    project_translator.image_translator.translate_image.assert_any_call(
+        image_file, "ja", ANY
+    )
+
 
 @pytest.mark.asyncio
 async def test_translate_project_async(project_translator):
@@ -115,23 +140,25 @@ async def test_translate_project_async(project_translator):
     # Setup
     project_translator.translate_all_markdown_files = AsyncMock()
     project_translator.translate_all_image_files = AsyncMock()
-    
+
     # Execute
     await project_translator.translate_project_async(images=True, markdown=True)
-    
+
     # Verify
     project_translator.translate_all_markdown_files.assert_called_once()
     project_translator.translate_all_image_files.assert_called_once()
 
+
 def test_translate_project(project_translator):
     """Test the synchronous translate_project method."""
     # Setup
-    with patch.object(asyncio, 'run') as mock_run:
+    with patch.object(asyncio, "run") as mock_run:
         # Execute
         project_translator.translate_project(images=True, markdown=True)
-        
+
         # Verify
         mock_run.assert_called_once()
+
 
 @pytest.mark.asyncio
 async def test_check_and_retry_translations(project_translator, temp_project_dir):
@@ -140,18 +167,21 @@ async def test_check_and_retry_translations(project_translator, temp_project_dir
     md_file = temp_project_dir / "docs" / "test.md"
     translated_file = temp_project_dir / "translations" / "ko" / "docs" / "test.md"
     translated_file.parent.mkdir(parents=True)
-    translated_file.write_text("# Test\nBroken translation")  # Create a "broken" translation
-    
+    translated_file.write_text(
+        "# Test\nBroken translation"
+    )  # Create a "broken" translation
+
     project_translator.markdown_translator.translate_markdown = AsyncMock(
         return_value="# 테스트 문서\n이것은 테스트입니다."
     )
-    
+
     # Execute
     await project_translator.check_and_retry_translations()
-    
+
     # Verify
     project_translator.markdown_translator.translate_markdown.assert_called()
     assert translated_file.exists()
+
 
 @pytest.mark.asyncio
 async def test_process_api_requests_parallel(project_translator):
@@ -160,12 +190,13 @@ async def test_process_api_requests_parallel(project_translator):
     mock_task1 = AsyncMock()
     mock_task2 = AsyncMock()
     tasks = [mock_task1, mock_task2]
-    
+
     # Execute
     await project_translator.process_api_requests_parallel(tasks, "Test tasks")
-    
+
     # No direct verification possible due to queue-based implementation
     # Success is indicated by no exceptions being raised
+
 
 @pytest.mark.asyncio
 async def test_process_api_requests_sequential(project_translator):
@@ -174,28 +205,39 @@ async def test_process_api_requests_sequential(project_translator):
     mock_task1 = AsyncMock()
     mock_task2 = AsyncMock()
     tasks = [lambda: mock_task1(), lambda: mock_task2()]
-    
+
     # Execute
     await project_translator.process_api_requests_sequential(tasks, "Test tasks")
-    
+
     # Verify
     mock_task1.assert_called_once()
     mock_task2.assert_called_once()
 
+
 def test_markdown_only_mode(temp_project_dir):
     """Test ProjectTranslator in markdown-only mode."""
-    with patch("co_op_translator.core.llm.text_translator.TextTranslator") as mock_text_translator, \
-         patch("co_op_translator.core.llm.markdown_translator.MarkdownTranslator") as mock_markdown_translator, \
-         patch("co_op_translator.config.llm_config.config.LLMConfig.get_available_provider") as mock_get_provider:
-        
+    with (
+        patch(
+            "co_op_translator.core.llm.text_translator.TextTranslator"
+        ) as mock_text_translator,
+        patch(
+            "co_op_translator.core.llm.markdown_translator.MarkdownTranslator"
+        ) as mock_markdown_translator,
+        patch(
+            "co_op_translator.config.llm_config.config.LLMConfig.get_available_provider"
+        ) as mock_get_provider,
+    ):
+
         # Setup mocks
         mock_text_translator.create.return_value = MagicMock()
         mock_markdown_translator.create.return_value = MagicMock()
         mock_get_provider.return_value = "azure"  # Mock LLM provider
-        
+
         # Create translator in markdown-only mode
-        translator = ProjectTranslator("ko", root_dir=temp_project_dir, markdown_only=True)
-        
+        translator = ProjectTranslator(
+            "ko", root_dir=temp_project_dir, markdown_only=True
+        )
+
         # Verify
         assert translator.markdown_only is True
         assert translator.image_translator is None

--- a/tests/co_op_translator/core/vision/test_image_translator.py
+++ b/tests/co_op_translator/core/vision/test_image_translator.py
@@ -8,24 +8,28 @@ from co_op_translator.core.llm.text_translator import TextTranslator
 TEST_IMAGE_PATH = Path("test_image.png").resolve()
 ROOT_DIR = Path(".").resolve()
 
+
 class MockTextTranslator(TextTranslator):
     """Mock implementation of TextTranslator for testing."""
+
     def __init__(self):
         self.client = self.get_openai_client()
 
     def get_openai_client(self):
         return MagicMock()
-    
+
     def get_model_name(self):
         return "gpt-4"
-    
+
     def translate_batch(self, texts, target_language):
         """Mock implementation of translate_batch."""
         return [f"Translated: {text}" for text in texts]
 
+
 class MockImageTranslator(ImageTranslator):
     """Mock implementation of ImageTranslator for testing."""
-    def __init__(self, default_output_dir='./translated_images', root_dir='.'):
+
+    def __init__(self, default_output_dir="./translated_images", root_dir="."):
         self.text_translator = MockTextTranslator()
         self.default_output_dir = default_output_dir
         self.root_dir = Path(root_dir)
@@ -40,7 +44,7 @@ class MockImageTranslator(ImageTranslator):
             {
                 "text": "LIFE IS LIKE",
                 "bounding_box": [41, 111, 963, 77, 966, 147, 41, 185],
-                "confidence": 0.988
+                "confidence": 0.988,
             }
         ]
 
@@ -49,11 +53,16 @@ class MockImageTranslator(ImageTranslator):
         bounding_boxes = self.extract_text_from_image(image_path)
         texts = [box["text"] for box in bounding_boxes]
         translated_texts = self.text_translator.translate_batch(texts, target_language)
-        return self.plot_annotated_image(image_path, bounding_boxes, translated_texts, target_language)
+        return self.plot_annotated_image(
+            image_path, bounding_boxes, translated_texts, target_language
+        )
 
-    def plot_annotated_image(self, image_path, bounding_boxes, translated_texts, target_language):
+    def plot_annotated_image(
+        self, image_path, bounding_boxes, translated_texts, target_language
+    ):
         """Mock implementation of plot_annotated_image."""
         return Path(self.default_output_dir) / "translated_image.png"
+
 
 @pytest.fixture
 def image_translator(tmp_path):
@@ -61,6 +70,7 @@ def image_translator(tmp_path):
     Fixture to provide an instance of MockImageTranslator for each test.
     """
     return MockImageTranslator(default_output_dir=tmp_path, root_dir=ROOT_DIR)
+
 
 @pytest.fixture
 def mock_line_bounding_boxes():
@@ -71,25 +81,22 @@ def mock_line_bounding_boxes():
         {
             "text": "LIFE IS LIKE",
             "bounding_box": [41, 111, 963, 77, 966, 147, 41, 185],
-            "confidence": 0.988
+            "confidence": 0.988,
         },
         {
             "text": "RIDING A BICYCLE",
             "bounding_box": [210, 231, 1035, 204, 1037, 254, 212, 281],
-            "confidence": 0.993
-        }
+            "confidence": 0.993,
+        },
     ]
 
-@patch('builtins.open', new_callable=MagicMock)
-@patch('PIL.Image.open', return_value=MagicMock(spec=Image.Image))
-@patch('PIL.Image.Image.save')
-@patch('os.makedirs')
+
+@patch("builtins.open", new_callable=MagicMock)
+@patch("PIL.Image.open", return_value=MagicMock(spec=Image.Image))
+@patch("PIL.Image.Image.save")
+@patch("os.makedirs")
 def test_extract_text_from_image(
-    mock_makedirs, 
-    mock_image_save, 
-    mock_image_open, 
-    mock_file_open, 
-    image_translator
+    mock_makedirs, mock_image_save, mock_image_open, mock_file_open, image_translator
 ):
     """
     Test extract_text_from_image method to ensure it extracts text and bounding boxes correctly.
@@ -104,7 +111,7 @@ def test_extract_text_from_image(
         MagicMock(x=41, y=111),
         MagicMock(x=963, y=77),
         MagicMock(x=966, y=147),
-        MagicMock(x=41, y=185)
+        MagicMock(x=41, y=185),
     ]
     mock_line.words = [MagicMock(confidence=0.988)]
     mock_block.lines = [mock_line]
@@ -113,16 +120,29 @@ def test_extract_text_from_image(
 
     bounding_boxes = image_translator.extract_text_from_image(TEST_IMAGE_PATH)
 
-    assert len(bounding_boxes) == 1, f"Expected 1 bounding box, got {len(bounding_boxes)}"
-    assert bounding_boxes[0]['text'] == "LIFE IS LIKE", f"Expected text 'LIFE IS LIKE', got {bounding_boxes[0]['text']}"
-    assert bounding_boxes[0]['bounding_box'] == [41, 111, 963, 77, 966, 147, 41, 185], f"Bounding box mismatch: {bounding_boxes[0]['bounding_box']}"
+    assert (
+        len(bounding_boxes) == 1
+    ), f"Expected 1 bounding box, got {len(bounding_boxes)}"
+    assert (
+        bounding_boxes[0]["text"] == "LIFE IS LIKE"
+    ), f"Expected text 'LIFE IS LIKE', got {bounding_boxes[0]['text']}"
+    assert bounding_boxes[0]["bounding_box"] == [
+        41,
+        111,
+        963,
+        77,
+        966,
+        147,
+        41,
+        185,
+    ], f"Bounding box mismatch: {bounding_boxes[0]['bounding_box']}"
 
-@patch('co_op_translator.core.vision.image_translator.ImageTranslator.plot_annotated_image')
+
+@patch(
+    "co_op_translator.core.vision.image_translator.ImageTranslator.plot_annotated_image"
+)
 def test_translate_image(
-    mock_plot_annotated_image,
-    image_translator, 
-    mock_line_bounding_boxes, 
-    tmp_path
+    mock_plot_annotated_image, image_translator, mock_line_bounding_boxes, tmp_path
 ):
     """
     Test translate_image method to ensure the image is correctly translated and annotated.
@@ -131,22 +151,29 @@ def test_translate_image(
     mock_plot_annotated_image.return_value = tmp_path / "translated_image.png"
     image_translator.plot_annotated_image = mock_plot_annotated_image
 
-    with patch.object(image_translator, 'extract_text_from_image', return_value=mock_line_bounding_boxes):
+    with patch.object(
+        image_translator,
+        "extract_text_from_image",
+        return_value=mock_line_bounding_boxes,
+    ):
         target_language = "es"
         result_path = image_translator.translate_image(TEST_IMAGE_PATH, target_language)
 
         assert str(result_path) == str(tmp_path / "translated_image.png")
-        
+
         # Verify that extract_text_from_image was called with correct arguments
-        image_translator.extract_text_from_image.assert_called_once_with(TEST_IMAGE_PATH)
-        
+        image_translator.extract_text_from_image.assert_called_once_with(
+            TEST_IMAGE_PATH
+        )
+
         # Verify that plot_annotated_image was called with correct arguments
         mock_plot_annotated_image.assert_called_once_with(
             TEST_IMAGE_PATH,
             mock_line_bounding_boxes,
             ["Translated: LIFE IS LIKE", "Translated: RIDING A BICYCLE"],
-            target_language
+            target_language,
         )
+
 
 def test_mock_text_translator_initialization():
     """
@@ -156,6 +183,7 @@ def test_mock_text_translator_initialization():
     assert translator.client is not None
     assert translator.get_model_name() == "gpt-4"
 
+
 def test_translate_batch_with_empty_input():
     """
     Test translate_batch method with empty input.
@@ -164,6 +192,7 @@ def test_translate_batch_with_empty_input():
     result = translator.translate_batch([], "ko")
     assert isinstance(result, list)
     assert len(result) == 0
+
 
 def test_translate_batch_with_various_inputs():
     """
@@ -175,16 +204,17 @@ def test_translate_batch_with_various_inputs():
         "123",
         "Special !@#$%^&*() chars",
         "한글도 테스트",
-        " Leading and trailing spaces "
+        " Leading and trailing spaces ",
     ]
     target_language = "ko"
-    
+
     results = translator.translate_batch(inputs, target_language)
-    
+
     assert len(results) == len(inputs)
     for original, translated in zip(inputs, results):
         assert isinstance(translated, str)
         assert translated == f"Translated: {original}"
+
 
 def test_plot_annotated_image_with_multiple_boxes(image_translator, tmp_path):
     """
@@ -195,60 +225,57 @@ def test_plot_annotated_image_with_multiple_boxes(image_translator, tmp_path):
         {
             "text": "Text 1",
             "bounding_box": [0, 0, 100, 0, 100, 50, 0, 50],
-            "confidence": 0.9
+            "confidence": 0.9,
         },
         {
             "text": "Text 2",
             "bounding_box": [150, 150, 250, 150, 250, 200, 150, 200],
-            "confidence": 0.95
-        }
+            "confidence": 0.95,
+        },
     ]
     translated_texts = ["번역 1", "번역 2"]
     target_language = "ko"
-    
+
     result_path = image_translator.plot_annotated_image(
-        image_path,
-        bounding_boxes,
-        translated_texts,
-        target_language
+        image_path, bounding_boxes, translated_texts, target_language
     )
-    
+
     assert isinstance(result_path, Path)
     assert result_path.parent == tmp_path
     assert str(result_path).endswith("translated_image.png")
 
+
 @pytest.mark.parametrize("target_language", ["ko", "en", "ja", "zh"])
 def test_translate_image_with_different_languages(
-    image_translator,
-    mock_line_bounding_boxes,
-    target_language
+    image_translator, mock_line_bounding_boxes, target_language
 ):
     """
     Test translate_image method with different target languages.
     """
     result_path = image_translator.translate_image(TEST_IMAGE_PATH, target_language)
-    
+
     assert isinstance(result_path, Path)
     assert str(result_path).endswith("translated_image.png")
+
 
 def test_extract_text_with_low_confidence(image_translator):
     """
     Test extract_text_from_image method's handling of low confidence text.
     """
     mock_client = image_translator.get_image_analysis_client()
-    
+
     # Override the mock implementation for this specific test
     def mock_extract_text(*args, **kwargs):
         return [
             {
                 "text": "Low confidence text",
                 "bounding_box": [10, 10, 100, 10, 100, 50, 10, 50],
-                "confidence": 0.3  # Low confidence score
+                "confidence": 0.3,  # Low confidence score
             }
         ]
-    
+
     image_translator.extract_text_from_image = mock_extract_text
-    
+
     result = image_translator.extract_text_from_image(TEST_IMAGE_PATH)
     assert len(result) == 1
     assert result[0]["confidence"] < 0.5

--- a/tests/co_op_translator/utils/common/test_file_utils.py
+++ b/tests/co_op_translator/utils/common/test_file_utils.py
@@ -7,17 +7,25 @@ import shutil
 from pathlib import Path
 import pytest
 from co_op_translator.utils.common.file_utils import (
-    read_input_file, write_output_file, handle_empty_document,
-    get_unique_id, get_filename_and_extension, filter_files,
-    generate_translated_filename, get_actual_image_path,
-    reset_translation_directories, delete_translated_markdown_files_by_language_code,
-    delete_translated_images_by_language_code
+    read_input_file,
+    write_output_file,
+    handle_empty_document,
+    get_unique_id,
+    get_filename_and_extension,
+    filter_files,
+    generate_translated_filename,
+    get_actual_image_path,
+    reset_translation_directories,
+    delete_translated_markdown_files_by_language_code,
+    delete_translated_images_by_language_code,
 )
+
 
 @pytest.fixture
 def temp_dir(tmp_path):
     """Create a temporary directory for testing."""
     return tmp_path
+
 
 @pytest.fixture
 def test_file(temp_dir):
@@ -27,6 +35,7 @@ def test_file(temp_dir):
         f.write("Test content\nLine 2")
     return file_path
 
+
 @pytest.fixture
 def empty_file(temp_dir):
     """Create an empty test file."""
@@ -34,19 +43,22 @@ def empty_file(temp_dir):
     file_path.touch()
     return file_path
 
+
 def test_read_input_file(test_file):
     """Test reading content from a file."""
     content = read_input_file(test_file)
     assert content == "Test content\nLine 2"
+
 
 def test_write_output_file(temp_dir):
     """Test writing content to a file."""
     output_file = temp_dir / "output.txt"
     results = ["Line 1", "Line 2", "Line 3"]
     write_output_file(output_file, results)
-    
+
     content = output_file.read_text(encoding="utf-8")
     assert content.strip() == "\n".join(results)
+
 
 def test_handle_empty_document(empty_file, temp_dir):
     """Test handling empty document by copying it."""
@@ -55,15 +67,17 @@ def test_handle_empty_document(empty_file, temp_dir):
     assert output_file.exists()
     assert output_file.stat().st_size == 0
 
+
 def test_get_unique_id(temp_dir):
     """Test generating unique ID for a file path."""
     file_path = temp_dir / "dir" / "file.txt"
     file_path.parent.mkdir(parents=True)
     file_path.touch()
-    
+
     unique_id = get_unique_id(file_path, temp_dir)
     assert isinstance(unique_id, str)
     assert len(unique_id) > 0
+
 
 def test_get_filename_and_extension():
     """Test extracting filename and extension."""
@@ -73,10 +87,11 @@ def test_get_filename_and_extension():
         ("file", ("file", "")),
         (".gitignore", (".gitignore", "")),
     ]
-    
+
     for input_path, expected in test_cases:
         filename, ext = get_filename_and_extension(input_path)
         assert (filename, ext) == expected
+
 
 def test_filter_files(temp_dir):
     """Test filtering files in a directory."""
@@ -86,54 +101,58 @@ def test_filter_files(temp_dir):
     (temp_dir / "file1.txt").touch()
     (temp_dir / "file2.txt").touch()
     (temp_dir / "dir1/file3.txt").touch()
-    
+
     excluded_dirs = {"dir1"}
     files = filter_files(temp_dir, excluded_dirs)
-    
+
     assert len(files) == 2
     assert all(f.name.endswith(".txt") for f in files)
     assert not any("dir1" in str(f) for f in files)
+
 
 def test_generate_translated_filename(temp_dir):
     """Test generating translated filename."""
     file_path = temp_dir / "dir" / "file.txt"
     file_path.parent.mkdir(parents=True)
     file_path.touch()
-    
+
     language_code = "ko"
     filename = generate_translated_filename(file_path, language_code, temp_dir)
     assert language_code in filename
     assert filename.endswith(".txt")
+
 
 def test_get_actual_image_path(temp_dir):
     """Test resolving actual image path."""
     md_file = temp_dir / "doc/readme.md"
     md_file.parent.mkdir(parents=True)
     md_file.touch()
-    
+
     image_path = "../images/test.png"
     actual_path = get_actual_image_path(image_path, md_file)
-    
+
     assert isinstance(actual_path, Path)
     assert str(actual_path).endswith("test.png")
+
 
 def test_reset_translation_directories(temp_dir):
     """Test resetting translation directories."""
     translations_dir = temp_dir / "translations"
     image_dir = temp_dir / "images"
     language_codes = ["ko", "en"]
-    
+
     # Create existing directories with content
     translations_dir.mkdir()
     image_dir.mkdir()
     (translations_dir / "old.txt").touch()
-    
+
     reset_translation_directories(translations_dir, image_dir, language_codes)
-    
+
     assert translations_dir.exists()
     assert image_dir.exists()
     assert not (translations_dir / "old.txt").exists()
     assert all((translations_dir / code).exists() for code in language_codes)
+
 
 def test_delete_translated_markdown_files(temp_dir):
     """Test deleting translated markdown files."""
@@ -141,9 +160,10 @@ def test_delete_translated_markdown_files(temp_dir):
     ko_dir = translations_dir / "ko"
     ko_dir.mkdir(parents=True)
     (ko_dir / "test.md").touch()
-    
+
     delete_translated_markdown_files_by_language_code("ko", translations_dir)
     assert not ko_dir.exists()
+
 
 def test_delete_translated_images(temp_dir):
     """Test deleting translated images."""
@@ -151,7 +171,7 @@ def test_delete_translated_images(temp_dir):
     image_dir.mkdir()
     (image_dir / "test.ko.png").touch()
     (image_dir / "test.en.png").touch()
-    
+
     delete_translated_images_by_language_code("ko", image_dir)
     assert not (image_dir / "test.ko.png").exists()
     assert (image_dir / "test.en.png").exists()

--- a/tests/co_op_translator/utils/common/test_task_utils.py
+++ b/tests/co_op_translator/utils/common/test_task_utils.py
@@ -7,68 +7,71 @@ import pytest
 from unittest.mock import AsyncMock, MagicMock
 from co_op_translator.utils.common.task_utils import worker
 
+
 @pytest.mark.asyncio
 async def test_worker_processes_tasks():
     """Test that worker processes tasks from queue."""
     # Create a mock task queue
     task_queue = asyncio.Queue()
-    
+
     # Create async mock tasks
     async def mock_task():
         return True
-    
+
     mock_tasks = [AsyncMock(wraps=mock_task) for _ in range(3)]
     for task in mock_tasks:
         await task_queue.put(task)
     await task_queue.put(None)  # Sentinel to stop the worker
-    
+
     # Create a mock progress bar
     mock_progress = MagicMock()
-    
+
     # Run the worker
     await worker(task_queue, mock_progress)
-    
+
     # Verify all tasks were processed
     assert task_queue.empty()
     for task in mock_tasks:
         task.assert_awaited_once()
 
+
 @pytest.mark.asyncio
 async def test_worker_handles_empty_queue():
     """Test that worker handles empty queue correctly."""
     task_queue = asyncio.Queue()
-    
+
     # Create a valid async task
     async def mock_task():
         return True
-    
+
     mock = AsyncMock(wraps=mock_task)
     await task_queue.put(mock)
     await task_queue.put(None)  # Sentinel to stop the worker
-    
+
     # Run the worker without progress bar
     await worker(task_queue)
-    
+
     # Verify the queue is empty and task was called
     assert task_queue.empty()
     mock.assert_awaited_once()
+
 
 @pytest.mark.asyncio
 async def test_worker_handles_task_error():
     """Test that worker handles task errors gracefully."""
     task_queue = asyncio.Queue()
-    
+
     # Create a mock task that raises an exception
     async def failing_task():
         raise ValueError("Task failed")
-    
+
     mock = AsyncMock(wraps=failing_task)
     await task_queue.put(mock)
     await task_queue.put(None)  # Sentinel to stop the worker
-    
+
     # Run the worker
     await worker(task_queue)
-    
+
     # Verify the queue is empty despite the error
     assert task_queue.empty()
     mock.assert_awaited_once()

--- a/tests/co_op_translator/utils/llm/test_markdown_utils.py
+++ b/tests/co_op_translator/utils/llm/test_markdown_utils.py
@@ -5,11 +5,16 @@ Test cases for markdown utility functions.
 import pytest
 from pathlib import Path
 from co_op_translator.utils.llm.markdown_utils import (
-    update_links, update_image_links, update_file_links,
-    process_markdown, process_markdown_with_many_links,
-    generate_prompt_template, count_links_in_markdown,
-    split_markdown_content
+    update_links,
+    update_image_links,
+    update_file_links,
+    process_markdown,
+    process_markdown_with_many_links,
+    generate_prompt_template,
+    count_links_in_markdown,
+    split_markdown_content,
 )
+
 
 @pytest.fixture
 def sample_markdown():
@@ -19,6 +24,7 @@ This is a test document with [a link](test.md) and ![an image](test.png).
 Here's another [link](docs/example.md) and ![image](images/test.jpg).
 """
 
+
 @pytest.fixture
 def temp_dir(tmp_path):
     """Create a temporary directory structure for testing."""
@@ -27,98 +33,107 @@ def temp_dir(tmp_path):
     (tmp_path / "translations/ko").mkdir()
     (tmp_path / "images").mkdir()
     (tmp_path / "translated_images").mkdir()
-    
+
     # Create test files
     (tmp_path / "test.md").touch()
     (tmp_path / "test.png").touch()
     (tmp_path / "images/test.jpg").touch()
-    
+
     return tmp_path
+
 
 def test_update_links(temp_dir, sample_markdown):
     """Test updating all links in markdown content."""
     md_file_path = temp_dir / "test.md"
     translations_dir = temp_dir / "translations"
     translated_images_dir = temp_dir / "translated_images"
-    
+
     result = update_links(
-        md_file_path, sample_markdown, "ko",
-        temp_dir, markdown_only=False
+        md_file_path, sample_markdown, "ko", temp_dir, markdown_only=False
     )
-    
+
     assert "ko" in result
     assert "translations/ko" in result or "translated_images" in result
+
 
 def test_update_image_links(temp_dir, sample_markdown):
     """Test updating image links in markdown content."""
     md_file_path = temp_dir / "test.md"
     translations_dir = temp_dir / "translations"
     translated_images_dir = temp_dir / "images"
-    
+
     result = update_image_links(
-        sample_markdown, md_file_path, "ko",
-        translations_dir, translated_images_dir, temp_dir
+        sample_markdown,
+        md_file_path,
+        "ko",
+        translations_dir,
+        translated_images_dir,
+        temp_dir,
     )
-    
+
     assert "ko" in result
     assert ".png" in result
     assert "test.png" not in result  # Original image links should be updated
+
 
 def test_update_file_links(temp_dir, sample_markdown):
     """Test updating file links in markdown content."""
     # Create necessary directories and files
     md_file_path = temp_dir / "test.md"
     md_file_path.touch()
-    
+
     translations_dir = temp_dir / "translations"
     translations_dir.mkdir(exist_ok=True)
     ko_dir = translations_dir / "ko"
     ko_dir.mkdir(exist_ok=True)
-    
+
     # Create test files
     docs_dir = temp_dir / "docs"
     docs_dir.mkdir(exist_ok=True)
     (docs_dir / "example.txt").touch()  # Non-markdown, non-image file
-    
+
     # Create test markdown with a text file link
     test_markdown = "# Test Document\nHere's a [link to text file](docs/example.txt)"
-    
+
     result = update_file_links(
-        test_markdown, md_file_path, "ko",
-        translations_dir, temp_dir
+        test_markdown, md_file_path, "ko", translations_dir, temp_dir
     )
-    
+
     # Verify that non-markdown, non-image links are updated with correct relative paths
     assert "../../docs/example.txt" in result  # Updated relative path
     assert "[link to text file]" in result  # Link text should remain unchanged
+
 
 def test_process_markdown():
     """Test processing markdown content into chunks."""
     content = "# Test\n" * 100  # Create large content
     chunks = process_markdown(content, max_tokens=100)
-    
+
     assert isinstance(chunks, list)
     assert len(chunks) > 1
     assert all(isinstance(chunk, str) for chunk in chunks)
+
 
 def test_process_markdown_with_many_links():
     """Test processing markdown with many links."""
     content = "[link](test.md)\n" * 10
     max_links = 5
     chunks = process_markdown_with_many_links(content, max_links)
-    
+
     assert isinstance(chunks, list)
     assert len(chunks) > 1
     assert all(count_links_in_markdown(chunk) <= max_links for chunk in chunks)
+
 
 def test_generate_prompt_template():
     """Test generating translation prompt template."""
     document_chunk = "Test content"
     prompt = generate_prompt_template("ko", document_chunk, False)
-    
+
     assert isinstance(prompt, str)
     assert "ko" in prompt
     assert document_chunk in prompt
+
 
 def test_count_links_in_markdown():
     """Test counting links in markdown content."""
@@ -131,6 +146,7 @@ def test_count_links_in_markdown():
     count = count_links_in_markdown(content)
     assert count == 3  # Two links and one image
 
+
 def test_split_markdown_content():
     """Test splitting markdown content into chunks."""
     content = """
@@ -142,14 +158,14 @@ def test_split_markdown_content():
     > blockquote
     Normal text again.
     """
-    
+
     # Create a mock tokenizer
     class MockTokenizer:
         def encode(self, text):
             return [0] * len(text)  # Simulate token count
-    
+
     chunks = split_markdown_content(content, 100, MockTokenizer())
-    
+
     assert isinstance(chunks, list)
     assert len(chunks) > 0
     assert all(isinstance(chunk, str) for chunk in chunks)

--- a/tests/co_op_translator/utils/llm/test_text_utils.py
+++ b/tests/co_op_translator/utils/llm/test_text_utils.py
@@ -6,70 +6,52 @@ import pytest
 from co_op_translator.utils.llm.text_utils import (
     remove_code_backticks,
     extract_yaml_lines,
-    gen_image_translation_prompt
+    gen_image_translation_prompt,
 )
+
 
 def test_remove_code_backticks():
     """Test removing code backticks from messages."""
     test_cases = [
-        (
-            "```python\nprint('hello')\n```",
-            "print('hello')"
-        ),
-        (
-            "```\nplain text\n```",
-            "plain text"
-        ),
-        (
-            "no backticks here",
-            "no backticks here"
-        ),
-        (
-            "```javascript\nconst x = 1;\n```",
-            "const x = 1;"
-        )
+        ("```python\nprint('hello')\n```", "print('hello')"),
+        ("```\nplain text\n```", "plain text"),
+        ("no backticks here", "no backticks here"),
+        ("```javascript\nconst x = 1;\n```", "const x = 1;"),
     ]
-    
+
     for input_text, expected in test_cases:
         result = remove_code_backticks(input_text)
         assert result == expected
+
 
 def test_extract_yaml_lines():
     """Test extracting YAML lines from messages."""
     test_cases = [
         (
             "- text: Hello\n- key: value\n---\nother content",
-            ["text: Hello", "key: value"]
+            ["text: Hello", "key: value"],
         ),
-        (
-            "no yaml content",
-            []
-        ),
-        (
-            "- key1: value1\n- key2: value2",
-            ["key1: value1", "key2: value2"]
-        )
+        ("no yaml content", []),
+        ("- key1: value1\n- key2: value2", ["key1: value1", "key2: value2"]),
     ]
-    
+
     for input_text, expected in test_cases:
         result = extract_yaml_lines(input_text)
         result = [line.strip() for line in result]  # Remove whitespace and newlines
         assert result == expected
 
+
 def test_gen_image_translation_prompt():
     """Test generating image translation prompts."""
-    text_data = [
-        "Line 1",
-        "Line 2",
-        "Line 3"
-    ]
+    text_data = ["Line 1", "Line 2", "Line 3"]
     language = "ko"
-    
+
     prompt = gen_image_translation_prompt(text_data, language)
-    
+
     assert isinstance(prompt, str)
     assert language in prompt
     assert all(line in prompt for line in text_data)
+
 
 def test_gen_image_translation_prompt_empty():
     """Test generating image translation prompt with empty data."""
@@ -77,14 +59,15 @@ def test_gen_image_translation_prompt_empty():
     assert isinstance(prompt, str)
     assert "ko" in prompt
 
+
 def test_gen_image_translation_prompt_special_chars():
     """Test generating image translation prompt with special characters."""
     text_data = [
         "Line with *special* chars",
         "Line with [markdown] syntax",
-        "Line with <html> tags"
+        "Line with <html> tags",
     ]
     prompt = gen_image_translation_prompt(text_data, "ko")
-    
+
     assert isinstance(prompt, str)
     assert all(line in prompt for line in text_data)

--- a/tests/co_op_translator/utils/vision/test_image_utils.py
+++ b/tests/co_op_translator/utils/vision/test_image_utils.py
@@ -12,6 +12,7 @@ from co_op_translator.utils.vision.image_utils import (
     get_image_mode,
 )
 
+
 @pytest.fixture
 def setup_test_environment(tmp_path):
     """
@@ -23,6 +24,7 @@ def setup_test_environment(tmp_path):
     analyzed_images_dir.mkdir()
     return tmp_path
 
+
 def test_get_average_color():
     """
     Test calculating the average color of an image's bounding box area.
@@ -31,6 +33,7 @@ def test_get_average_color():
     bounding_box = [50, 50, 150, 50, 150, 150, 50, 150]
     avg_color = get_average_color(img, bounding_box)
     assert avg_color == (0, 0, 255), f"Expected (0, 0, 255), got {avg_color}"
+
 
 def test_get_text_color():
     """
@@ -45,6 +48,7 @@ def test_get_text_color():
     bg_color = (200, 200, 255)  # Light blue
     text_color = get_text_color(bg_color)
     assert text_color == (0, 0, 0), f"Expected black text for light background"
+
 
 @patch("PIL.ImageFont.truetype")
 @patch("PIL.ImageDraw.Draw")
@@ -64,9 +68,12 @@ def test_draw_text_on_image(mock_image_new, mock_image_draw, mock_truetype):
 
     text_image = draw_text_on_image("Test Text", font_mock, (0, 0, 0))
 
-    mock_image_new.assert_called_once_with('RGBA', (100, 30), (255, 255, 255, 0))
+    mock_image_new.assert_called_once_with("RGBA", (100, 30), (255, 255, 255, 0))
     assert text_image == text_image_mock
-    draw_mock.text.assert_called_once_with((0, 0), "Test Text", font=font_mock, fill=(0, 0, 0))
+    draw_mock.text.assert_called_once_with(
+        (0, 0), "Test Text", font=font_mock, fill=(0, 0, 0)
+    )
+
 
 @patch("PIL.Image.new")
 @patch("PIL.ImageDraw.Draw")
@@ -82,18 +89,19 @@ def test_create_filled_polygon_mask(mock_image_draw, mock_image_new):
 
     mask_image = create_filled_polygon_mask(bounding_box, (200, 200), (255, 0, 0, 255))
 
-    mock_image_new.assert_called_once_with('RGBA', (200, 200), (255, 255, 255, 0))
+    mock_image_new.assert_called_once_with("RGBA", (200, 200), (255, 255, 255, 0))
     assert mask_image == mask_image_mock
     expected_points = [(50, 50), (150, 50), (150, 150), (50, 150)]
     draw_mock.polygon.assert_called_once_with(expected_points, fill=(255, 0, 0, 255))
+
 
 def test_get_image_mode():
     """
     Test determining the appropriate image mode based on the file extension.
     """
-    assert get_image_mode("test.jpg") == 'RGB'
-    assert get_image_mode("test.jpeg") == 'RGB'
-    assert get_image_mode("test.png") == 'RGBA'
-    
+    assert get_image_mode("test.jpg") == "RGB"
+    assert get_image_mode("test.jpeg") == "RGB"
+    assert get_image_mode("test.png") == "RGBA"
+
     with pytest.raises(ValueError):
         get_image_mode("test.bmp")


### PR DESCRIPTION
## Purpose

Add Black code formatter to ensure consistent code style across the project and improve code quality. This change will help maintain a uniform coding style and reduce time spent on code review discussions about formatting.

## Description

This PR introduces Black code formatter configuration and documentation:

1. Added Black configuration to `pyproject.toml` with:
   - Line length set to 88 characters (Black's default)
   - Python 3.10 as target version
   - Support for both `.py` and `.pyi` files

2. Added Black badge to README.md to indicate project's code style
3. Updated CONTRIBUTING.md with detailed code style guidelines including:
   - Black installation instructions (both Poetry and pip)
   - Usage instructions with examples
   - Editor integration recommendations

## Related Issue

N/A

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

This change only affects development tooling and documentation. It does not impact the runtime behavior of the application.

## Type of change

- [ ] Bugfix
- [ ] Feature
- [x] Code style update (e.g., formatting, local variables)
- [x] Refactoring (no functional or API changes)
- [x] Documentation content changes
- [ ] Other... Please describe:

## Checklist

Before submitting your pull request, please confirm the following:

- [x] **I have thoroughly tested my changes**: I have applied Black formatting to the entire codebase and verified that it works correctly.
- [x] **All existing tests pass**: I have run the test suite after applying Black formatting to ensure no tests were broken.
- [ ] **I have added new tests** (if applicable): I have written tests that cover the new functionality introduced by my code changes.
- [x] **I have followed the Co-op Translators coding conventions**: The changes introduce Black as the official code style formatter.
- [x] **I have documented my changes**: Added comprehensive documentation about Black usage in CONTRIBUTING.md.

## Additional context

N/A