### PR TITLE
Core: Implement structured outputs to resolve translation issues

### DIFF
--- a/src/co_op_translator/utils/llm/text_utils.py
+++ b/src/co_op_translator/utils/llm/text_utils.py
@@ -5,13 +5,22 @@ Functions include generating translation prompts and processing responses from O
 
 import re
 import logging
+from typing import List
+from pydantic import BaseModel
+
+
+class TranslationResponse(BaseModel):
+    """Schema for structured translation output."""
+
+    translations: List[str]
+
 
 logger = logging.getLogger(__name__)
 
 
 def gen_image_translation_prompt(text_data, language_code, language_name):
     """
-    Generate a translation prompt for the given text data.
+    Generate a translation prompt for structured output.
 
     Args:
         text_data (list): List of text lines to be translated.
@@ -19,15 +28,11 @@ def gen_image_translation_prompt(text_data, language_code, language_name):
         language_name (str): Target language name for translation.
 
     Returns:
-        str: Generated translation prompt.
+        str: Generated translation prompt for structured output.
     """
-    prompt = f"""
-    You are a translator that receives a batch of lines in an image. Given the following yaml file, please translate each line into {language_name} ({language_code}).
-    For each line, fill it in with the translation, respecting the context of the text.
-    Return only the yaml file, fully filled in.
-    """
-    for line in text_data:
-        prompt += f"- {line}\n"
+    prompt = f"Translate each line to {language_name} ({language_code}). Keep exact same number of lines:\n\n"
+    for i, line in enumerate(text_data, 1):
+        prompt += f"{i}. {line}\n"
     return prompt
 
 
