### PR TITLE
Clarify `pt` Mapping to `pt-PT` and Support Brazilian Portuguese `br` Locale

### DIFF
--- a/getting_started/supported-languages.md
+++ b/getting_started/supported-languages.md
@@ -9,9 +9,9 @@ The table below lists the languages currently supported by **Co-op Translator**.
 | es            | Spanish              | NotoSans-Medium.ttf               | No          | No           |
 | de            | German               | NotoSans-Medium.ttf               | No          | No           |
 | ru            | Russian              | NotoSans-Medium.ttf               | No          | No           |
-| ar            | Arabic               | NotoSansArabic-Medium.ttf         | Yes         | Yes          |
-| fa            | Persian (Farsi)      | NotoSansArabic-Medium.ttf         | Yes         | Yes          |
-| ur            | Urdu                 | NotoSansArabic-Medium.ttf         | Yes         | Yes          |
+| ar            | Arabic               | NotoSansArabic-Medium.ttf         | Yes         | No           |
+| fa            | Persian (Farsi)      | NotoSansArabic-Medium.ttf         | Yes         | No           |
+| ur            | Urdu                 | NotoSansArabic-Medium.ttf         | Yes         | No           |
 | zh            | Chinese (Simplified) | NotoSansCJK-Medium.ttc            | No          | No           |
 | mo            | Chinese (Traditional, Macau) | NotoSansCJK-Medium.ttc    | No          | No           |
 | hk            | Chinese (Traditional, Hong Kong) | NotoSansCJK-Medium.ttc| No          | No           |
@@ -23,7 +23,8 @@ The table below lists the languages currently supported by **Co-op Translator**.
 | mr            | Marathi              | NotoSansDevanagari-Medium.ttf     | No          | No           |
 | ne            | Nepali               | NotoSansDevanagari-Medium.ttf     | No          | No           |
 | pa            | Punjabi (Gurmukhi)   | NotoSansGurmukhi-Medium.ttf       | No          | No           |
-| pt            | Portuguese           | NotoSans-Medium.ttf               | No          | No           |
+| pt            | Portuguese (Portugal)| NotoSans-Medium.ttf               | No          | No           |
+| br            | Portuguese (Brazil)  | NotoSans-Medium.ttf               | No          | No           |
 | it            | Italian              | NotoSans-Medium.ttf               | No          | No           |
 | pl            | Polish               | NotoSans-Medium.ttf               | No          | No           |
 | tr            | Turkish              | NotoSans-Medium.ttf               | No          | No           |

--- a/src/co_op_translator/fonts/font_language_mappings.yml
+++ b/src/co_op_translator/fonts/font_language_mappings.yml
@@ -59,8 +59,13 @@ pa:
   name: "Punjabi (Gurmukhi)"
   font: "NotoSansGurmukhi-Medium.ttf"  
 pt:
-  name: "Portuguese"
+  name: "Portuguese (Portugal)"
   font: "NotoSans-Medium.ttf"
+
+br:
+  name: "Portuguese (Brazil)"
+  font: "NotoSans-Medium.ttf"
+
 it:
   name: "Italian"
   font: "NotoSans-Medium.ttf"


### PR DESCRIPTION
## Purpose

<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
Adds support for Brazilian Portuguese (br) as a distinct locale and clarifies the current behavior of `pt` mapping to Portuguese (Portugal).

## Description

<!-- Provide a concise summary of your changes. Why is this change necessary? -->

## Related Issue

<!-- If this PR addresses an issue, please link it here (e.g., Fixes #123) -->

Fixes #97 

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

- [ ] Yes
- [x] No

## Type of change

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (e.g., formatting, local variables)
- [ ] Refactoring (no functional or API changes)
- [x] Documentation content changes
- [ ] Other... Please describe:

## Checklist

Before submitting your pull request, please confirm the following:

- [ ] **I have thoroughly tested my changes**: I confirm that I have run the code and manually tested all affected areas.
- [ ] **All existing tests pass**: I have run all tests and confirmed that nothing is broken.
- [ ] **I have added new tests** (if applicable): I have written tests that cover the new functionality introduced by my code changes.
- [x] **I have followed the Co-op Translators coding conventions**: My code adheres to the style guide and coding conventions outlined in the repository.
- [x] **I have documented my changes** (if applicable): I have updated the documentation to reflect the changes where necessary.

## Additional context

<!-- Add any additional context or screenshots if applicable -->
