### PR TITLE
Core: Add CLI option for selective notebook file translation (-n/--notebook)

### DIFF
--- a/src/co_op_translator/core/llm/jupyter_notebook_translator.py
+++ b/src/co_op_translator/core/llm/jupyter_notebook_translator.py
@@ -17,20 +17,20 @@ logger = logging.getLogger(__name__)
 
 class JupyterNotebookTranslator:
     """Handles translation of Jupyter Notebook (.ipynb) files.
-    
+
     Translates markdown cells while preserving code cells, metadata,
     and the overall notebook structure.
     """
-    
+
     def __init__(self, root_dir: Path = None):
         """Initialize the notebook translator.
-        
+
         Args:
             root_dir: Root directory of the project for path calculations
         """
         self.root_dir = root_dir
         self.markdown_translator = MarkdownTranslator.create(root_dir)
-    
+
     async def translate_notebook(
         self,
         notebook_path: str | Path,
@@ -38,97 +38,101 @@ class JupyterNotebookTranslator:
         markdown_only: bool = False,
     ) -> str:
         """Translate a Jupyter Notebook file to the target language.
-        
+
         Extracts markdown cells from the notebook, translates them using
         the existing markdown translator, and reconstructs the notebook
         with translated content.
-        
+
         Args:
             notebook_path: Path to the .ipynb file
             language_code: Target language code
             markdown_only: Skip embedded image translation if True
-            
+
         Returns:
             str: The translated notebook content as JSON string
         """
         notebook_path = Path(notebook_path)
-        
+
         # Read the notebook file
-        with open(notebook_path, 'r', encoding='utf-8') as f:
+        with open(notebook_path, "r", encoding="utf-8") as f:
             notebook = json.load(f)
-        
+
         # Track which cells were translated for logging
         translated_cells = 0
         total_markdown_cells = 0
-        
+
         # Process each cell
-        for cell in notebook.get('cells', []):
-            if cell.get('cell_type') == 'markdown':
+        for cell in notebook.get("cells", []):
+            if cell.get("cell_type") == "markdown":
                 total_markdown_cells += 1
-                
+
                 # Extract the source content
-                source = cell.get('source', [])
+                source = cell.get("source", [])
                 if not source:
                     continue
-                
+
                 # Convert source to string (it might be a list of lines)
                 if isinstance(source, list):
-                    markdown_content = ''.join(source)
+                    markdown_content = "".join(source)
                 else:
                     markdown_content = str(source)
-                
+
                 # Skip empty cells
                 if not markdown_content.strip():
                     continue
-                
+
                 try:
                     # Translate the markdown content
                     # Don't add metadata and disclaimer to individual cells
-                    translated_content = await self.markdown_translator.translate_markdown(
-                        markdown_content,
-                        language_code,
-                        notebook_path,
-                        markdown_only=markdown_only,
-                        add_metadata=False,
-                        add_disclaimer=False,
+                    translated_content = (
+                        await self.markdown_translator.translate_markdown(
+                            markdown_content,
+                            language_code,
+                            notebook_path,
+                            markdown_only=markdown_only,
+                            add_metadata=False,
+                            add_disclaimer=False,
+                        )
                     )
-                    
+
                     # Convert back to the original format (list or string)
                     if isinstance(source, list):
                         # Split by lines but preserve the original line ending behavior
                         translated_lines = translated_content.splitlines(keepends=True)
                         # Ensure lines end with \n if they don't already
-                        translated_lines = [line if line.endswith('\n') else line + '\n' 
-                                          for line in translated_lines]
-                        cell['source'] = translated_lines
+                        translated_lines = [
+                            line if line.endswith("\n") else line + "\n"
+                            for line in translated_lines
+                        ]
+                        cell["source"] = translated_lines
                     else:
-                        cell['source'] = translated_content
-                    
+                        cell["source"] = translated_content
+
                     translated_cells += 1
-                    
+
                 except Exception as e:
                     logger.warning(
                         f"Failed to translate cell in {notebook_path}: {e}. "
                         f"Keeping original content."
                     )
-        
+
         logger.info(
             f"Translated {translated_cells}/{total_markdown_cells} markdown cells "
             f"in {notebook_path.name}"
         )
-        
+
         # Return the modified notebook as JSON string
         return json.dumps(notebook, ensure_ascii=False, indent=1)
-    
+
     @classmethod
     def create(cls, root_dir: Path = None) -> "JupyterNotebookTranslator":
         """Create a Jupyter Notebook translator instance.
-        
+
         Factory method for creating the translator.
-        
+
         Args:
             root_dir: Root directory of the project for path calculations
-            
+
         Returns:
             JupyterNotebookTranslator instance
         """

--- a/src/co_op_translator/core/llm/markdown_translator.py
+++ b/src/co_op_translator/core/llm/markdown_translator.py
@@ -7,8 +7,6 @@ from co_op_translator.utils.llm.markdown_utils import (
     process_markdown,
     update_links,
     generate_prompt_template,
-    count_links_in_markdown,
-    process_markdown_with_many_links,
     replace_code_blocks,
     restore_code_blocks,
 )
@@ -114,20 +112,8 @@ class MarkdownTranslator(ABC):
             placeholder_map,
         ) = replace_code_blocks(document)
 