@@ -43,18 +48,3 @@ def remove_code_backticks(message):
     """
     match = re.match(r"```(?:\w+)?\n(.*?)\n```", message, re.DOTALL)
     return match.group(1) if match else message
-
-
-def extract_yaml_lines(message):
-    """
-    Extract YAML lines from a message.
-
-    Args:
-        message (str): The message containing YAML lines.
-
-    Returns:
-        list: List of extracted YAML lines.
-    """
-    lines = message.split("\n")
-    yaml_lines = [line[2:] for line in lines if line.startswith("- ")]
-    return yaml_lines

--- a/tests/co_op_translator/core/llm/test_jupyter_notebook_translator.py
+++ b/tests/co_op_translator/core/llm/test_jupyter_notebook_translator.py
@@ -291,7 +291,7 @@ class TestJupyterNotebookTranslator:
         # Setup mock
         mock_translator = AsyncMock()
         mock_translator.translate_markdown = AsyncMock(
-            return_value="# 번역된 제목\n\n번역된 내용"
+            return_value="# Translated Title\n\nTranslated content"
         )
         mock_markdown_translator_class.create.return_value = mock_translator
 
@@ -332,10 +332,10 @@ class TestJupyterNotebookTranslator:
         # Setup mock translator
         mock_translator = AsyncMock()
         mock_translator.translate_markdown = AsyncMock(
-            return_value="# 번역된 제목\n\n번역된 내용"
+            return_value="# Translated Title\n\nTranslated content"
         )
         mock_translator.generate_disclaimer = AsyncMock(
-            return_value="**면책조항**: 이 문서는 AI 번역 서비스를 사용하여 번역되었습니다."
+            return_value="**Disclaimer**: This document has been translated using an AI translation service."
         )
         mock_markdown_translator_class.create.return_value = mock_translator
 
@@ -355,7 +355,7 @@ class TestJupyterNotebookTranslator:
         disclaimer_cell = cells[-1]  # Last cell should be disclaimer
         assert disclaimer_cell["cell_type"] == "markdown"
         disclaimer_content = "".join(disclaimer_cell["source"])
-        assert "면책조항" in disclaimer_content
+        assert "Disclaimer" in disclaimer_content
         assert "---" in disclaimer_content  # Separator line
 
         # Verify generate_disclaimer was called
@@ -370,10 +370,10 @@ class TestJupyterNotebookTranslator:
         # Setup mock translator
         mock_translator = AsyncMock()
         mock_translator.translate_markdown = AsyncMock(
-            return_value="# 번역된 제목\n\n번역된 내용"
+            return_value="# Translated Title\n\nTranslated content"
         )
         mock_translator.generate_disclaimer = AsyncMock(
-            return_value="**면책조항**: 이 문서는 AI 번역 서비스를 사용하여 번역되었습니다."
+            return_value="**Disclaimer**: This document has been translated using an AI translation service."
         )
         mock_markdown_translator_class.create.return_value = mock_translator
 
@@ -402,7 +402,7 @@ class TestJupyterNotebookTranslator:
         # Setup mock translator with failing disclaimer generation
         mock_translator = AsyncMock()
         mock_translator.translate_markdown = AsyncMock(
-            return_value="# 번역된 제목\n\n번역된 내용"
+            return_value="# Translated Title\n\nTranslated content"
         )
         mock_translator.generate_disclaimer = AsyncMock(
             return_value=""  # Empty disclaimer (failure case)

--- a/tests/co_op_translator/core/llm/test_markdown_evaluator.py
+++ b/tests/co_op_translator/core/llm/test_markdown_evaluator.py
@@ -64,7 +64,7 @@ class TestGenerateEvaluationPrompt:
         """Verify the prompt includes all required sections and formatting."""
         # Arrange
         original = "Test content"
-        translated = "테스트 콘텐츠"
+        translated = "Test content"
         language_code = "ko"
         language_name = "Korean"
 
@@ -114,7 +114,7 @@ class TestGenerateEvaluationPrompt:
     def test_basic_functionality(self):
         """Test basic functionality of generate_evaluation_prompt."""
         original = "# Hello World\nThis is a test document."
-        translated = "# 안녕 세상\n이것은 테스트 문서입니다."
+        translated = "# Hello World\nThis is a test document."
         language_code = "ko"
         language_name = "Korean"
 
@@ -187,7 +187,7 @@ class TestRuleBasedEvaluation:
     @pytest.mark.parametrize(
         "original,translated,expected_score,description",
         [
-            ("Short text", "짧은 텍스트", 1.0, "Similar length"),
+            ("Short text", "Short text", 1.0, "Similar length"),
             (
                 "Short text",
                 "This is a much longer translated text that might indicate issues",
@@ -197,13 +197,13 @@ class TestRuleBasedEvaluation:
             ("", "", 1.0, "Empty strings"),
             (
                 "Test with code: ```print('hi')```",
-                "테스트 코드: ```print('hi')```",
+                "Test code: ```print('hi')```",
                 1.0,
                 "Code block preservation",
             ),
             (
                 "Test with [link](test.md)",
-                "[링크](test.md) 테스트",
+                "[link](test.md) test",
                 1.0,
                 "Link preservation",
             ),
@@ -239,7 +239,7 @@ class TestRuleBasedEvaluation:
         )
 
         original = SAMPLE_MD_CONTENT
-        translated = SAMPLE_MD_CONTENT.replace("Sample Document", "샘플 문서")
+        translated = SAMPLE_MD_CONTENT.replace("Sample Document", "Sample Document")
 
         # Act
         result = evaluate_translation_rule_based(original, translated, "ko")

--- a/tests/co_op_translator/core/llm/test_text_translator.py
+++ b/tests/co_op_translator/core/llm/test_text_translator.py
@@ -22,7 +22,7 @@ class MockTextTranslator(TextTranslator):
             MagicMock(
                 message=MagicMock(
                     parsed=TranslationResponse(
-                        translations=["번역된 라인 1", "번역된 라인 2"]
+                        translations=["Translated line 1", "Translated line 2"]
                     )
                 )
             )
@@ -88,7 +88,7 @@ def test_translate_image_text(text_translator):
     target_language = "ko"
     result = text_translator.translate_image_text(text_data, target_language)
 
-    assert result == ["번역된 라인 1", "번역된 라인 2"]
+    assert result == ["Translated line 1", "Translated line 2"]
     assert len(result) == len(text_data)
     # Verify structured output was used
     text_translator.client.chat.completions.parse.assert_called_once()

--- a/tests/co_op_translator/core/llm/test_text_translator.py
+++ b/tests/co_op_translator/core/llm/test_text_translator.py
@@ -1,6 +1,7 @@
 import pytest
 from unittest.mock import MagicMock
 from co_op_translator.core.llm.text_translator import TextTranslator
+from co_op_translator.utils.llm.text_utils import TranslationResponse
 
 
 class MockTextTranslator(TextTranslator):
@@ -8,18 +9,37 @@ class MockTextTranslator(TextTranslator):
 
     def __init__(self):
         self.client = self.get_openai_client()
+        # Mock font_config
+        self.font_config = MagicMock()
+        self.font_config.get_language_name.return_value = "Korean"
 
     def get_openai_client(self):
         mock_client = MagicMock()
+
+        # Mock for structured outputs (translate_image_text)
+        mock_parsed_response = MagicMock()
+        mock_parsed_response.choices = [
+            MagicMock(
+                message=MagicMock(
+                    parsed=TranslationResponse(
+                        translations=["번역된 라인 1", "번역된 라인 2"]
+                    )
+                )
+            )
+        ]
+        mock_client.chat.completions.parse.return_value = mock_parsed_response
+
+        # Mock for regular text translation
         mock_response = MagicMock()
         mock_response.choices = [
             MagicMock(message=MagicMock(content="```\nTranslated Text\n```"))
         ]
         mock_client.chat.completions.create.return_value = mock_response
+
         return mock_client
 
     def get_model_name(self):
-        return "gpt-4"
+        return "gpt-4o"
 
     def translate_batch(self, texts, target_language):
         """Mock implementation of translate_batch."""
@@ -58,3 +78,25 @@ def test_translate_batch(text_translator):
     result = text_translator.translate_batch(texts, target_language)
 
     assert result == ["Translated: Line 1", "Translated: Line 2"]
+
+
+def test_translate_image_text(text_translator):
+    """
+    Test the translate_image_text method using structured outputs.
+    """
+    text_data = ["Line 1", "Line 2"]
+    target_language = "ko"
+    result = text_translator.translate_image_text(text_data, target_language)
+
+    assert result == ["번역된 라인 1", "번역된 라인 2"]
+    assert len(result) == len(text_data)
+    # Verify structured output was used
+    text_translator.client.chat.completions.parse.assert_called_once()
+
+
+def test_translate_image_text_empty(text_translator):
+    """
+    Test the translate_image_text method with empty input.
+    """
+    result = text_translator.translate_image_text([], "ko")
+    assert result == []

--- a/tests/co_op_translator/core/project/test_translation_manager.py
+++ b/tests/co_op_translator/core/project/test_translation_manager.py
@@ -164,7 +164,7 @@ async def test_get_outdated_translations(mock_translation_manager, temp_project_
     test_md.write_text("# Test Document\nThis is a test.", encoding="utf-8")
     ko_test_md = ko_dir / "test.md"
     ko_test_md.parent.mkdir(parents=True, exist_ok=True)
-    ko_test_md.write_text("# 테스트 문서\n이것은 테스트입니다.", encoding="utf-8")
+    ko_test_md.write_text("# Test Document\nThis is a test.", encoding="utf-8")
 
     # Mock _is_translation_outdated to return True for our test file
     mock_translation_manager._is_translation_outdated = MagicMock(return_value=True)
@@ -195,7 +195,7 @@ async def test_retranslate_outdated_files(mock_translation_manager, temp_project
     ko_dir = temp_project_dir / "translations" / "ko"
     ko_dir.mkdir(parents=True, exist_ok=True)
     ko_test_md = ko_dir / "test.md"
-    ko_test_md.write_text("# 테스트 문서\n이것은 테스트입니다.", encoding="utf-8")
+    ko_test_md.write_text("# Test Document\nThis is a test.", encoding="utf-8")
 
     # Create a list of outdated files
     outdated_files = [(test_md, ko_test_md)]
@@ -203,7 +203,7 @@ async def test_retranslate_outdated_files(mock_translation_manager, temp_project
     # Mock translate_markdown
     mock_translation_manager.markdown_translator = MagicMock()
     mock_translation_manager.markdown_translator.translate_markdown = AsyncMock(
-        return_value="# 테스트 문서\n이것은 테스트입니다."
+        return_value="# Test Document\nThis is a test."
     )
     mock_translation_manager.markdown_translator.create_metadata = MagicMock(
         return_value={"file_hash": "test_hash"}
@@ -289,7 +289,7 @@ async def test_translate_notebook_basic(mock_translation_manager, temp_project_d
         return_value=json.dumps(
             {
                 "cells": [
-                    {"cell_type": "markdown", "source": ["# 테스트 노트북"]},
+                    {"cell_type": "markdown", "source": ["# Test Notebook"]},
                     {"cell_type": "code", "source": ["print('hello')"]},
                 ],
                 "metadata": {
@@ -385,7 +385,7 @@ async def test_translate_all_notebook_files_with_hash_check(temp_project_dir):
     # Create existing translated notebook (up-to-date)
     translated_notebook = ko_dir / "test.ipynb"
     translated_content = {
-        "cells": [{"cell_type": "markdown", "source": ["# 원본"]}],
+        "cells": [{"cell_type": "markdown", "source": ["# Original"]}],
         "metadata": {
             "coopTranslator": {
                 "original_hash": "current_hash",  # Will be mocked to match
@@ -468,7 +468,7 @@ async def test_translate_all_notebook_files_outdated(temp_project_dir):
     # Create existing translated notebook (outdated)
     translated_notebook = ko_dir / "test.ipynb"
     translated_content = {
-        "cells": [{"cell_type": "markdown", "source": ["# 이전 버전"]}],
+        "cells": [{"cell_type": "markdown", "source": ["# Previous version"]}],
         "metadata": {
             "coopTranslator": {
                 "original_hash": "old_hash",  # Different from current

--- a/tests/co_op_translator/core/vision/test_image_translator.py
+++ b/tests/co_op_translator/core/vision/test_image_translator.py
@@ -203,7 +203,7 @@ def test_translate_batch_with_various_inputs():
         "Hello",
         "123",
         "Special !@#$%^&*() chars",
-        "한글도 테스트",
+        "Korean text test",
         " Leading and trailing spaces ",
     ]
     target_language = "ko"
@@ -233,7 +233,7 @@ def test_plot_annotated_image_with_multiple_boxes(image_translator, tmp_path):
             "confidence": 0.95,
         },
     ]
-    translated_texts = ["번역 1", "번역 2"]
+    translated_texts = ["Translation 1", "Translation 2"]
     target_language = "ko"
 
     result_path = image_translator.plot_annotated_image(

--- a/tests/co_op_translator/utils/common/test_metadata_utils.py
+++ b/tests/co_op_translator/utils/common/test_metadata_utils.py
@@ -273,7 +273,7 @@ def test_is_notebook_up_to_date(tmp_path):
     # Create translated notebook with correct hash
     translated_file = tmp_path / "translated.ipynb"
     translated_content = {
-        "cells": [{"cell_type": "markdown", "source": ["# 번역됨"]}],
+        "cells": [{"cell_type": "markdown", "source": ["# Translated"]}],
         "metadata": {
             "coopTranslator": {
                 "original_hash": original_hash,
@@ -291,7 +291,7 @@ def test_is_notebook_up_to_date(tmp_path):
     # Create translated notebook with incorrect hash
     outdated_translated_file = tmp_path / "outdated.ipynb"
     outdated_content = {
-        "cells": [{"cell_type": "markdown", "source": ["# 오래된 번역"]}],
+        "cells": [{"cell_type": "markdown", "source": ["# Outdated translation"]}],
         "metadata": {
             "coopTranslator": {
                 "original_hash": "wrong_hash",

--- a/tests/co_op_translator/utils/llm/test_text_utils.py
+++ b/tests/co_op_translator/utils/llm/test_text_utils.py
@@ -1,7 +1,7 @@
 from co_op_translator.utils.llm.text_utils import (
     remove_code_backticks,
-    extract_yaml_lines,
     gen_image_translation_prompt,
+    TranslationResponse,
 )
 
 
@@ -19,25 +19,8 @@ def test_remove_code_backticks():
         assert result == expected
 
 
-def test_extract_yaml_lines():
-    """Test extracting YAML lines from messages."""
-    test_cases = [
-        (
-            "- text: Hello\n- key: value\n---\nother content",
-            ["text: Hello", "key: value"],
-        ),
-        ("no yaml content", []),
-        ("- key1: value1\n- key2: value2", ["key1: value1", "key2: value2"]),
-    ]
-
-    for input_text, expected in test_cases:
-        result = extract_yaml_lines(input_text)
-        result = [line.strip() for line in result]  # Remove whitespace and newlines
-        assert result == expected
-
-
 def test_gen_image_translation_prompt():
-    """Test generating image translation prompts."""
+    """Test generating image translation prompts with numbered format."""
     text_data = ["Line 1", "Line 2", "Line 3"]
     language_code = "ko"
     language_name = "Korean"
@@ -47,7 +30,10 @@ def test_gen_image_translation_prompt():
     assert isinstance(prompt, str)
     assert language_code in prompt
     assert language_name in prompt
-    assert all(line in prompt for line in text_data)
+    assert "Keep exact same number of lines" in prompt
+    assert "1. Line 1" in prompt
+    assert "2. Line 2" in prompt
+    assert "3. Line 3" in prompt
 
 
 def test_gen_image_translation_prompt_empty():
@@ -69,3 +55,13 @@ def test_gen_image_translation_prompt_special_chars():
 
     assert isinstance(prompt, str)
     assert all(line in prompt for line in text_data)
+
+
+def test_translation_response():
+    """Test TranslationResponse Pydantic model."""
+    translations = ["번역된 라인 1", "번역된 라인 2", "번역된 라인 3"]
+    response = TranslationResponse(translations=translations)
+
+    assert response.translations == translations
+    assert len(response.translations) == 3
+    assert response.translations[0] == "번역된 라인 1"

--- a/tests/co_op_translator/utils/llm/test_text_utils.py
+++ b/tests/co_op_translator/utils/llm/test_text_utils.py
@@ -59,9 +59,9 @@ def test_gen_image_translation_prompt_special_chars():
 
 def test_translation_response():
     """Test TranslationResponse Pydantic model."""
-    translations = ["번역된 라인 1", "번역된 라인 2", "번역된 라인 3"]
+    translations = ["Translated line 1", "Translated line 2", "Translated line 3"]
     response = TranslationResponse(translations=translations)
-
+    
     assert response.translations == translations
     assert len(response.translations) == 3
-    assert response.translations[0] == "번역된 라인 1"
+    assert response.translations[0] == "Translated line 1"


### PR DESCRIPTION
## Purpose

<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->

Fix critical translation issues by implementing OpenAI structured outputs to ensure accurate text positioning and eliminate output inconsistencies. This addresses Arabic ligature rendering problems and Korean translation duplication issues that were caused by inconsistent line count mapping between input and output text.

## Description

<!-- Provide a concise summary of your changes. Why is this change necessary? -->

This PR replaces the existing YAML-based translation approach with OpenAI's structured outputs feature, which guarantees exact 1:1 line mapping between source and translated text. The previous implementation relied on manual YAML parsing that sometimes resulted in mismatched line counts, causing:

- Arabic ligature issues (#123): Text positioned incorrectly due to line count mismatches
- Korean translation duplication (#204): Both English and Korean text appearing in output

Key Changes:

- Replace YAML-based translation with OpenAI structured outputs
- Ensure 1:1 line mapping for accurate text positioning
- Fix Arabic ligature rendering issues
- Resolve Korean translation showing both English and Korean text
- Remove unused extract_yaml_lines function
- Update tests for new structured output approach

## Related Issue

<!-- If this PR addresses an issue, please link it here (e.g., Fixes #123) -->

Fixes #123, #204

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

- [ ] Yes
- [x] No

## Type of change

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (e.g., formatting, local variables)
- [ ] Refactoring (no functional or API changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Checklist

Before submitting your pull request, please confirm the following:

- [x] **I have thoroughly tested my changes**: I confirm that I have run the code and manually tested all affected areas.
- [x] **All existing tests pass**: I have run all tests and confirmed that nothing is broken.
- [ ] **I have added new tests** (if applicable): I have written tests that cover the new functionality introduced by my code changes.
- [x] **I have followed the Co-op Translators coding conventions**: My code adheres to the style guide and coding conventions outlined in the repository.
- [ ] **I have documented my changes** (if applicable): I have updated the documentation to reflect the changes where necessary.

## Additional context

<!-- Add any additional context or screenshots if applicable -->
<img width="638" height="378" alt="image" src="https://github.com/user-attachments/assets/eb8484ea-0176-40cf-86ea-66dbba8bd57c" />
<img width="638" height="378" alt="image 4ee84a82b5e4c9e6651b13fd27dcf615e427ec584929f2cef7167aa99151a77a ar" src="https://github.com/user-attachments/assets/abcb2d98-7989-4992-9350-802d82bbe7e8" />
<img width="638" height="378" alt="image 4ee84a82b5e4c9e6651b13fd27dcf615e427ec584929f2cef7167aa99151a77a ko" src="https://github.com/user-attachments/assets/5d975805-0fe1-44ab-8ffb-361465aeda59" />

---

<img width="1920" height="1080" alt="repo-thumbnailv4-fixed" src="https://github.com/user-attachments/assets/811d193d-b6cf-4f9a-b22c-066c3dfc9bd7" />
<img width="1920" height="1080" alt="repo-thumbnailv4-fixed 973f8d50317d195e5f14af4455b4b42b5e7da9378b12e4ec900a5e2db28963e0 ko" src="https://github.com/user-attachments/assets/5bb43831-fdc0-40b2-9950-d996e79d7a03" />
<img width="1920" height="1080" alt="repo-thumbnailv4-fixed 973f8d50317d195e5f14af4455b4b42b5e7da9378b12e4ec900a5e2db28963e0 ar" src="https://github.com/user-attachments/assets/bcdf54c6-3bc8-4e2f-8ad3-cbfd6cbe595a" />


