### PR TITLE
Remove unwanted numbering from image translation prompts

### DIFF
--- a/src/co_op_translator/utils/llm/text_utils.py
+++ b/src/co_op_translator/utils/llm/text_utils.py
@@ -30,9 +30,9 @@ def gen_image_translation_prompt(text_data, language_code, language_name):
     Returns:
         str: Generated translation prompt for structured output.
     """
-    prompt = f"Translate each line to {language_name} ({language_code}). Keep exact same number of lines:\n\n"
-    for i, line in enumerate(text_data, 1):
-        prompt += f"{i}. {line}\n"
+    prompt = f"Translate each line to {language_name} ({language_code}). Keep exact same number of lines and preserve original formatting:\n\n"
+    for line in text_data:
+        prompt += f"{line}\n"
     return prompt
 
 

--- a/tests/co_op_translator/utils/llm/test_text_utils.py
+++ b/tests/co_op_translator/utils/llm/test_text_utils.py
@@ -20,7 +20,7 @@ def test_remove_code_backticks():
 
 
 def test_gen_image_translation_prompt():
-    """Test generating image translation prompts with numbered format."""
+    """Test generating image translation prompts without numbering."""
     text_data = ["Line 1", "Line 2", "Line 3"]
     language_code = "ko"
     language_name = "Korean"
@@ -31,9 +31,14 @@ def test_gen_image_translation_prompt():
     assert language_code in prompt
     assert language_name in prompt
     assert "Keep exact same number of lines" in prompt
-    assert "1. Line 1" in prompt
-    assert "2. Line 2" in prompt
-    assert "3. Line 3" in prompt
+    assert "preserve original formatting" in prompt
+    assert "Line 1\n" in prompt
+    assert "Line 2\n" in prompt
+    assert "Line 3\n" in prompt
+    # Ensure no numbering is added
+    assert "1. Line 1" not in prompt
+    assert "2. Line 2" not in prompt
+    assert "3. Line 3" not in prompt
 
 
 def test_gen_image_translation_prompt_empty():


### PR DESCRIPTION
## Purpose

<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->

- Remove automatic line numbering (1., 2., etc.) from gen_image_translation_prompt
- Add "preserve original formatting" instruction to translation prompt
- Ensures translated text maintains original format without added numbers
- Fixes issue where images without numbering were getting numbered translations

## Description

<!-- Provide a concise summary of your changes. Why is this change necessary? -->

## Related Issue

<!-- If this PR addresses an issue, please link it here (e.g., Fixes #123) -->

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

- [ ] Yes
- [ ] No

## Type of change

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (e.g., formatting, local variables)
- [ ] Refactoring (no functional or API changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Checklist

Before submitting your pull request, please confirm the following:

- [ ] **I have thoroughly tested my changes**: I confirm that I have run the code and manually tested all affected areas.
- [ ] **All existing tests pass**: I have run all tests and confirmed that nothing is broken.
- [ ] **I have added new tests** (if applicable): I have written tests that cover the new functionality introduced by my code changes.
- [ ] **I have followed the Co-op Translators coding conventions**: My code adheres to the style guide and coding conventions outlined in the repository.
- [ ] **I have documented my changes** (if applicable): I have updated the documentation to reflect the changes where necessary.

## Additional context

<!-- Add any additional context or screenshots if applicable -->
