### PR TITLE
Docs: Add 6-hour time limit warning under 'Running the Workflow' section

### DIFF
--- a/getting_started/github-actions-guide/github-actions-guide-org.md
+++ b/getting_started/github-actions-guide/github-actions-guide-org.md
@@ -213,6 +213,14 @@ jobs:
 
 ## Running the Workflow
 
+> [!WARNING]  
+> **GitHub-hosted Runner Time Limit:**  
+> GitHub-hosted runners such as `ubuntu-latest` have a **maximum execution time limit of 6 hours**.  
+> For large documentation repositories, if the translation process exceeds 6 hours, the workflow will be automatically terminated.  
+> To prevent this, consider:  
+> - Using a **self-hosted runner** (no time limit)  
+> - Reducing the number of target languages per run
+
 Once the `co-op-translator.yml` file is merged into your main branch (or the branch specified in the `on:` trigger), the workflow will automatically run whenever changes are pushed to that branch (and match the `paths` filter, if configured).
 
 If translations are generated or updated, the action will automatically create a Pull Request containing the changes, ready for your review and merging.

--- a/getting_started/github-actions-guide/github-actions-guide-public.md
+++ b/getting_started/github-actions-guide/github-actions-guide-public.md
@@ -163,3 +163,15 @@ jobs:
   - **[!IMPORTANT] Target Languages:** In the `Run Co-op Translator` step, you **MUST review and modify the list of language codes** within the `translate -l "..." -y` command to match your project's requirements. The example list (`ar de es...`) needs to be replaced or adjusted.
   - **Trigger (`on:`):** The current trigger runs on every push to `main`. For large repositories, consider adding a `paths:` filter (see commented example in the YAML) to run the workflow only when relevant files (e.g., source documentation) change, saving runner minutes.
   - **PR Details:** Customize the `commit-message`, `title`, `body`, `branch` name, and `labels` in the `Create Pull Request` step if needed.
+
+## Running the Workflow
+
+> [!WARNING]  
+> **GitHub-hosted Runner Time Limit:**  
+> GitHub-hosted runners such as `ubuntu-latest` have a **maximum execution time limit of 6 hours**.  
+> For large documentation repositories, if the translation process exceeds 6 hours, the workflow will be automatically terminated.  
+> To prevent this, consider:  
+> - Using a **self-hosted runner** (no time limit)  
+> - Reducing the number of target languages per run
+
+Once the `co-op-translator.yml` file is merged into your main branch (or the branch specified in the `on:` trigger), the workflow will automatically run whenever changes are pushed to that branch (and match the `paths` filter, if configured).


### PR DESCRIPTION
## Purpose

<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->

## Description

<!-- Provide a concise summary of your changes. Why is this change necessary? -->

## Related Issue

<!-- If this PR addresses an issue, please link it here (e.g., Fixes #123) -->

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

- [ ] Yes
- [ ] No

## Type of change

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (e.g., formatting, local variables)
- [ ] Refactoring (no functional or API changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Checklist

Before submitting your pull request, please confirm the following:

- [ ] **I have thoroughly tested my changes**: I confirm that I have run the code and manually tested all affected areas.
- [ ] **All existing tests pass**: I have run all tests and confirmed that nothing is broken.
- [ ] **I have added new tests** (if applicable): I have written tests that cover the new functionality introduced by my code changes.
- [ ] **I have followed the Co-op Translators coding conventions**: My code adheres to the style guide and coding conventions outlined in the repository.
- [ ] **I have documented my changes** (if applicable): I have updated the documentation to reflect the changes where necessary.

## Additional context

<!-- Add any additional context or screenshots if applicable -->
