### PR TITLE
Add Jupyter Notebook (.ipynb) translation support

### DIFF
--- a/src/co_op_translator/config/constants.py
+++ b/src/co_op_translator/config/constants.py
@@ -3,6 +3,9 @@ RGBA_IMAGE_EXTENSIONS = {".png"}
 RGB_IMAGE_EXTENSIONS = {".jpg", ".jpeg"}
 SUPPORTED_IMAGE_EXTENSIONS = RGBA_IMAGE_EXTENSIONS.union(RGB_IMAGE_EXTENSIONS)
 
+# Supported notebook file extensions
+SUPPORTED_NOTEBOOK_EXTENSIONS = {".ipynb"}
+
 EXCLUDED_DIRS = {
     "translations",
     "translated_images",

--- a/src/co_op_translator/core/llm/__init__.py
+++ b/src/co_op_translator/core/llm/__init__.py
@@ -6,10 +6,14 @@ from co_op_translator.core.llm.providers.openai import (
     OpenAITextTranslator,
     OpenAIMarkdownTranslator,
 )
+from co_op_translator.core.llm.jupyter_notebook_translator import (
+    JupyterNotebookTranslator,
+)
 
 __all__ = [
     "AzureTextTranslator",
     "AzureMarkdownTranslator",
     "OpenAITextTranslator",
     "OpenAIMarkdownTranslator",
+    "JupyterNotebookTranslator",
 ]

--- a/src/co_op_translator/core/llm/jupyter_notebook_translator.py
+++ b/src/co_op_translator/core/llm/jupyter_notebook_translator.py
@@ -1,0 +1,132 @@
+"""
+Jupyter Notebook translator for translating .ipynb files.
+
+This module provides functionality to translate Jupyter Notebook files by
+extracting markdown cells, translating them, and preserving code cells unchanged.
+"""
+
+import json
+import logging
+from pathlib import Path
+from typing import Dict, Any, List
+
+from .markdown_translator import MarkdownTranslator
+
+logger = logging.getLogger(__name__)
+
+
+class JupyterNotebookTranslator:
+    """Handles translation of Jupyter Notebook (.ipynb) files.
+    
+    Translates markdown cells while preserving code cells, metadata,
+    and the overall notebook structure.
+    """
+    
+    def __init__(self, root_dir: Path = None):
+        """Initialize the notebook translator.
+        
+        Args:
+            root_dir: Root directory of the project for path calculations
+        """
+        self.root_dir = root_dir
+        self.markdown_translator = MarkdownTranslator.create(root_dir)
+    
+    async def translate_notebook(
+        self,
+        notebook_path: str | Path,
+        language_code: str,
+        markdown_only: bool = False,
+    ) -> str:
+        """Translate a Jupyter Notebook file to the target language.
+        
+        Extracts markdown cells from the notebook, translates them using
+        the existing markdown translator, and reconstructs the notebook
+        with translated content.
+        
+        Args:
+            notebook_path: Path to the .ipynb file
+            language_code: Target language code
+            markdown_only: Skip embedded image translation if True
+            
+        Returns:
+            str: The translated notebook content as JSON string
+        """
+        notebook_path = Path(notebook_path)
+        
+        # Read the notebook file
+        with open(notebook_path, 'r', encoding='utf-8') as f:
+            notebook = json.load(f)
+        
+        # Track which cells were translated for logging
+        translated_cells = 0
+        total_markdown_cells = 0
+        
+        # Process each cell
+        for cell in notebook.get('cells', []):
+            if cell.get('cell_type') == 'markdown':
+                total_markdown_cells += 1
+                
+                # Extract the source content
+                source = cell.get('source', [])
+                if not source:
+                    continue
+                
+                # Convert source to string (it might be a list of lines)
+                if isinstance(source, list):
+                    markdown_content = ''.join(source)
+                else:
+                    markdown_content = str(source)
+                
+                # Skip empty cells
+                if not markdown_content.strip():
+                    continue
+                
+                try:
+                    # Translate the markdown content
+                    translated_content = await self.markdown_translator.translate_markdown(
+                        markdown_content,
+                        language_code,
+                        notebook_path,
+                        markdown_only=markdown_only,
+                    )
+                    
+                    # Convert back to the original format (list or string)
+                    if isinstance(source, list):
+                        # Split by lines but preserve the original line ending behavior
+                        translated_lines = translated_content.splitlines(keepends=True)
+                        # Ensure lines end with \n if they don't already
+                        translated_lines = [line if line.endswith('\n') else line + '\n' 
+                                          for line in translated_lines]
+                        cell['source'] = translated_lines
+                    else:
+                        cell['source'] = translated_content
+                    
+                    translated_cells += 1
+                    
+                except Exception as e:
+                    logger.warning(
+                        f"Failed to translate cell in {notebook_path}: {e}. "
+                        f"Keeping original content."
+                    )
+        
+        logger.info(
+            f"Translated {translated_cells}/{total_markdown_cells} markdown cells "
+            f"in {notebook_path.name}"
+        )
+        
+        # Return the modified notebook as JSON string
+        return json.dumps(notebook, ensure_ascii=False, indent=1)
+    
+    @classmethod
+    def create(cls, root_dir: Path = None) -> "JupyterNotebookTranslator":
+        """Create a Jupyter Notebook translator instance.
+        
+        Factory method for creating the translator.
+        
+        Args:
+            root_dir: Root directory of the project for path calculations
+            
+        Returns:
+            JupyterNotebookTranslator instance
+        """
+        return cls(root_dir)

--- a/tests/co_op_translator/core/llm/test_jupyter_notebook_translator.py
+++ b/tests/co_op_translator/core/llm/test_jupyter_notebook_translator.py
@@ -1,0 +1,183 @@
+"""
+Tests for JupyterNotebookTranslator functionality.
+"""
+
+import json
+import pytest
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from co_op_translator.core.llm.jupyter_notebook_translator import JupyterNotebookTranslator
+
+
+@pytest.fixture
+def sample_notebook():
+    """Sample notebook content for testing."""
+    return {
+        "cells": [
+            {
+                "cell_type": "markdown",
+                "metadata": {},
+                "source": [
+                    "# Hello World\n",
+                    "\n",
+                    "This is a test notebook."
+                ]
+            },
+            {
+                "cell_type": "code",
+                "execution_count": None,
+                "metadata": {},
+                "outputs": [],
+                "source": [
+                    "print('Hello, World!')\n",
+                    "# This should not be translated"
+                ]
+            },
+            {
+                "cell_type": "markdown",
+                "metadata": {},
+                "source": ["## Section 2\n", "\n", "Another markdown cell."]
+            }
+        ],
+        "metadata": {
+            "kernelspec": {
+                "display_name": "Python 3",
+                "language": "python",
+                "name": "python3"
+            }
+        },
+        "nbformat": 4,
+        "nbformat_minor": 4
+    }
+
+
+@pytest.fixture
+def temp_notebook_file(tmp_path, sample_notebook):
+    """Create a temporary notebook file for testing."""
+    notebook_file = tmp_path / "test.ipynb"
+    with open(notebook_file, 'w', encoding='utf-8') as f:
+        json.dump(sample_notebook, f, ensure_ascii=False, indent=1)
+    return notebook_file
+
+
+class TestJupyterNotebookTranslator:
+    """Test cases for JupyterNotebookTranslator."""
+
+    @patch('co_op_translator.core.llm.jupyter_notebook_translator.MarkdownTranslator')
+    def test_create_translator(self, mock_markdown_translator_class):
+        """Test that translator can be created."""
+        mock_markdown_translator_class.create.return_value = MagicMock()
+        translator = JupyterNotebookTranslator.create()
+        assert translator is not None
+        assert translator.root_dir is None
+
+    @patch('co_op_translator.core.llm.jupyter_notebook_translator.MarkdownTranslator')
+    def test_create_translator_with_root_dir(self, mock_markdown_translator_class, tmp_path):
+        """Test that translator can be created with root directory."""
+        mock_markdown_translator_class.create.return_value = MagicMock()
+        translator = JupyterNotebookTranslator.create(tmp_path)
+        assert translator.root_dir == tmp_path
+
+    @patch('co_op_translator.core.llm.jupyter_notebook_translator.MarkdownTranslator')
+    @pytest.mark.asyncio
+    async def test_translate_notebook_basic(self, mock_markdown_translator_class, temp_notebook_file):
+        """Test basic notebook translation functionality."""
+        # Setup mock
+        mock_translator = AsyncMock()
+        mock_translator.translate_markdown = AsyncMock(return_value="# Translated Content\n\nTranslated text.")
+        mock_markdown_translator_class.create.return_value = mock_translator
+
+        # Create translator and translate
+        translator = JupyterNotebookTranslator.create()
+        result = await translator.translate_notebook(
+            temp_notebook_file, "es", markdown_only=True
+        )
+
+        # Verify result is valid JSON
+        translated_notebook = json.loads(result)
+        assert "cells" in translated_notebook
+        assert len(translated_notebook["cells"]) == 3
+
+        # Verify markdown cells were processed
+        assert mock_translator.translate_markdown.call_count == 2  # Two markdown cells
+
+        # Verify code cell remains unchanged
+        code_cell = translated_notebook["cells"][1]
+        assert code_cell["cell_type"] == "code"
+        assert "print('Hello, World!')" in "".join(code_cell["source"])
+
+    @patch('co_op_translator.core.llm.jupyter_notebook_translator.MarkdownTranslator')
+    @pytest.mark.asyncio
+    async def test_translate_notebook_empty_cells(self, mock_markdown_translator_class, tmp_path):
+        """Test translation with empty markdown cells."""
+        # Create notebook with empty cells
+        notebook_content = {
+            "cells": [
+                {"cell_type": "markdown", "metadata": {}, "source": []},
+                {"cell_type": "markdown", "metadata": {}, "source": ""},
+                {"cell_type": "code", "metadata": {}, "source": ["print('test')"]}
+            ],
+            "metadata": {},
+            "nbformat": 4,
+            "nbformat_minor": 4
+        }
+        
+        notebook_file = tmp_path / "empty_test.ipynb"
+        with open(notebook_file, 'w', encoding='utf-8') as f:
+            json.dump(notebook_content, f)
+
+        # Setup mock
+        mock_translator = AsyncMock()
+        mock_markdown_translator_class.create.return_value = mock_translator
+
+        # Create translator and translate
+        translator = JupyterNotebookTranslator.create()
+        result = await translator.translate_notebook(notebook_file, "es")
+
+        # Verify no translation calls were made for empty cells
+        mock_translator.translate_markdown.assert_not_called()
+
+        # Verify result is valid
+        translated_notebook = json.loads(result)
+        assert len(translated_notebook["cells"]) == 3
+
+    @patch('co_op_translator.core.llm.jupyter_notebook_translator.MarkdownTranslator')
+    @pytest.mark.asyncio
+    async def test_translate_notebook_with_list_source(self, mock_markdown_translator_class, tmp_path):
+        """Test translation with source as list of strings."""
+        # Create notebook with list-based source
+        notebook_content = {
+            "cells": [
+                {
+                    "cell_type": "markdown",
+                    "metadata": {},
+                    "source": ["# Title\n", "\n", "Some content"]
+                }
+            ],
+            "metadata": {},
+            "nbformat": 4,
+            "nbformat_minor": 4
+        }
+        
+        notebook_file = tmp_path / "list_test.ipynb"
+        with open(notebook_file, 'w', encoding='utf-8') as f:
+            json.dump(notebook_content, f)
+
+        # Setup mock
+        mock_translator = AsyncMock()
+        mock_translator.translate_markdown = AsyncMock(return_value="# Translated Title\n\nTranslated content")
+        mock_markdown_translator_class.create.return_value = mock_translator
+
+        # Create translator and translate
+        translator = JupyterNotebookTranslator.create()
+        result = await translator.translate_notebook(notebook_file, "es")
+
+        # Verify translation was called
+        mock_translator.translate_markdown.assert_called_once()
+
+        # Verify result maintains list format
+        translated_notebook = json.loads(result)
+        cell_source = translated_notebook["cells"][0]["source"]
+        assert isinstance(cell_source, list)
+        assert all(isinstance(line, str) for line in cell_source)

--- a/tests/co_op_translator/core/project/test_jupyter_notebook_integration.py
+++ b/tests/co_op_translator/core/project/test_jupyter_notebook_integration.py
@@ -1,0 +1,171 @@
+"""
+Integration tests for Jupyter Notebook translation functionality.
+"""
+
+import json
+import pytest
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from co_op_translator.core.project.project_translator import ProjectTranslator
+
+
+@pytest.fixture
+def temp_project_with_notebook(tmp_path):
+    """Create a temporary project directory with notebook files."""
+    # Create a sample notebook
+    notebook_content = {
+        "cells": [
+            {
+                "cell_type": "markdown",
+                "metadata": {},
+                "source": ["# Test Notebook\n", "\n", "This is a test for translation."]
+            },
+            {
+                "cell_type": "code",
+                "execution_count": None,
+                "metadata": {},
+                "outputs": [],
+                "source": ["print('Hello, World!')"]
+            },
+            {
+                "cell_type": "markdown",
+                "metadata": {},
+                "source": "## Section 2\n\nAnother section to translate."
+            }
+        ],
+        "metadata": {"kernelspec": {"display_name": "Python 3", "language": "python", "name": "python3"}},
+        "nbformat": 4,
+        "nbformat_minor": 4
+    }
+
+    # Create notebook file
+    notebook_file = tmp_path / "test_notebook.ipynb"
+    with open(notebook_file, 'w', encoding='utf-8') as f:
+        json.dump(notebook_content, f, ensure_ascii=False, indent=1)
+
+    # Create markdown file for comparison
+    (tmp_path / "test.md").write_text("# Test Document\nThis is a test.")
+
+    return tmp_path
+
+
+class TestJupyterNotebookIntegration:
+    """Integration tests for Jupyter Notebook translation."""
+
+    @patch("co_op_translator.core.llm.text_translator.TextTranslator")
+    @patch("co_op_translator.core.llm.markdown_translator.MarkdownTranslator")
+    @patch("co_op_translator.core.llm.jupyter_notebook_translator.MarkdownTranslator")
+    @patch("co_op_translator.config.llm_config.config.LLMConfig.get_available_provider")
+    def test_project_translator_includes_notebooks(
+        self,
+        mock_get_provider,
+        mock_jupyter_markdown_translator,
+        mock_markdown_translator,
+        mock_text_translator,
+        temp_project_with_notebook,
+    ):
+        """Test that ProjectTranslator correctly initializes notebook translator."""
+        # Setup mocks
+        mock_get_provider.return_value = "azure"
+        mock_text_translator.create.return_value = MagicMock()
+        mock_markdown_translator.create.return_value = MagicMock()
+        mock_jupyter_markdown_translator.create.return_value = MagicMock()
+
+        # Create translator
+        translator = ProjectTranslator("ko", root_dir=temp_project_with_notebook, markdown_only=True)
+
+        # Verify notebook translator was created
+        assert translator.notebook_translator is not None
+
+        # Verify translation manager has notebook translator
+        assert translator.translation_manager.notebook_translator is not None
+
+    @patch("co_op_translator.core.llm.text_translator.TextTranslator")
+    @patch("co_op_translator.core.llm.markdown_translator.MarkdownTranslator")
+    @patch("co_op_translator.core.llm.jupyter_notebook_translator.MarkdownTranslator")
+    @patch("co_op_translator.config.llm_config.config.LLMConfig.get_available_provider")
+    @pytest.mark.asyncio
+    async def test_translation_manager_processes_notebooks(
+        self,
+        mock_get_provider,
+        mock_jupyter_markdown_translator,
+        mock_markdown_translator,
+        mock_text_translator,
+        temp_project_with_notebook,
+    ):
+        """Test that TranslationManager processes notebook files."""
+        # Setup mocks
+        mock_get_provider.return_value = "azure"
+        mock_text_translator.create.return_value = MagicMock()
+        
+        # Mock markdown translator
+        mock_md_translator = AsyncMock()
+        mock_md_translator.translate_markdown = AsyncMock(return_value="# Translated\nTranslated content")
+        mock_markdown_translator.create.return_value = mock_md_translator
+
+        # Mock jupyter notebook translator
+        mock_jupyter_md_translator = AsyncMock()
+        mock_jupyter_md_translator.translate_markdown = AsyncMock(return_value="# Translated\nTranslated content")
+        mock_jupyter_markdown_translator.create.return_value = mock_jupyter_md_translator
+
+        # Create translator
+        translator = ProjectTranslator("ko", root_dir=temp_project_with_notebook, markdown_only=True)
+
+        # Mock the notebook translator's translate_notebook method
+        mock_notebook_translator = AsyncMock()
+        translated_notebook = {
+            "cells": [
+                {"cell_type": "markdown", "metadata": {}, "source": ["# Translated\n", "Translated content"]},
+                {"cell_type": "code", "metadata": {}, "source": ["print('Hello, World!')"]},
+                {"cell_type": "markdown", "metadata": {}, "source": "## Translated Section\nTranslated content"}
+            ],
+            "metadata": {"kernelspec": {"display_name": "Python 3", "language": "python", "name": "python3"}},
+            "nbformat": 4,
+            "nbformat_minor": 4
+        }
+        mock_notebook_translator.translate_notebook = AsyncMock(
+            return_value=json.dumps(translated_notebook, ensure_ascii=False, indent=1)
+        )
+        translator.translation_manager.notebook_translator = mock_notebook_translator
+
+        # Run translation
+        total_modified, errors = await translator.translation_manager.translate_all_notebook_files()
+
+        # Verify notebook translation was attempted
+        assert mock_notebook_translator.translate_notebook.call_count >= 1
+        assert total_modified >= 0  # Should have attempted to translate
+        assert isinstance(errors, list)
+
+    @patch("co_op_translator.core.llm.text_translator.TextTranslator")
+    @patch("co_op_translator.core.llm.markdown_translator.MarkdownTranslator")
+    @patch("co_op_translator.core.llm.jupyter_notebook_translator.MarkdownTranslator")
+    @patch("co_op_translator.config.llm_config.config.LLMConfig.get_available_provider")
+    def test_project_translator_handles_no_notebook_translator(
+        self,
+        mock_get_provider,
+        mock_jupyter_markdown_translator,
+        mock_markdown_translator,
+        mock_text_translator,
+        temp_project_with_notebook,
+    ):
+        """Test that system gracefully handles missing notebook translator."""
+        # Setup mocks
+        mock_get_provider.return_value = "azure"
+        mock_text_translator.create.return_value = MagicMock()
+        mock_markdown_translator.create.return_value = MagicMock()
+        mock_jupyter_markdown_translator.create.return_value = MagicMock()
+
+        # Create translator
+        translator = ProjectTranslator("ko", root_dir=temp_project_with_notebook, markdown_only=True)
+
+        # Simulate missing notebook translator
+        translator.translation_manager.notebook_translator = None
+
+        # Should not raise exception
+        assert translator.translation_manager.notebook_translator is None
+
+    def test_constants_include_notebook_extensions(self):
+        """Test that notebook extensions are included in constants."""
+        from co_op_translator.config.constants import SUPPORTED_NOTEBOOK_EXTENSIONS
+        assert ".ipynb" in SUPPORTED_NOTEBOOK_EXTENSIONS


### PR DESCRIPTION

## Purpose

This pull request introduces support for translating Jupyter Notebook (`.ipynb`) files in the `co_op_translator` project.

## Description

 The changes include adding a new `JupyterNotebookTranslator` class, integrating it into the project translation workflow, and updating relevant configurations and methods to handle notebook files.
 
## Related Issue

Fixes #51

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

- [ ] Yes
- [x] No

## Type of change

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (e.g., formatting, local variables)
- [ ] Refactoring (no functional or API changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Checklist

Before submitting your pull request, please confirm the following:

- [x] **I have thoroughly tested my changes**: I confirm that I have run the code and manually tested all affected areas.
- [x] **All existing tests pass**: I have run all tests and confirmed that nothing is broken.
- [x] **I have added new tests** (if applicable): I have written tests that cover the new functionality introduced by my code changes.
- [x] **I have followed the Co-op Translators coding conventions**: My code adheres to the style guide and coding conventions outlined in the repository.
- [x] **I have documented my changes** (if applicable): I have updated the documentation to reflect the changes where necessary.

## Additional context


### Notebook Translation Support:

* **New `JupyterNotebookTranslator` class**: Added a dedicated class in `src/co_op_translator/core/llm/jupyter_notebook_translator.py` to handle the translation of Jupyter Notebook files. It extracts markdown cells for translation while preserving code cells and metadata.
* **Constants update**: Introduced `SUPPORTED_NOTEBOOK_EXTENSIONS` in `src/co_op_translator/config/constants.py` to define supported notebook file extensions.

### Integration into Translation Workflow:

* **Core module updates**:
  - Imported `JupyterNotebookTranslator` in `src/co_op_translator/core/llm/__init__.py` and added it to the `__all__` list.
  - Updated `src/co_op_translator/core/project/project_translator.py` to initialize and use the notebook translator in the `ProjectTranslator` class.

* **Translation manager enhancements**:
  - Integrated notebook translation into the `TranslationManager` class in `src/co_op_translator/core/project/translation_manager.py`. Added methods `translate_notebook` and `translate_all_notebook_files` to handle individual and bulk notebook translations.
  - Updated `translate_project_async` to include notebook translation when processing markdown files.
  - Modified `get_outdated_translations` to account for outdated notebook translations.

These changes collectively enable seamless translation of Jupyter Notebook files within the existing project translation workflow.
