### PR TITLE
Add --yes flag to bypass confirmation prompts in CLI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "co_op_translator"
-version = "0.8.0"
+version = "0.8.1"
 description = "Easily automate multilingual translations for your projects with co-op-translator, powered by advanced LLM technology."
 authors = [
     "Minseok Song <skytin1004@gmail.com>",

--- a/src/co_op_translator/__main__.py
+++ b/src/co_op_translator/__main__.py
@@ -46,7 +46,13 @@ logger = logging.getLogger(__name__)
     is_flag=True,
     help="Use fast mode for image translation (up to 3x faster at a slight cost to quality and alignment).",
 )
-def main(language_codes, root_dir, update, images, markdown, debug, check, fast):
+@click.option(
+    "--yes",
+    "-y",
+    is_flag=True,
+    help="Automatically confirm all prompts (useful for CI/CD pipelines).",
+)
+def main(language_codes, root_dir, update, images, markdown, debug, check, fast, yes):
     """
     CLI for translating project files.
 
@@ -143,16 +149,19 @@ def main(language_codes, root_dir, update, images, markdown, debug, check, fast)
                 "For better efficiency, it's recommended that contributors handle individual languages and upload their translations separately."
             )
             # Option to proceed or not
-            confirmation_all = click.prompt(
-                "Do you still want to proceed with translating all languages? Type 'yes' to continue",
-                type=str,
-            )
+            if not yes:
+                confirmation_all = click.prompt(
+                    "Do you still want to proceed with translating all languages? Type 'yes' to continue",
+                    type=str,
+                )
 
-            if confirmation_all.lower() != "yes":
-                click.echo("Translation for 'all' languages cancelled.")
-                return
+                if confirmation_all.lower() != "yes":
+                    click.echo("Translation for 'all' languages cancelled.")
+                    return
+                else:
+                    click.echo("Proceeding with translation for all languages...")
             else:
-                click.echo("Proceeding with translation for all languages...")
+                click.echo("Auto-confirming translation for all languages...")
 
             try:
                 with importlib.resources.path(
@@ -184,15 +193,18 @@ def main(language_codes, root_dir, update, images, markdown, debug, check, fast)
             click.echo(
                 f"Warning: The update command will delete all existing translations for '{language_codes}' and re-translate everything."
             )
-            confirmation_update = click.prompt(
-                "Do you want to continue? Type 'yes' to proceed", type=str
-            )
+            if not yes:
+                confirmation_update = click.prompt(
+                    "Do you want to continue? Type 'yes' to proceed", type=str
+                )
 
-            if confirmation_update.lower() != "yes":
-                click.echo("Update cancelled by user.")
-                return
+                if confirmation_update.lower() != "yes":
+                    click.echo("Update cancelled by user.")
+                    return
+                else:
+                    click.echo("Proceeding with update...")
             else:
-                click.echo("Proceeding with update...")
+                click.echo("Auto-confirming update operation...")
 
         # Initialize ProjectTranslator with determined settings
         translator = ProjectTranslator(


### PR DESCRIPTION
## Purpose

<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
This PR adds a --yes flag to the CLI tool to bypass confirmation prompts, making it suitable for use in CI/CD environments like GitHub Actions where interactive prompts cannot be answered.

## Description

<!-- Provide a concise summary of your changes. Why is this change necessary? -->

The current implementation requires manual confirmation when using the --update option or when translating all languages. This creates issues in automated environments like GitHub Actions where the process hangs waiting for user input.

This PR adds a new --yes (-y) flag that automatically confirms these prompts, allowing the tool to run non-interactively in CI/CD pipelines.

## Related Issue

<!-- If this PR addresses an issue, please link it here (e.g., Fixes #123) -->

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

- [ ] Yes
- [x] No

## Type of change

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (e.g., formatting, local variables)
- [ ] Refactoring (no functional or API changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Checklist

Before submitting your pull request, please confirm the following:

- [ ] **I have thoroughly tested my changes**: I confirm that I have run the code and manually tested all affected areas.
- [ ] **All existing tests pass**: I have run all tests and confirmed that nothing is broken.
- [ ] **I have added new tests** (if applicable): I have written tests that cover the new functionality introduced by my code changes.
- [x] **I have followed the Co-op Translators coding conventions**: My code adheres to the style guide and coding conventions outlined in the repository.
- [ ] **I have documented my changes** (if applicable): I have updated the documentation to reflect the changes where necessary.

## Additional context

<!-- Add any additional context or screenshots if applicable -->
