### PR TITLE
Build: Improve the translation prompt to fix the issue where Co-op Translator adds unnecessary triple backticks (''') when generating markdown translations and update version to 0.6.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "co_op_translator"
-version = "0.6.4"
+version = "0.6.5"
 description = "Easily automate multilingual translations for your projects with co-op-translator, powered by advanced LLM technology."
 authors = [
     "Minseok Song <skytin1004@gmail.com>",

--- a/src/co_op_translator/utils/llm/markdown_utils.py
+++ b/src/co_op_translator/utils/llm/markdown_utils.py
@@ -36,15 +36,22 @@ def generate_prompt_template(
     """
 
     if len(document_chunk.split("\n")) == 1:
-        prompt = f"Translate the following text to {output_lang}. NEVER ADD ANY EXTRA CONTENT OUTSIDE THE TRANSLATION. TRANSLATE ONLY WHAT IS GIVEN TO YOU.. MAINTAIN MARKDOWN FORMAT\n\n{document_chunk}"
+        prompt = f"Translate the following text to {output_lang}. NEVER ADD ANY EXTRA CONTENT OR TAGS OUTSIDE THE TRANSLATION. DO NOT ADD '''markdown OR ANY OTHER TAGS. TRANSLATE ONLY WHAT IS GIVEN TO YOU. MAINTAIN MARKDOWN FORMAT.\n\n{document_chunk}"
     else:
         prompt = f"""
         Translate the following markdown file to {output_lang}.
-        Make sure the translation does not sound too literal. Make sure you translate comments as well.
-        This file is written in Markdown format. Do not treat this as XML or HTML.
-        Do not translate any [!NOTE], [!WARNING], [!TIP], [!IMPORTANT], or [!CAUTION].
-        Do not translate any entities, such as variable names, function names, class names, or placeholders like @@INLINE_CODE_x@@ or @@CODE_BLOCK_x@@, but keep them in the file.
-        Do not translate any urls or paths, but keep them in the file.
+        IMPORTANT RULES:
+        1. DO NOT add '''markdown or any other tags around the translation
+        2. Make sure the translation does not sound too literal
+        3. Translate comments as well
+        4. This file is written in Markdown format - do not treat it as XML or HTML
+        5. Do not translate:
+           - [!NOTE], [!WARNING], [!TIP], [!IMPORTANT], [!CAUTION]
+           - Variable names, function names, class names
+           - Placeholders like @@INLINE_CODE_x@@ or @@CODE_BLOCK_x@@
+           - URLs or paths
+        6. Keep all original markdown formatting intact
+        7. Return ONLY the translated content without any additional tags or markup
         """
 
     if is_rtl:


### PR DESCRIPTION

## Purpose

<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->

## Description

<!-- Provide a concise summary of your changes. Why is this change necessary? -->

## Related Issue

<!-- If this PR addresses an issue, please link it here (e.g., Fixes #123) -->

Fixed #83 

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

- [ ] Yes
- [x] No

## Type of change

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (e.g., formatting, local variables)
- [ ] Refactoring (no functional or API changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Checklist

Before submitting your pull request, please confirm the following:

- [x] **I have thoroughly tested my changes**: I confirm that I have run the code and manually tested all affected areas.
- [x] **All existing tests pass**: I have run all tests and confirmed that nothing is broken.
- [ ] **I have added new tests** (if applicable): I have written tests that cover the new functionality introduced by my code changes.
- [x] **I have followed the Co-op Translators coding conventions**: My code adheres to the style guide and coding conventions outlined in the repository.
- [ ] **I have documented my changes** (if applicable): I have updated the documentation to reflect the changes where necessary.

## Additional context

<!-- Add any additional context or screenshots if applicable -->