-        # Step 2: Split the document into chunks and generate prompts
-        link_limit = 30
-        if count_links_in_markdown(document_with_placeholders) > link_limit:
-            logger.info(
-                f"Document contains more than {link_limit} links, splitting the document into chunks."
-            )
-            document_chunks = process_markdown_with_many_links(
-                document_with_placeholders, link_limit
-            )
-        else:
-            logger.info(
-                f"Document contains {link_limit} or fewer links, processing normally."
-            )
-            document_chunks = process_markdown(document_with_placeholders)
+        # Step 2: Split the document into chunks
+        document_chunks = process_markdown(document_with_placeholders)
 
         # Step 3: Generate translation prompts and translate each chunk
         language_name = self.font_config.get_language_name(language_code)

--- a/src/co_op_translator/core/llm/markdown_translator.py
+++ b/src/co_op_translator/core/llm/markdown_translator.py
@@ -114,8 +114,20 @@ class MarkdownTranslator(ABC):
             placeholder_map,
         ) = replace_code_blocks(document)
 
-        # Step 2: Split the document into chunks
-        document_chunks = process_markdown(document_with_placeholders)
+        # Step 2: Split the document into chunks and generate prompts
+        link_limit = 30
+        if count_links_in_markdown(document_with_placeholders) > link_limit:
+            logger.info(
+                f"Document contains more than {link_limit} links, splitting the document into chunks."
+            )
+            document_chunks = process_markdown_with_many_links(
+                document_with_placeholders, link_limit
+            )
+        else:
+            logger.info(
+                f"Document contains {link_limit} or fewer links, processing normally."
+            )
+            document_chunks = process_markdown(document_with_placeholders)
 
         # Step 3: Generate translation prompts and translate each chunk
         language_name = self.font_config.get_language_name(language_code)
@@ -138,7 +150,7 @@ class MarkdownTranslator(ABC):
             self.root_dir,
             markdown_only=markdown_only,
         )
-        
+
         # Step 6: Add metadata and disclaimer (only if requested)
         result = updated_content
         if add_metadata:

--- a/src/co_op_translator/core/project/project_translator.py
+++ b/src/co_op_translator/core/project/project_translator.py
@@ -91,7 +91,12 @@ class ProjectTranslator:
         )
 
     def translate_project(
-        self, images=False, markdown=False, update=False, fast_mode=False
+        self,
+        images=False,
+        markdown=False,
+        notebook=False,
+        update=False,
+        fast_mode=False,
     ):
         """Start the project translation process synchronously.
 
@@ -100,12 +105,17 @@ class ProjectTranslator:
         Args:
             images: Whether to translate images
             markdown: Whether to translate markdown files
+            notebook: Whether to translate notebook files
             update: Whether to update existing translations
             fast_mode: Whether to use faster translation method
         """
         asyncio.run(
             self.translation_manager.translate_project_async(
-                images=images, markdown=markdown, update=update, fast_mode=fast_mode
+                images=images,
+                markdown=markdown,
+                notebook=notebook,
+                update=update,
+                fast_mode=fast_mode,
             )
         )
 

