### PR TITLE
Fix image filename hash inconsistency by normalizing path separators across OS

### DIFF
--- a/src/co_op_translator/utils/common/file_utils.py
+++ b/src/co_op_translator/utils/common/file_utils.py
@@ -116,16 +116,14 @@ def get_unique_id(file_path: str | Path, root_dir: Path) -> str:
     relative_path = file_path.relative_to(root_dir)
 
     # Normalize path separators to '/' for cross-platform consistency
-    normalized_path = str(relative_path).replace(os.sep, '/')
-    
+    normalized_path = str(relative_path).replace(os.sep, "/")
+
     # Convert the normalized path to bytes and hash it
     relative_path_bytes = normalized_path.encode("utf-8")
     hash_object = hashlib.sha256(relative_path_bytes)
     unique_identifier = hash_object.hexdigest()
 
-    logger.info(
-        f"HASH for normalized path: {normalized_path} HASH={unique_identifier}"
-    )
+    logger.info(f"HASH for normalized path: {normalized_path} HASH={unique_identifier}")
 
     return unique_identifier
 

--- a/src/co_op_translator/utils/common/file_utils.py
+++ b/src/co_op_translator/utils/common/file_utils.py
@@ -103,24 +103,28 @@ def get_actual_image_path(
 def get_unique_id(file_path: str | Path, root_dir: Path) -> str:
     """
     Generate a unique identifier (hash) for the given file path, based on the relative path to the root directory.
+    This function normalizes path separators to '/' before hashing to ensure consistency across operating systems.
 
     Args:
         file_path (str | Path): The file path to hash.
         root_dir (Path): The root directory to which the file path should be relative.
 
     Returns:
-        str: A SHA-256 hash of the relative file path.
+        str: A SHA-256 hash of the normalized relative file path.
     """
     file_path = Path(file_path).resolve()
     relative_path = file_path.relative_to(root_dir)
 
-    # Convert the relative path to bytes and hash it
-    relative_path_bytes = str(relative_path).encode("utf-8")
+    # Normalize path separators to '/' for cross-platform consistency
+    normalized_path = str(relative_path).replace(os.sep, '/')
+    
+    # Convert the normalized path to bytes and hash it
+    relative_path_bytes = normalized_path.encode("utf-8")
     hash_object = hashlib.sha256(relative_path_bytes)
     unique_identifier = hash_object.hexdigest()
 
     logger.info(
-        f"HASH for relative file path: {relative_path} HASH={unique_identifier}"
+        f"HASH for normalized path: {normalized_path} HASH={unique_identifier}"
     )
 
     return unique_identifier

--- a/tests/co_op_translator/utils/common/test_file_utils.py
+++ b/tests/co_op_translator/utils/common/test_file_utils.py
@@ -73,6 +73,40 @@ def test_get_unique_id(temp_dir):
     assert len(unique_id) > 0
 
 
+def test_cross_platform_path_hash_consistency(temp_dir, monkeypatch):
+    """Test that path hashing is consistent across different OS path separators."""
+    import os
+
+    # Setup test directory structure
+    test_dir = temp_dir / "test_dir"
+    test_dir.mkdir()
+    file_path = test_dir / "subdir" / "test_file.txt"
+    file_path.parent.mkdir(parents=True)
+    file_path.touch()
+
+    # Case 1: Get hash with default OS path separator
+    original_hash = get_unique_id(file_path, temp_dir)
+
+    # Case 2: Simulate Windows-style paths with backslashes
+    windows_style_path = str(file_path).replace("/", "\\")
+    windows_hash = get_unique_id(windows_style_path, temp_dir)
+
+    # Case 3: Simulate Unix-style paths with forward slashes
+    unix_style_path = str(file_path).replace("\\", "/")
+    unix_hash = get_unique_id(unix_style_path, temp_dir)
+
+    # All hashes should be identical regardless of path separator style
+    assert (
+        original_hash == windows_hash
+    ), "Hash should be the same regardless of Windows or default style paths"
+    assert (
+        original_hash == unix_hash
+    ), "Hash should be the same regardless of Unix or default style paths"
+    assert (
+        windows_hash == unix_hash
+    ), "Hash should be the same regardless of Windows or Unix style paths"
+
+
 def test_get_filename_and_extension():
     """Test extracting filename and extension."""
     test_cases = [


### PR DESCRIPTION
# Normalize path separators for cross-platform hash consistency

## Purpose

Ensure consistent hash generation across different operating systems by normalizing file path separators. This prevents platform-specific discrepancies in `get_unique_id`.

## Description

- Updated `get_unique_id` to normalize path separators to `'/'` before hashing.
- Ensures consistent SHA-256 hashes regardless of whether input paths use `\` (Windows) or `/` (Unix).
- Added a new test `test_cross_platform_path_hash_consistency` to validate hash stability across OS-specific path formats.

## Related Issue

<!-- No related issue explicitly mentioned. -->

#128 

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?

- [x] No

## Type of change

- [x] Bugfix
- [x] Code style update (e.g., formatting, local variables)
- [x] Test coverage improvement

## Checklist

- [x] **I have thoroughly tested my changes**
- [x] **All existing tests pass**
- [x] **I have added new tests** (cross-platform consistency)
- [x] **I have followed the Co-op Translators coding conventions**
- [x] **I have documented my changes** (via docstring and logging updates)

## Additional context

This resolves an edge case where identical file structures on Windows and Unix could result in different translation cache keys due to differing path separator styles. This is especially important for consistent behavior in CI/CD pipelines and cache re-use.
