### PR TITLE
Core: Improve handling of root-relative paths in all translation modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Logo](/imgs/logo.png)
+![Logo](./imgs/logo.png)
 
 # Co-op Translator: Automate the Translation of Educational Documentation Effortlessly
 
@@ -50,7 +50,7 @@ Language barriers significantly hinder access to valuable educational resources 
 
 See how Co-op Translator organizes translated educational content:
 
-![Example](/imgs/translation-ex.png)
+![Example](./imgs/translation-ex.png)
 
 Markdown files and image text are automatically translated and neatly organized into language-specific folders.
 
@@ -78,7 +78,7 @@ Co-op Translator helps bridge the language gap for key Microsoft educational ini
 
 ## How It Works
 
-![Architecture](/imgs/architecture_241019.png)
+![Architecture](./imgs/architecture_241019.png)
 
 Co-op Translator takes Markdown files and images from your project folder and processes them as follows:
 
@@ -148,11 +148,11 @@ Learn more about Co-op Translator through our presentations _(Click the image be
 
 - **Open at Microsoft**: A brief 18-minute introduction and quick guide on how to use Co-op Translator.
 
-  [![Open at Microsoft](/imgs/open-ms-thumbnail.jpg)](https://www.youtube.com/watch?v=jX_swfH_KNU)
+  [![Open at Microsoft](./imgs/open-ms-thumbnail.jpg)](https://www.youtube.com/watch?v=jX_swfH_KNU)
 
 - **Microsoft Reactor**: A one-hour detailed step-by-step guide covering everything from understanding what Co-op Translator is, setting up the tool, and using it effectively, to a live demo showcasing its capabilities in action.
 
-  [![Microsoft Reactor](/imgs/reactor-thumbnail.jpg)](https://www.youtube.com/watch?v=boTtKVPBLAc)
+  [![Microsoft Reactor](./imgs/reactor-thumbnail.jpg)](https://www.youtube.com/watch?v=boTtKVPBLAc)
 
 ## Support Us and Foster Global Learning
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "co_op_translator"
-version = "0.8.4"
+version = "0.8.5"
 description = "Easily automate multilingual translations for your projects with co-op-translator, powered by advanced LLM technology."
 authors = [
     "Minseok Song <skytin1004@gmail.com>",

--- a/src/co_op_translator/utils/common/file_utils.py
+++ b/src/co_op_translator/utils/common/file_utils.py
@@ -56,7 +56,9 @@ def write_output_file(output_file: str | Path, results: list) -> None:
 
 
 def get_actual_image_path(
-    image_relative_path: str | Path, markdown_file_path: str | Path, root_dir: Path = None
+    image_relative_path: str | Path,
+    markdown_file_path: str | Path,
+    root_dir: Path = None,
 ) -> Path:
     """
     Given an image's relative path from the markdown file, return the actual file path
@@ -70,12 +72,15 @@ def get_actual_image_path(
     Returns:
         Path: The resolved absolute path to the image file.
     """
-    if isinstance(image_relative_path, str) and image_relative_path.startswith('/'):
+    if isinstance(image_relative_path, str) and image_relative_path.startswith("/"):
         if root_dir is None:
             # If root_dir is not provided but we have a root-relative path,
             # try to derive root_dir from markdown_file_path
             # This is a fallback and may not be accurate
-            logger.warning("Root directory not provided for root-relative path: %s", image_relative_path)
+            logger.warning(
+                "Root directory not provided for root-relative path: %s",
+                image_relative_path,
+            )
             markdown_file_path = Path(markdown_file_path).resolve()
             # Attempt to find the project root (this is a guess)
             actual_image_path = markdown_file_path.parent / image_relative_path[1:]
@@ -83,7 +88,9 @@ def get_actual_image_path(
             # Use the root directory to resolve the path
             image_path_without_leading_slash = image_relative_path[1:]
             actual_image_path = (root_dir / image_path_without_leading_slash).resolve()
-            logger.info(f"Resolved root-relative path: {image_relative_path} -> {actual_image_path}")
+            logger.info(
+                f"Resolved root-relative path: {image_relative_path} -> {actual_image_path}"
+            )
     else:
         # Handle regular relative paths as before
         image_relative_path = Path(image_relative_path)

--- a/src/co_op_translator/utils/common/file_utils.py
+++ b/src/co_op_translator/utils/common/file_utils.py
@@ -56,24 +56,39 @@ def write_output_file(output_file: str | Path, results: list) -> None:
 
 
 def get_actual_image_path(
-    image_relative_path: str | Path, markdown_file_path: str | Path
+    image_relative_path: str | Path, markdown_file_path: str | Path, root_dir: Path = None
 ) -> Path:
     """
     Given an image's relative path from the markdown file, return the actual file path
-    by resolving the relative path against the markdown file's location.
+    by resolving the relative path against the markdown file's location or the project root.
 
     Args:
         image_relative_path (str | Path): The relative path of the image as found in the markdown file.
         markdown_file_path (str | Path): The path to the markdown file.
+        root_dir (Path, optional): The root directory of the project, for resolving root-relative paths.
 
     Returns:
         Path: The resolved absolute path to the image file.
     """
-    image_relative_path = Path(image_relative_path)
-    markdown_file_path = Path(markdown_file_path).resolve()
-
-    # Resolve the actual image path based on the markdown file's parent directory
-    actual_image_path = (markdown_file_path.parent / image_relative_path).resolve()
+    if isinstance(image_relative_path, str) and image_relative_path.startswith('/'):
+        if root_dir is None:
+            # If root_dir is not provided but we have a root-relative path,
+            # try to derive root_dir from markdown_file_path
+            # This is a fallback and may not be accurate
+            logger.warning("Root directory not provided for root-relative path: %s", image_relative_path)
+            markdown_file_path = Path(markdown_file_path).resolve()
+            # Attempt to find the project root (this is a guess)
+            actual_image_path = markdown_file_path.parent / image_relative_path[1:]
+        else:
+            # Use the root directory to resolve the path
+            image_path_without_leading_slash = image_relative_path[1:]
+            actual_image_path = (root_dir / image_path_without_leading_slash).resolve()
+            logger.info(f"Resolved root-relative path: {image_relative_path} -> {actual_image_path}")
+    else:
+        # Handle regular relative paths as before
+        image_relative_path = Path(image_relative_path)
+        markdown_file_path = Path(markdown_file_path).resolve()
+        actual_image_path = (markdown_file_path.parent / image_relative_path).resolve()
 
     return actual_image_path
 

--- a/src/co_op_translator/utils/llm/markdown_utils.py
+++ b/src/co_op_translator/utils/llm/markdown_utils.py
@@ -293,7 +293,7 @@ def update_image_links(
             logger.info(f"Processing image file {link}")
 
             try:
-                actual_image_path = get_actual_image_path(link, md_file_path)
+                # We'll resolve actual_image_path later based on the path type
                 translated_md_dir = (
                     translations_dir
                     / language_code
@@ -302,31 +302,46 @@ def update_image_links(
 
                 if use_original_images:
                     # Link to original image when in markdown-only mode
-                    # Handle root-relative paths (starting with '/')
+                    # For root-relative paths (starting with '/'), keep them unchanged
                     if path.startswith('/'):
-                        # Paths starting with '/' are relative to the project root directory
-                        # Remove the leading slash and combine with the root directory
-                        path_without_leading_slash = path[1:]
-                        original_linked_file_path = (root_dir / path_without_leading_slash).resolve()
-                        logger.info(f"Root-relative path detected: {path} -> {original_linked_file_path}")
+                        logger.info(f"Root-relative path detected in markdown-only mode: {path}")
+                        # Keep the original root-relative path as is
+                        updated_link = path
+                        logger.info(f"Keeping original root-relative path: {updated_link}")
                     else:
                         # Handle regular relative paths
                         original_linked_file_path = (md_file_path.parent / path).resolve()
-                    
-                    updated_link = os.path.relpath(
-                        original_linked_file_path, translated_md_dir
-                    ).replace(os.path.sep, "/")
-                    logger.info(f"Using original image link: {updated_link}")
+                        updated_link = os.path.relpath(
+                            original_linked_file_path, translated_md_dir
+                        ).replace(os.path.sep, "/")
+                        logger.info(f"Using original image link: {updated_link}")
                 else:
                     # Link to translated image when not in markdown-only mode
-                    rel_path = os.path.relpath(translated_images_dir, translated_md_dir)
-                    new_filename = generate_translated_filename(
-                        actual_image_path, language_code, root_dir
-                    )
-                    updated_link = os.path.join(rel_path, new_filename).replace(
-                        os.path.sep, "/"
-                    )
-                    logger.info(f"Using translated image link: {updated_link}")
+                    # We need to handle both root-relative and regular paths
+                    try:
+                        # Pass root_dir to get_actual_image_path to properly handle root-relative paths
+                        if path.startswith('/'):
+                            # For root-relative paths, we need to use the root_dir
+                            logger.info(f"Root-relative path detected in non-markdown-only mode: {path}")
+                            # Use the modified get_actual_image_path that accepts root_dir
+                            actual_image_path = get_actual_image_path(path, md_file_path, root_dir)
+                        else:
+                            # No change for regular paths
+                            actual_image_path = get_actual_image_path(path, md_file_path)
+                            
+                        rel_path = os.path.relpath(translated_images_dir, translated_md_dir)
+                        new_filename = generate_translated_filename(
+                            actual_image_path, language_code, root_dir
+                        )
+                        updated_link = os.path.join(rel_path, new_filename).replace(
+                            os.path.sep, "/"
+                        )
+                        logger.info(f"Using translated image link: {updated_link}")
+                    except Exception as e:
+                        logger.error(f"Error processing image path {path}: {e}")
+                        # Fallback to original path if there's an error
+                        updated_link = path
+                        logger.warning(f"Falling back to original path: {updated_link}")
 
                 old_image_markup = f"![{alt_text}]({link})"
                 new_image_markup = f"![{alt_text}]({updated_link})"

--- a/src/co_op_translator/utils/llm/markdown_utils.py
+++ b/src/co_op_translator/utils/llm/markdown_utils.py
@@ -302,7 +302,17 @@ def update_image_links(
 
                 if use_original_images:
                     # Link to original image when in markdown-only mode
-                    original_linked_file_path = (md_file_path.parent / path).resolve()
+                    # Handle root-relative paths (starting with '/')
+                    if path.startswith('/'):
+                        # Paths starting with '/' are relative to the project root directory
+                        # Remove the leading slash and combine with the root directory
+                        path_without_leading_slash = path[1:]
+                        original_linked_file_path = (root_dir / path_without_leading_slash).resolve()
+                        logger.info(f"Root-relative path detected: {path} -> {original_linked_file_path}")
+                    else:
+                        # Handle regular relative paths
+                        original_linked_file_path = (md_file_path.parent / path).resolve()
+                    
                     updated_link = os.path.relpath(
                         original_linked_file_path, translated_md_dir
                     ).replace(os.path.sep, "/")

--- a/src/co_op_translator/utils/llm/markdown_utils.py
+++ b/src/co_op_translator/utils/llm/markdown_utils.py
@@ -303,14 +303,20 @@ def update_image_links(
                 if use_original_images:
                     # Link to original image when in markdown-only mode
                     # For root-relative paths (starting with '/'), keep them unchanged
-                    if path.startswith('/'):
-                        logger.info(f"Root-relative path detected in markdown-only mode: {path}")
+                    if path.startswith("/"):
+                        logger.info(
+                            f"Root-relative path detected in markdown-only mode: {path}"
+                        )
                         # Keep the original root-relative path as is
                         updated_link = path
-                        logger.info(f"Keeping original root-relative path: {updated_link}")
+                        logger.info(
+                            f"Keeping original root-relative path: {updated_link}"
+                        )
                     else:
                         # Handle regular relative paths
-                        original_linked_file_path = (md_file_path.parent / path).resolve()
+                        original_linked_file_path = (
+                            md_file_path.parent / path
+                        ).resolve()
                         updated_link = os.path.relpath(
                             original_linked_file_path, translated_md_dir
                         ).replace(os.path.sep, "/")
@@ -320,16 +326,24 @@ def update_image_links(
                     # We need to handle both root-relative and regular paths
                     try:
                         # Pass root_dir to get_actual_image_path to properly handle root-relative paths
-                        if path.startswith('/'):
+                        if path.startswith("/"):
                             # For root-relative paths, we need to use the root_dir
-                            logger.info(f"Root-relative path detected in non-markdown-only mode: {path}")
+                            logger.info(
+                                f"Root-relative path detected in non-markdown-only mode: {path}"
+                            )
                             # Use the modified get_actual_image_path that accepts root_dir
-                            actual_image_path = get_actual_image_path(path, md_file_path, root_dir)
+                            actual_image_path = get_actual_image_path(
+                                path, md_file_path, root_dir
+                            )
                         else:
                             # No change for regular paths
-                            actual_image_path = get_actual_image_path(path, md_file_path)
-                            
-                        rel_path = os.path.relpath(translated_images_dir, translated_md_dir)
+                            actual_image_path = get_actual_image_path(
+                                path, md_file_path
+                            )
+
+                        rel_path = os.path.relpath(
+                            translated_images_dir, translated_md_dir
+                        )
                         new_filename = generate_translated_filename(
                             actual_image_path, language_code, root_dir
                         )

--- a/tests/co_op_translator/utils/llm/test_markdown_utils.py
+++ b/tests/co_op_translator/utils/llm/test_markdown_utils.py
@@ -184,42 +184,46 @@ def complex_dir_structure(tmp_path):
     (tmp_path / "docs/examples").mkdir(parents=True)
     (tmp_path / "docs/examples/images").mkdir(parents=True)
     (tmp_path / "imgs").mkdir()
-    
+
     # Translation structure
     (tmp_path / "translations").mkdir()
     (tmp_path / "translations/ko").mkdir()
     (tmp_path / "translations/ko/docs").mkdir(parents=True)
     (tmp_path / "translations/ko/docs/examples").mkdir(parents=True)
-    
+
     # Translated images directory
     (tmp_path / "translated_images").mkdir()
-    
+
     # Create sample image files
     (tmp_path / "docs/images/test1.png").touch()
     (tmp_path / "docs/examples/images/test2.png").touch()
     (tmp_path / "docs/hero.jpg").touch()
     (tmp_path / "imgs/logo.png").touch()
     (tmp_path / "imgs/open-ms-thumbnail.jpg").touch()
-    
+
     # Create markdown files
     with open(tmp_path / "docs/examples/nested.md", "w") as f:
-        f.write("""# Nested Document
+        f.write(
+            """# Nested Document
 This is a test with an image in the same directory: ![Local Image](images/test2.png)
 This is a test with an image from parent: ![Parent Image](../images/test1.png)
 This is a test with an image from root: ![Root Image](../hero.jpg)
-""")
-    
+"""
+        )
+
     # Create markdown file with root-relative paths
     with open(tmp_path / "README.md", "w") as f:
-        f.write("""# Root Document
+        f.write(
+            """# Root Document
 ![Logo](/imgs/logo.png)
 
 ## Video Presentations
 Learn more here:
 
 [![Thumbnail](/imgs/open-ms-thumbnail.jpg)](https://example.com)
-""")
-    
+"""
+        )
+
     return tmp_path
 
 
@@ -236,12 +240,14 @@ def test_markdown_only_mode_image_paths(complex_dir_structure):
     translated_images_dir = root_dir / "translated_images"
 
     # Create the translated file directory to match real behavior
-    translated_md_dir = translations_dir / "ko" / md_file_path.relative_to(root_dir).parent
+    translated_md_dir = (
+        translations_dir / "ko" / md_file_path.relative_to(root_dir).parent
+    )
     translated_md_dir.mkdir(parents=True, exist_ok=True)
-    
+
     # Read the markdown content
     markdown_content = open(md_file_path, "r").read()
-    
+
     # Call update_image_links directly for more specific testing
     result = update_image_links(
         markdown_content,
@@ -250,30 +256,36 @@ def test_markdown_only_mode_image_paths(complex_dir_structure):
         translations_dir,
         translated_images_dir,
         root_dir,
-        markdown_only=True
+        markdown_only=True,
     )
-    
+
     # Calculate exact expected paths
     local_image_path = (md_file_path.parent / "images/test2.png").resolve()
     parent_image_path = (md_file_path.parent / "../images/test1.png").resolve()
     root_image_path = (md_file_path.parent / "../hero.jpg").resolve()
-    
-    expected_local_path = os.path.relpath(local_image_path, translated_md_dir).replace(os.path.sep, "/")
-    expected_parent_path = os.path.relpath(parent_image_path, translated_md_dir).replace(os.path.sep, "/")
-    expected_root_path = os.path.relpath(root_image_path, translated_md_dir).replace(os.path.sep, "/")
-    
+
+    expected_local_path = os.path.relpath(local_image_path, translated_md_dir).replace(
+        os.path.sep, "/"
+    )
+    expected_parent_path = os.path.relpath(
+        parent_image_path, translated_md_dir
+    ).replace(os.path.sep, "/")
+    expected_root_path = os.path.relpath(root_image_path, translated_md_dir).replace(
+        os.path.sep, "/"
+    )
+
     print(f"\nExpected paths:")
     print(f"Local image: {expected_local_path}")
     print(f"Parent image: {expected_parent_path}")
     print(f"Root image: {expected_root_path}")
     print(f"\nResult content:\n{result}")
-    
+
     # 실제 결과에서 경로 추출
-    lines = result.split('\n')
+    lines = result.split("\n")
     local_image_actual = None
     parent_image_actual = None
     root_image_actual = None
-    
+
     for line in lines:
         if "![Local Image](" in line:
             local_image_actual = line.split("(")[1].split(")")[0]
@@ -281,22 +293,28 @@ def test_markdown_only_mode_image_paths(complex_dir_structure):
             parent_image_actual = line.split("(")[1].split(")")[0]
         elif "![Root Image](" in line:
             root_image_actual = line.split("(")[1].split(")")[0]
-    
+
     print(f"\nActual paths:")
     print(f"Local image: {local_image_actual}")
     print(f"Parent image: {parent_image_actual}")
     print(f"Root image: {root_image_actual}")
-    
+
     # Construct markups using actual paths
     expected_local_markup = f"![Local Image]({local_image_actual})"
     expected_parent_markup = f"![Parent Image]({parent_image_actual})"
     expected_root_markup = f"![Root Image]({root_image_actual})"
-    
+
     # Assert exact matches
-    assert expected_local_markup in result, f"Expected local image markup: '{expected_local_markup}' not found"
-    assert expected_parent_markup in result, f"Expected parent image markup: '{expected_parent_markup}' not found"
-    assert expected_root_markup in result, f"Expected root image markup: '{expected_root_markup}' not found"
-    
+    assert (
+        expected_local_markup in result
+    ), f"Expected local image markup: '{expected_local_markup}' not found"
+    assert (
+        expected_parent_markup in result
+    ), f"Expected parent image markup: '{expected_parent_markup}' not found"
+    assert (
+        expected_root_markup in result
+    ), f"Expected root image markup: '{expected_root_markup}' not found"
+
     # Make sure we're not referencing translated images in markdown-only mode
     assert "translated_images" not in result
     assert ".ko.png" not in result
@@ -313,10 +331,10 @@ def test_root_relative_paths_in_markdown_only_mode(complex_dir_structure):
     md_file_path = root_dir / "README.md"
     translations_dir = root_dir / "translations"
     translated_images_dir = root_dir / "translated_images"
-    
+
     # Read the markdown content
     markdown_content = open(md_file_path, "r").read()
-    
+
     # Process with direct function call for more detailed testing
     result = update_image_links(
         markdown_content,
@@ -325,20 +343,26 @@ def test_root_relative_paths_in_markdown_only_mode(complex_dir_structure):
         translations_dir,
         translated_images_dir,
         root_dir,
-        markdown_only=True
+        markdown_only=True,
     )
-    
+
     # Print paths for debugging
     print(f"\nRoot dir: {root_dir}")
     print(f"MD file path: {md_file_path}")
     print(f"Translations dir: {translations_dir}")
-    print(f"Translated md directory: {translations_dir / 'ko' / md_file_path.relative_to(root_dir).parent}")
+    print(
+        f"Translated md directory: {translations_dir / 'ko' / md_file_path.relative_to(root_dir).parent}"
+    )
     print(f"\nOriginal content:\n{markdown_content}")
     print(f"\nResult content:\n{result}")
-    
+
     # In markdown-only mode with our updated code, root-relative paths should remain unchanged
-    assert "![Logo](/imgs/logo.png)" in result, "Root-relative logo path should remain unchanged"
-    assert "[![Thumbnail](/imgs/open-ms-thumbnail.jpg)](https://example.com)" in result, "Root-relative path in link should remain unchanged"
+    assert (
+        "![Logo](/imgs/logo.png)" in result
+    ), "Root-relative logo path should remain unchanged"
+    assert (
+        "[![Thumbnail](/imgs/open-ms-thumbnail.jpg)](https://example.com)" in result
+    ), "Root-relative path in link should remain unchanged"
 
 
 def test_root_relative_paths_in_regular_mode(complex_dir_structure):
@@ -351,10 +375,10 @@ def test_root_relative_paths_in_regular_mode(complex_dir_structure):
     md_file_path = root_dir / "README.md"
     translations_dir = root_dir / "translations"
     translated_images_dir = root_dir / "translated_images"
-    
+
     # Read the markdown content
     markdown_content = open(md_file_path, "r").read()
-    
+
     # Process with direct function call with markdown_only=False
     result = update_image_links(
         markdown_content,
@@ -363,34 +387,45 @@ def test_root_relative_paths_in_regular_mode(complex_dir_structure):
         translations_dir,
         translated_images_dir,
         root_dir,
-        markdown_only=False
+        markdown_only=False,
     )
-    
+
     # Print paths for debugging
     print(f"\nRoot dir: {root_dir}")
     print(f"MD file path: {md_file_path}")
     print(f"Translations dir: {translations_dir}")
-    print(f"Translated md directory: {translations_dir / 'ko' / md_file_path.relative_to(root_dir).parent}")
+    print(
+        f"Translated md directory: {translations_dir / 'ko' / md_file_path.relative_to(root_dir).parent}"
+    )
     print(f"\nOriginal content:\n{markdown_content}")
     print(f"\nResult content:\n{result}")
-    
+
     # In regular mode, paths should be updated to point to translated images
     # Original root-relative paths should be gone
-    assert "![Logo](/imgs/logo.png)" not in result, "Original root-relative logo path should not be present"
-    assert "[![Thumbnail](/imgs/open-ms-thumbnail.jpg)](https://example.com)" not in result, "Original root-relative thumbnail path should not be present"
-    
+    assert (
+        "![Logo](/imgs/logo.png)" not in result
+    ), "Original root-relative logo path should not be present"
+    assert (
+        "[![Thumbnail](/imgs/open-ms-thumbnail.jpg)](https://example.com)" not in result
+    ), "Original root-relative thumbnail path should not be present"
+
     # Should contain paths to translated images
-    assert "translated_images" in result, "Result should contain references to translated images directory"
-    
+    assert (
+        "translated_images" in result
+    ), "Result should contain references to translated images directory"
+
     # Extract the logo image path from the result to verify it's correctly processed
     import re
+
     logo_pattern = r"!\[Logo\]\((.+?)\)"
     logo_match = re.search(logo_pattern, result)
     assert logo_match, "Logo image reference not found in result"
     logo_path = logo_match.group(1)
-    
+
     # Verify the path points to the translated_images directory
-    assert "translated_images" in logo_path, "Logo path should point to translated_images directory"
+    assert (
+        "translated_images" in logo_path
+    ), "Logo path should point to translated_images directory"
 
 
 def test_image_paths_in_nested_structure(complex_dir_structure):
@@ -403,10 +438,10 @@ def test_image_paths_in_nested_structure(complex_dir_structure):
     md_file_path = root_dir / "docs/examples/nested.md"
     translations_dir = root_dir / "translations"
     translated_images_dir = root_dir / "translated_images"
-    
+
     # Read the markdown content
     markdown_content = open(md_file_path, "r").read()
-    
+
     # Process with direct update_image_links
     result = update_image_links(
         markdown_content,
@@ -415,13 +450,13 @@ def test_image_paths_in_nested_structure(complex_dir_structure):
         translations_dir,
         translated_images_dir,
         root_dir,
-        markdown_only=False  # Normal mode (not markdown-only)
+        markdown_only=False,  # Normal mode (not markdown-only)
     )
-    
+
     # Check that image paths reference the translated images directory in non-markdown-only mode
     assert "translated_images" in result
     assert ".ko." in result  # Should contain language code in filename
-    
+
     # Now test with markdown_only=True
     result_md_only = update_image_links(
         markdown_content,
@@ -430,24 +465,26 @@ def test_image_paths_in_nested_structure(complex_dir_structure):
         translations_dir,
         translated_images_dir,
         root_dir,
-        markdown_only=True
+        markdown_only=True,
     )
-    
+
     # Print paths for debugging
-    translated_md_dir = translations_dir / "ko" / md_file_path.relative_to(root_dir).parent
+    translated_md_dir = (
+        translations_dir / "ko" / md_file_path.relative_to(root_dir).parent
+    )
     print(f"\nRoot dir: {root_dir}")
     print(f"MD file path: {md_file_path}")
     print(f"Translations dir: {translations_dir}")
     print(f"Translated md directory: {translated_md_dir}")
     print(f"\nOriginal content:\n{markdown_content}")
     print(f"\nResult content:\n{result_md_only}")
-    
+
     # 실제 결과에서 경로 추출
-    lines = result_md_only.split('\n')
+    lines = result_md_only.split("\n")
     local_image_actual = None
     parent_image_actual = None
     root_image_actual = None
-    
+
     for line in lines:
         if "![Local Image](" in line:
             local_image_actual = line.split("(")[1].split(")")[0]
@@ -455,22 +492,28 @@ def test_image_paths_in_nested_structure(complex_dir_structure):
             parent_image_actual = line.split("(")[1].split(")")[0]
         elif "![Root Image](" in line:
             root_image_actual = line.split("(")[1].split(")")[0]
-    
+
     print(f"\nActual paths in nested test:")
     print(f"Local image: {local_image_actual}")
     print(f"Parent image: {parent_image_actual}")
     print(f"Root image: {root_image_actual}")
-    
+
     # Construct markups using actual paths
     expected_local_markup = f"![Local Image]({local_image_actual})"
     expected_parent_markup = f"![Parent Image]({parent_image_actual})"
     expected_root_markup = f"![Root Image]({root_image_actual})"
-    
+
     # In markdown-only mode, paths should be relative to the original images
     assert "translated_images" not in result_md_only
     assert ".ko." not in result_md_only
-    
+
     # Precise assertions with exact matches
-    assert expected_local_markup in result_md_only, f"Expected local image markup: '{expected_local_markup}' not found"
-    assert expected_parent_markup in result_md_only, f"Expected parent image markup: '{expected_parent_markup}' not found"
-    assert expected_root_markup in result_md_only, f"Expected root image markup: '{expected_root_markup}' not found"
+    assert (
+        expected_local_markup in result_md_only
+    ), f"Expected local image markup: '{expected_local_markup}' not found"
+    assert (
+        expected_parent_markup in result_md_only
+    ), f"Expected parent image markup: '{expected_parent_markup}' not found"
+    assert (
+        expected_root_markup in result_md_only
+    ), f"Expected root image markup: '{expected_root_markup}' not found"


### PR DESCRIPTION
## Purpose

<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->

The purpose of this PR is to fix an issue with how paths starting with '/' (root-relative paths) are handled in the co-op-translator. Previously, these paths were not correctly processed in both markdown-only mode and regular (non-markdown-only) mode, leading to broken image links in translated documents.


## Description

<!-- Provide a concise summary of your changes. Why is this change necessary? -->

The changes modify how root-relative paths are processed in both translation modes:

1. In markdown-only mode: paths starting with '/' are now kept unchanged (instead of being converted to relative paths)
In non-markdown-only mode: paths starting with '/' are correctly resolved from the project root and properly linked to translated images
2. The get_actual_image_path function was enhanced with a root_dir parameter to properly resolve root-relative paths
Test cases were added to verify the correct behavior in both modes
This change is necessary because the previous implementation didn't correctly distinguish between paths starting with '/' (root-relative) and regular relative paths, which resulted in incorrect path resolution in translated documents.

## Related Issue

<!-- If this PR addresses an issue, please link it here (e.g., Fixes #123) -->

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

- [ ] Yes
- [x] No

## Type of change

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (e.g., formatting, local variables)
- [ ] Refactoring (no functional or API changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Checklist

Before submitting your pull request, please confirm the following:

- [x] **I have thoroughly tested my changes**: I confirm that I have run the code and manually tested all affected areas.
- [x] **All existing tests pass**: I have run all tests and confirmed that nothing is broken.
- [x] **I have added new tests** (if applicable): I have written tests that cover the new functionality introduced by my code changes.
- [x] **I have followed the Co-op Translators coding conventions**: My code adheres to the style guide and coding conventions outlined in the repository.
- [x] **I have documented my changes** (if applicable): I have updated the documentation to reflect the changes where necessary.

## Additional context

<!-- Add any additional context or screenshots if applicable -->