--- a/src/co_op_translator/core/project/translation_manager.py
+++ b/src/co_op_translator/core/project/translation_manager.py
@@ -598,6 +598,7 @@ class TranslationManager:
         self,
         images: bool = False,
         markdown: bool = False,
+        notebook: bool = False,
         update: bool = False,
         fast_mode: bool = False,
     ) -> tuple[int, list[str]]:
@@ -612,6 +613,7 @@ class TranslationManager:
         Args:
             images: Whether to translate images
             markdown: Whether to translate markdown files
+            notebook: Whether to translate notebook files
             update: Whether to update existing translations
             fast_mode: Whether to use faster translation method
 
@@ -646,7 +648,7 @@ class TranslationManager:
                 sync_progress.update(1)
 
             # Find files needing translation due to source changes
-            if markdown:
+            if markdown or notebook:
                 with tqdm(total=1, desc="🔍 Checking translations") as check_progress:
                     outdated_files = self.get_outdated_translations()
                     check_progress.set_postfix_str(
@@ -659,7 +661,7 @@ class TranslationManager:
                 if outdated_files:
                     await self.retranslate_outdated_files(outdated_files)
 
-            # Execute translation for markdown and image files
+            # Execute translation for markdown, notebook and image files
             if markdown:
                 md_modified, md_errors = await self.translate_all_markdown_files(
                     update=update
@@ -667,7 +669,7 @@ class TranslationManager:
                 total_modified += md_modified
                 all_errors.extend(md_errors)
 
-                # Also translate notebook files when markdown translation is enabled
+            if notebook:
                 nb_modified, nb_errors = await self.translate_all_notebook_files(
                     update=update
                 )

--- a/src/co_op_translator/core/project/translation_manager.py
+++ b/src/co_op_translator/core/project/translation_manager.py
@@ -18,7 +18,9 @@ from co_op_translator.utils.common.file_utils import (
 )
 from co_op_translator.utils.common.metadata_utils import calculate_file_hash
 from co_op_translator.core.llm.markdown_translator import MarkdownTranslator
-from co_op_translator.core.llm.jupyter_notebook_translator import JupyterNotebookTranslator
+from co_op_translator.core.llm.jupyter_notebook_translator import (
+    JupyterNotebookTranslator,
+)
 from co_op_translator.core.project.directory_manager import DirectoryManager
 from co_op_translator.config.constants import SUPPORTED_IMAGE_EXTENSIONS
 from co_op_translator.utils.common.task_utils import worker
@@ -349,7 +351,8 @@ class TranslationManager:
         # Discover notebook files requiring translation using supported_notebook_extensions
         all_files = filter_files(self.root_dir, self.excluded_dirs)
         notebook_files = [
-            file for file in all_files
+            file
+            for file in all_files
             if file.suffix.lower() in self.supported_notebook_extensions
         ]
         tasks = []

--- a/src/co_op_translator/core/project/translation_manager.py
+++ b/src/co_op_translator/core/project/translation_manager.py
@@ -349,12 +349,10 @@ class TranslationManager:
                         logger.info(f"Deleted translated notebook: {notebook_file}")
 
         # Discover notebook files requiring translation using supported_notebook_extensions
-        all_files = filter_files(self.root_dir, self.excluded_dirs)
-        notebook_files = [
-            file
-            for file in all_files
-            if file.suffix.lower() in self.supported_notebook_extensions
-        ]
+        notebook_files = []
+        for ext in self.supported_notebook_extensions:
+            notebook_files.extend(filter_files(self.root_dir, self.excluded_dirs, ext))
+
         tasks = []
         task_info = []  # Store (file_path, language_code) for error reporting
 

--- a/src/co_op_translator/utils/common/file_utils.py
+++ b/src/co_op_translator/utils/common/file_utils.py
@@ -180,13 +180,16 @@ def get_filename_and_extension(file_path: str | Path) -> tuple[str, str]:
     return original_filename, file_ext.lower()
 
 
-def filter_files(directory: str | Path, excluded_dirs) -> list:
+def filter_files(directory: str | Path, excluded_dirs, extension: str = None) -> list:
     """
     Filter and return only the files in the given directory, excluding specified directories.
+    Optionally filter by file extension.
 
     Args:
         directory (str | Path): The directory path to search for files.
         excluded_dirs (set): A set of directory names to exclude from the search.
+        extension (str, optional): File extension to filter by (e.g., '.ipynb').
+                                If None, all file types are included.
 
     Returns:
         list: A list of Path objects representing only the files (excluding specified directories).
@@ -196,9 +199,11 @@ def filter_files(directory: str | Path, excluded_dirs) -> list:
 
     # Recursively traverse the directory
     for path in directory.rglob("*"):
-        # Check if the path is a file and does not contain any excluded directories
-        if path.is_file() and not any(
-            excluded_dir in path.parts for excluded_dir in excluded_dirs
+        # Check if the path is a file, matches extension if specified, and doesn't contain excluded dirs
+        if (
+            path.is_file()
+            and (extension is None or path.suffix.lower() == extension.lower())
+            and not any(excluded_dir in path.parts for excluded_dir in excluded_dirs)
         ):
             files.append(path)
 

--- a/tests/co_op_translator/core/llm/test_jupyter_notebook_translator.py
+++ b/tests/co_op_translator/core/llm/test_jupyter_notebook_translator.py
@@ -7,7 +7,9 @@ import pytest
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from co_op_translator.core.llm.jupyter_notebook_translator import JupyterNotebookTranslator
+from co_op_translator.core.llm.jupyter_notebook_translator import (
+    JupyterNotebookTranslator,
+)
 
 
 @pytest.fixture
@@ -18,11 +20,7 @@ def sample_notebook():
             {
                 "cell_type": "markdown",
                 "metadata": {},
-                "source": [
-                    "# Hello World\n",
-                    "\n",
-                    "This is a test notebook."
-                ]
+                "source": ["# Hello World\n", "\n", "This is a test notebook."],
             },
             {
                 "cell_type": "code",
@@ -31,24 +29,24 @@ def sample_notebook():
                 "outputs": [],
                 "source": [
                     "print('Hello, World!')\n",
-                    "# This should not be translated"
-                ]
+                    "# This should not be translated",
+                ],
             },
             {
                 "cell_type": "markdown",
                 "metadata": {},
-                "source": ["## Section 2\n", "\n", "Another markdown cell."]
-            }
+                "source": ["## Section 2\n", "\n", "Another markdown cell."],
+            },
         ],
         "metadata": {
             "kernelspec": {
                 "display_name": "Python 3",
                 "language": "python",
-                "name": "python3"
+                "name": "python3",
             }
         },
         "nbformat": 4,
-        "nbformat_minor": 4
+        "nbformat_minor": 4,
     }
 
 
@@ -56,7 +54,7 @@ def sample_notebook():
 def temp_notebook_file(tmp_path, sample_notebook):
     """Create a temporary notebook file for testing."""
     notebook_file = tmp_path / "test.ipynb"
-    with open(notebook_file, 'w', encoding='utf-8') as f:
+    with open(notebook_file, "w", encoding="utf-8") as f:
         json.dump(sample_notebook, f, ensure_ascii=False, indent=1)
     return notebook_file
 
@@ -64,7 +62,7 @@ def temp_notebook_file(tmp_path, sample_notebook):
 class TestJupyterNotebookTranslator:
     """Test cases for JupyterNotebookTranslator."""
 
-    @patch('co_op_translator.core.llm.jupyter_notebook_translator.MarkdownTranslator')
+    @patch("co_op_translator.core.llm.jupyter_notebook_translator.MarkdownTranslator")
     def test_create_translator(self, mock_markdown_translator_class):
         """Test that translator can be created."""
         mock_markdown_translator_class.create.return_value = MagicMock()
@@ -72,20 +70,26 @@ class TestJupyterNotebookTranslator:
         assert translator is not None
         assert translator.root_dir is None
 
-    @patch('co_op_translator.core.llm.jupyter_notebook_translator.MarkdownTranslator')
-    def test_create_translator_with_root_dir(self, mock_markdown_translator_class, tmp_path):
+    @patch("co_op_translator.core.llm.jupyter_notebook_translator.MarkdownTranslator")
+    def test_create_translator_with_root_dir(
+        self, mock_markdown_translator_class, tmp_path
+    ):
         """Test that translator can be created with root directory."""
         mock_markdown_translator_class.create.return_value = MagicMock()
         translator = JupyterNotebookTranslator.create(tmp_path)
         assert translator.root_dir == tmp_path
 
-    @patch('co_op_translator.core.llm.jupyter_notebook_translator.MarkdownTranslator')
+    @patch("co_op_translator.core.llm.jupyter_notebook_translator.MarkdownTranslator")
     @pytest.mark.asyncio
-    async def test_translate_notebook_basic(self, mock_markdown_translator_class, temp_notebook_file):
+    async def test_translate_notebook_basic(
+        self, mock_markdown_translator_class, temp_notebook_file
+    ):
         """Test basic notebook translation functionality."""
         # Setup mock
         mock_translator = AsyncMock()
-        mock_translator.translate_markdown = AsyncMock(return_value="# Translated Content\n\nTranslated text.")
+        mock_translator.translate_markdown = AsyncMock(
+            return_value="# Translated Content\n\nTranslated text."
+        )
         mock_markdown_translator_class.create.return_value = mock_translator
 
         # Create translator and translate
@@ -107,24 +111,26 @@ class TestJupyterNotebookTranslator:
         assert code_cell["cell_type"] == "code"
         assert "print('Hello, World!')" in "".join(code_cell["source"])
 
-    @patch('co_op_translator.core.llm.jupyter_notebook_translator.MarkdownTranslator')
+    @patch("co_op_translator.core.llm.jupyter_notebook_translator.MarkdownTranslator")
     @pytest.mark.asyncio
-    async def test_translate_notebook_empty_cells(self, mock_markdown_translator_class, tmp_path):
+    async def test_translate_notebook_empty_cells(
+        self, mock_markdown_translator_class, tmp_path
+    ):
         """Test translation with empty markdown cells."""
         # Create notebook with empty cells
         notebook_content = {
             "cells": [
                 {"cell_type": "markdown", "metadata": {}, "source": []},
                 {"cell_type": "markdown", "metadata": {}, "source": ""},
-                {"cell_type": "code", "metadata": {}, "source": ["print('test')"]}
+                {"cell_type": "code", "metadata": {}, "source": ["print('test')"]},
             ],
             "metadata": {},
             "nbformat": 4,
-            "nbformat_minor": 4
+            "nbformat_minor": 4,
         }
-        
+
         notebook_file = tmp_path / "empty_test.ipynb"
-        with open(notebook_file, 'w', encoding='utf-8') as f:
+        with open(notebook_file, "w", encoding="utf-8") as f:
             json.dump(notebook_content, f)
 
         # Setup mock
@@ -142,9 +148,11 @@ class TestJupyterNotebookTranslator:
         translated_notebook = json.loads(result)
         assert len(translated_notebook["cells"]) == 3
 
-    @patch('co_op_translator.core.llm.jupyter_notebook_translator.MarkdownTranslator')
+    @patch("co_op_translator.core.llm.jupyter_notebook_translator.MarkdownTranslator")
     @pytest.mark.asyncio
-    async def test_translate_notebook_with_list_source(self, mock_markdown_translator_class, tmp_path):
+    async def test_translate_notebook_with_list_source(
+        self, mock_markdown_translator_class, tmp_path
+    ):
         """Test translation with source as list of strings."""
         # Create notebook with list-based source
         notebook_content = {
@@ -152,21 +160,23 @@ class TestJupyterNotebookTranslator:
                 {
                     "cell_type": "markdown",
                     "metadata": {},
-                    "source": ["# Title\n", "\n", "Some content"]
+                    "source": ["# Title\n", "\n", "Some content"],
                 }
             ],
             "metadata": {},
             "nbformat": 4,
-            "nbformat_minor": 4
+            "nbformat_minor": 4,
         }
-        
+
         notebook_file = tmp_path / "list_test.ipynb"
-        with open(notebook_file, 'w', encoding='utf-8') as f:
+        with open(notebook_file, "w", encoding="utf-8") as f:
             json.dump(notebook_content, f)
 
         # Setup mock
         mock_translator = AsyncMock()
-        mock_translator.translate_markdown = AsyncMock(return_value="# Translated Title\n\nTranslated content")
+        mock_translator.translate_markdown = AsyncMock(
+            return_value="# Translated Title\n\nTranslated content"
+        )
         mock_markdown_translator_class.create.return_value = mock_translator
 
         # Create translator and translate

--- a/tests/co_op_translator/core/project/test_jupyter_notebook_integration.py
+++ b/tests/co_op_translator/core/project/test_jupyter_notebook_integration.py
@@ -19,29 +19,39 @@ def temp_project_with_notebook(tmp_path):
             {
                 "cell_type": "markdown",
                 "metadata": {},
-                "source": ["# Test Notebook\n", "\n", "This is a test for translation."]
+                "source": [
+                    "# Test Notebook\n",
+                    "\n",
+                    "This is a test for translation.",
+                ],
             },
             {
                 "cell_type": "code",
                 "execution_count": None,
                 "metadata": {},
                 "outputs": [],
-                "source": ["print('Hello, World!')"]
+                "source": ["print('Hello, World!')"],
             },
             {
                 "cell_type": "markdown",
                 "metadata": {},
-                "source": "## Section 2\n\nAnother section to translate."
-            }
+                "source": "## Section 2\n\nAnother section to translate.",
+            },
         ],
-        "metadata": {"kernelspec": {"display_name": "Python 3", "language": "python", "name": "python3"}},
+        "metadata": {
+            "kernelspec": {
+                "display_name": "Python 3",
+                "language": "python",
+                "name": "python3",
+            }
+        },
         "nbformat": 4,
-        "nbformat_minor": 4
+        "nbformat_minor": 4,
     }
 
     # Create notebook file
     notebook_file = tmp_path / "test_notebook.ipynb"
-    with open(notebook_file, 'w', encoding='utf-8') as f:
+    with open(notebook_file, "w", encoding="utf-8") as f:
         json.dump(notebook_content, f, ensure_ascii=False, indent=1)
 
     # Create markdown file for comparison
@@ -73,7 +83,9 @@ class TestJupyterNotebookIntegration:
         mock_jupyter_markdown_translator.create.return_value = MagicMock()
 
         # Create translator
-        translator = ProjectTranslator("ko", root_dir=temp_project_with_notebook, markdown_only=True)
+        translator = ProjectTranslator(
+            "ko", root_dir=temp_project_with_notebook, markdown_only=True
+        )
 
         # Verify notebook translator was created
         assert translator.notebook_translator is not None
@@ -98,31 +110,57 @@ class TestJupyterNotebookIntegration:
         # Setup mocks
         mock_get_provider.return_value = "azure"
         mock_text_translator.create.return_value = MagicMock()
-        
+
         # Mock markdown translator
         mock_md_translator = AsyncMock()
-        mock_md_translator.translate_markdown = AsyncMock(return_value="# Translated\nTranslated content")
+        mock_md_translator.translate_markdown = AsyncMock(
+            return_value="# Translated\nTranslated content"
+        )
         mock_markdown_translator.create.return_value = mock_md_translator
 
         # Mock jupyter notebook translator
         mock_jupyter_md_translator = AsyncMock()
-        mock_jupyter_md_translator.translate_markdown = AsyncMock(return_value="# Translated\nTranslated content")
-        mock_jupyter_markdown_translator.create.return_value = mock_jupyter_md_translator
+        mock_jupyter_md_translator.translate_markdown = AsyncMock(
+            return_value="# Translated\nTranslated content"
+        )
+        mock_jupyter_markdown_translator.create.return_value = (
+            mock_jupyter_md_translator
+        )
 
         # Create translator
-        translator = ProjectTranslator("ko", root_dir=temp_project_with_notebook, markdown_only=True)
+        translator = ProjectTranslator(
+            "ko", root_dir=temp_project_with_notebook, markdown_only=True
+        )
 
         # Mock the notebook translator's translate_notebook method
         mock_notebook_translator = AsyncMock()
         translated_notebook = {
             "cells": [
-                {"cell_type": "markdown", "metadata": {}, "source": ["# Translated\n", "Translated content"]},
-                {"cell_type": "code", "metadata": {}, "source": ["print('Hello, World!')"]},
-                {"cell_type": "markdown", "metadata": {}, "source": "## Translated Section\nTranslated content"}
+                {
+                    "cell_type": "markdown",
+                    "metadata": {},
+                    "source": ["# Translated\n", "Translated content"],
+                },
+                {
+                    "cell_type": "code",
+                    "metadata": {},
+                    "source": ["print('Hello, World!')"],
+                },
+                {
+                    "cell_type": "markdown",
+                    "metadata": {},
+                    "source": "## Translated Section\nTranslated content",
+                },
             ],
-            "metadata": {"kernelspec": {"display_name": "Python 3", "language": "python", "name": "python3"}},
+            "metadata": {
+                "kernelspec": {
+                    "display_name": "Python 3",
+                    "language": "python",
+                    "name": "python3",
+                }
+            },
             "nbformat": 4,
-            "nbformat_minor": 4
+            "nbformat_minor": 4,
         }
         mock_notebook_translator.translate_notebook = AsyncMock(
             return_value=json.dumps(translated_notebook, ensure_ascii=False, indent=1)
@@ -130,7 +168,9 @@ class TestJupyterNotebookIntegration:
         translator.translation_manager.notebook_translator = mock_notebook_translator
 
         # Run translation
-        total_modified, errors = await translator.translation_manager.translate_all_notebook_files()
+        total_modified, errors = (
+            await translator.translation_manager.translate_all_notebook_files()
+        )
 
         # Verify notebook translation was attempted
         assert mock_notebook_translator.translate_notebook.call_count >= 1
@@ -157,7 +197,9 @@ class TestJupyterNotebookIntegration:
         mock_jupyter_markdown_translator.create.return_value = MagicMock()
 
         # Create translator
-        translator = ProjectTranslator("ko", root_dir=temp_project_with_notebook, markdown_only=True)
+        translator = ProjectTranslator(
+            "ko", root_dir=temp_project_with_notebook, markdown_only=True
+        )
 
         # Simulate missing notebook translator
         translator.translation_manager.notebook_translator = None
@@ -168,4 +210,5 @@ class TestJupyterNotebookIntegration:
     def test_constants_include_notebook_extensions(self):
         """Test that notebook extensions are included in constants."""
         from co_op_translator.config.constants import SUPPORTED_NOTEBOOK_EXTENSIONS
+
         assert ".ipynb" in SUPPORTED_NOTEBOOK_EXTENSIONS

--- a/tests/co_op_translator/core/project/test_project_translator.py
+++ b/tests/co_op_translator/core/project/test_project_translator.py
@@ -2,6 +2,7 @@ import pytest
 import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 from co_op_translator.core.project.project_translator import ProjectTranslator
+from co_op_translator.config.llm_config.provider import LLMProvider
 
 
 @pytest.fixture
@@ -36,6 +37,9 @@ async def project_translator(temp_project_dir):
             "co_op_translator.core.vision.image_translator.ImageTranslator"
         ) as mock_image_translator,
         patch(
+            "co_op_translator.core.llm.jupyter_notebook_translator.JupyterNotebookTranslator"
+        ) as mock_jupyter_translator,
+        patch(
             "co_op_translator.config.llm_config.config.LLMConfig.get_available_provider"
         ) as mock_get_provider,
     ):
@@ -43,7 +47,8 @@ async def project_translator(temp_project_dir):
         mock_text_translator.create.return_value = MagicMock()
         mock_markdown_translator.create.return_value = MagicMock()
         mock_image_translator.create.return_value = MagicMock()
-        mock_get_provider.return_value = "azure"  # Mock LLM provider
+        mock_jupyter_translator.create.return_value = MagicMock()
+        mock_get_provider.return_value = LLMProvider.AZURE_OPENAI  # Mock LLM provider
 
         translator = ProjectTranslator("ko ja", root_dir=temp_project_dir)
         translator.translation_manager.translate_all_markdown_files = AsyncMock(
@@ -114,6 +119,9 @@ async def test_markdown_only_mode(temp_project_dir):
             "co_op_translator.core.llm.markdown_translator.MarkdownTranslator"
         ) as mock_markdown_translator,
         patch(
+            "co_op_translator.core.llm.jupyter_notebook_translator.JupyterNotebookTranslator"
+        ) as mock_jupyter_translator,
+        patch(
             "co_op_translator.config.llm_config.config.LLMConfig.get_available_provider"
         ) as mock_get_provider,
     ):
@@ -124,7 +132,10 @@ async def test_markdown_only_mode(temp_project_dir):
         mock_markdown_translator_instance = AsyncMock()
         mock_markdown_translator.create.return_value = mock_markdown_translator_instance
 
-        mock_get_provider.return_value = "azure"
+        mock_jupyter_translator_instance = AsyncMock()
+        mock_jupyter_translator.create.return_value = mock_jupyter_translator_instance
+
+        mock_get_provider.return_value = LLMProvider.AZURE_OPENAI
 
         # Create translator in markdown-only mode
         translator = ProjectTranslator(


### PR DESCRIPTION
## Purpose

<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->

Add support for selective translation of Jupyter notebook files through a new CLI option, allowing users to translate only notebook files when needed instead of processing all file types.

## Description

<!-- Provide a concise summary of your changes. Why is this change necessary? -->

This PR introduces a new --notebook/-n CLI option that enables users to translate only Jupyter notebook files (.ipynb). This complements the existing --markdown and --images options, providing more granular control over translation workflows.

### Key Changes:
- CLI Enhancement: Added --notebook/-n flag to the translate command
- Improved Logic: Enhanced translation mode determination to handle notebook-only translation
- Updated Pipeline: Modified ProjectTranslator and TranslationManager to support selective notebook translation
- Better UX: Updated help text and usage examples to include notebook translation scenarios

### Usage Example:

```
# Translate only notebook files
translate -l "ko" -n
translate -l "ko" --notebook

# Update existing notebook translations
translate -l "ko" -n -u

# Multiple languages for notebooks only
translate -l "ko ja fr" --notebook
```

## Related Issue

<!-- If this PR addresses an issue, please link it here (e.g., Fixes #123) -->

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

- [ ] Yes
- [x] No

## Type of change

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (e.g., formatting, local variables)
- [ ] Refactoring (no functional or API changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Checklist

Before submitting your pull request, please confirm the following:

- [x] **I have thoroughly tested my changes**: I confirm that I have run the code and manually tested all affected areas.
- [x] **All existing tests pass**: I have run all tests and confirmed that nothing is broken.
- [x] **I have added new tests** (if applicable): I have written tests that cover the new functionality introduced by my code changes.
- [x] **I have followed the Co-op Translators coding conventions**: My code adheres to the style guide and coding conventions outlined in the repository.
- [ ] **I have documented my changes** (if applicable): I have updated the documentation to reflect the changes where necessary.

## Additional context

<!-- Add any additional context or screenshots if applicable -->
