### PR TITLE
Add migrate-links command

### DIFF
--- a/getting_started/command-reference.md
+++ b/getting_started/command-reference.md
@@ -19,6 +19,11 @@ evaluate -l "language_code"                  | Evaluates translation quality for
 evaluate -l "language_code" -c 0.8           | Evaluates translations with custom confidence threshold
 evaluate -l "language_code" -f               | Fast evaluation mode (rule-based only, no LLM)
 evaluate -l "language_code" -D               | Deep evaluation mode (LLM-based only, more thorough but slower)
+migrate-links -l "language_codes"             | Reprocess translated Markdown files to update links to notebooks (.ipynb). Prefers translated notebooks when available; otherwise can fall back to original notebooks.
+migrate-links -l "language_codes" -r          | Specify the project root directory (default: current directory).
+migrate-links -l "language_codes" --dry-run   | Show which files would change without writing changes.
+migrate-links -l "language_codes" --no-fallback-to-original | Do not rewrite links to original notebooks when translated counterparts are missing (only update when translated exists).
+migrate-links -l "language_codes" -d          | Enable debug mode for detailed logging.
 
 ## Usage examples
 
@@ -43,6 +48,12 @@ evaluate -l "language_code" -D               | Deep evaluation mode (LLM-based o
   10. Fix low confidence translations with custom threshold: translate -l "ko" --fix -c 0.8
 
   11. Debug mode example: - translate -l "ko" -d: Enable debug logging.
+
+  12. Migrate notebook links for Korean translations (update links to translated notebooks when available):    migrate-links -l "ko"
+
+  13. Migrate links with dry-run (no file writes):    migrate-links -l "ko" --dry-run
+
+  14. Only update links when translated notebooks exist (do not fallback to originals):    migrate-links -l "ko" --no-fallback-to-original
 
 ### Evaluation Examples
 

--- a/getting_started/command-reference.md
+++ b/getting_started/command-reference.md
@@ -24,6 +24,7 @@ migrate-links -l "language_codes" -r          | Specify the project root directo
 migrate-links -l "language_codes" --dry-run   | Show which files would change without writing changes.
 migrate-links -l "language_codes" --no-fallback-to-original | Do not rewrite links to original notebooks when translated counterparts are missing (only update when translated exists).
 migrate-links -l "language_codes" -d          | Enable debug mode for detailed logging.
+migrate-links -l "all" -y                      | Process all languages and auto-confirm the warning prompt.
 
 ## Usage examples
 
@@ -54,6 +55,10 @@ migrate-links -l "language_codes" -d          | Enable debug mode for detailed l
   13. Migrate links with dry-run (no file writes):    migrate-links -l "ko" --dry-run
 
   14. Only update links when translated notebooks exist (do not fallback to originals):    migrate-links -l "ko" --no-fallback-to-original
+
+  15. Process all languages with confirmation prompt:    migrate-links -l "all"
+
+  16. Process all languages and auto-confirm:    migrate-links -l "all" -y
 
 ### Evaluation Examples
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ documentation = "https://github.com/Azure/co-op-translator/tree/main/getting_sta
 [tool.poetry.scripts]
 translate = "co_op_translator.__main__:main"
 evaluate = "co_op_translator.__main__:main"
+migrate-links = "co_op_translator.__main__:main"
 
 [tool.poetry.dependencies]
 python = ">=3.10,<3.13"

--- a/src/co_op_translator/__main__.py
+++ b/src/co_op_translator/__main__.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 from co_op_translator.cli.translate import translate_command
 from co_op_translator.cli.evaluate import evaluate_command
+from co_op_translator.cli.migrate_links import migrate_links_command
 
 logger = logging.getLogger(__name__)
 
@@ -20,12 +21,9 @@ def main():
     """
     script_name = Path(sys.argv[0]).name
     if script_name == "evaluate":
-        command_name = "evaluate"
-    else:
-        command_name = "translate"
-
-    if command_name == "evaluate":
         evaluate_command()
+    elif script_name == "migrate-links":
+        migrate_links_command()
     else:
         translate_command()
 

--- a/src/co_op_translator/cli/migrate_links.py
+++ b/src/co_op_translator/cli/migrate_links.py
@@ -51,7 +51,7 @@ logger = logging.getLogger(__name__)
         "Enabled by default."
     ),
 )
-@click.option("--debug", is_flag=True, help="Enable debug logging.")
+@click.option("-d", "--debug", is_flag=True, help="Enable debug logging.")
 def migrate_links_command(
     language_codes, root_dir, dry_run, fallback_to_original, debug
 ):
@@ -60,11 +60,12 @@ def migrate_links_command(
     update links to point to translated notebooks when available.
     """
     try:
-        # Basic logging setup
+        # Basic logging setup (align with translate.py)
         if debug:
             logging.basicConfig(level=logging.DEBUG)
+            logging.debug("Debug mode enabled.")
         else:
-            logging.basicConfig(level=logging.INFO)
+            logging.basicConfig(level=logging.CRITICAL)
 
         # Validate root directory and config
         Config.check_configuration()
@@ -79,7 +80,7 @@ def migrate_links_command(
 
         translations_dir = root_path / "translations"
         if not translations_dir.exists():
-            click.echo("No translations directory found. Nothing to migrate.")
+            click.echo(f"No translations directory found at: {translations_dir}")
             return
 
         # Parse language codes list

--- a/src/co_op_translator/cli/migrate_links.py
+++ b/src/co_op_translator/cli/migrate_links.py
@@ -1,0 +1,300 @@
+"""
+Migrate-links command: reprocess translated markdowns that contain .ipynb links
+to update them to translated notebooks when available (and keep originals otherwise).
+
+This performs link-only processing using utils.llm.markdown_utils.update_links(),
+so there are no LLM calls and it's fast and idempotent.
+"""
+
+import logging
+from pathlib import Path
+import click
+import os
+import re
+from urllib.parse import urlparse
+from tqdm import tqdm
+
+from co_op_translator.config.base_config import Config
+from co_op_translator.utils.llm.markdown_utils import (
+    migrate_notebook_links,
+    update_notebook_links,
+)
+from co_op_translator.utils.common.file_utils import map_original_to_translated
+
+logger = logging.getLogger(__name__)
+
+
+@click.command(name="migrate-links")
+@click.option(
+    "--language-codes",
+    "-l",
+    required=True,
+    help='Space-separated language codes to process (e.g., "ko ja").',
+)
+@click.option(
+    "--root-dir",
+    "-r",
+    default=".",
+    help="Root directory of the project (default is current directory).",
+)
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    default=False,
+    help="Perform a dry run without writing changes.",
+)
+@click.option(
+    "--fallback-to-original/--no-fallback-to-original",
+    default=True,
+    help=(
+        "If a translated notebook is missing, rewrite links to point to the original notebook. "
+        "Enabled by default."
+    ),
+)
+@click.option("--debug", is_flag=True, help="Enable debug logging.")
+def migrate_links_command(
+    language_codes, root_dir, dry_run, fallback_to_original, debug
+):
+    """
+    Reprocess only translated markdown files that contain .ipynb links and
+    update links to point to translated notebooks when available.
+    """
+    try:
+        # Basic logging setup
+        if debug:
+            logging.basicConfig(level=logging.DEBUG)
+        else:
+            logging.basicConfig(level=logging.INFO)
+
+        # Validate root directory and config
+        Config.check_configuration()
+
+        root_path = Path(root_dir).resolve()
+        if not root_path.exists() or not root_path.is_dir():
+            raise click.ClickException(f"Invalid root directory: {root_dir}")
+        if not os.access(root_path, os.R_OK | os.W_OK):
+            raise click.ClickException(
+                f"Insufficient permissions for directory: {root_dir}"
+            )
+
+        translations_dir = root_path / "translations"
+        if not translations_dir.exists():
+            click.echo("No translations directory found. Nothing to migrate.")
+            return
+
+        # Parse language codes list
+        lang_list = [code.strip() for code in language_codes.split() if code.strip()]
+        if not lang_list:
+            raise click.ClickException("No valid language codes provided.")
+
+        total_scanned = 0
+        total_matched = 0  # files with at least one actionable in-root .ipynb link
+        total_changed = 0
+        total_candidates_updatable = 0  # files needing at least one update
+        total_candidates_already = (
+            0  # files where all actionable links already point to translation
+        )
+        total_candidates_missing = (
+            0  # files where actionable links lack translated counterpart
+        )
+
+        for lang in lang_list:
+            lang_dir = translations_dir / lang
+            if not lang_dir.exists():
+                logger.info(f"Language directory missing, skipping: {lang_dir}")
+                continue
+
+            # Find translated markdowns and show progress bar
+            md_files = list(lang_dir.rglob("*.md"))
+            for md_translated in tqdm(md_files, desc=f"{lang} md", unit="file"):
+                total_scanned += 1
+                try:
+                    content = md_translated.read_text(encoding="utf-8")
+                except Exception:
+                    logger.warning(f"Failed to read: {md_translated}")
+                    continue
+
+                # Quick filter: only process files containing .ipynb links
+                if ".ipynb" not in content:
+                    continue
+
+                # Derive original md path from translated path (needed to resolve links)
+                try:
+                    relative = md_translated.relative_to(lang_dir)
+                except ValueError:
+                    logger.warning(
+                        f"Cannot compute relative path for {md_translated}, skipping."
+                    )
+                    continue
+
+                original_md_path = (root_path / relative).resolve()
+
+                # Analyze .ipynb links within root for this file
+                actionable_links = []
+                already_translated = (
+                    True  # assume already translated until proven otherwise
+                )
+                missing_translation = True  # assume missing until we find at least one translated counterpart
+
+                for alt_text, link in re.findall(r"\[(.*?)\]\((.*?)\)", content):
+                    # Normalize possible angle-bracketed URL and strip markdown title
+                    raw = link.strip()
+                    if raw.startswith("<") and ">" in raw:
+                        raw = raw[1 : raw.index(">")]
+                    # Drop optional title: (url "title") or (url 'title')
+                    if '"' in raw or "'" in raw:
+                        raw = raw.split()[0]
+                    parsed = urlparse(raw)
+                    if parsed.scheme in ("mailto", "http", "https") or "@" in link:
+                        continue
+                    path = parsed.path
+                    if not path.lower().endswith(".ipynb"):
+                        continue
+                    # Resolve absolute path of the linked notebook
+                    if path.startswith("/"):
+                        linked_abs = (root_path / path.lstrip("/")).resolve()
+                    else:
+                        linked_abs = (original_md_path.parent / path).resolve()
+                        try:
+                            _ = linked_abs.relative_to(root_path)
+                        except ValueError:
+                            # Try resolving relative to translated markdown directory, then map back to root
+                            translated_md_dir = (
+                                (root_path / "translations")
+                                / lang
+                                / original_md_path.relative_to(root_path).parent
+                            )
+                            alt_abs = (translated_md_dir / path).resolve()
+                            try:
+                                rel_to_lang = alt_abs.relative_to(
+                                    (root_path / "translations") / lang
+                                )
+                                linked_abs = (root_path / rel_to_lang).resolve()
+                                _ = linked_abs.relative_to(root_path)
+                            except Exception:
+                                # If not under translations/<lang>, but under root, accept as-is
+                                try:
+                                    _ = alt_abs.relative_to(root_path)
+                                    linked_abs = alt_abs
+                                except Exception:
+                                    continue  # still outside root
+
+                    # Determine translated counterpart if exists
+                    candidate_translated = map_original_to_translated(
+                        original_abs=linked_abs,
+                        language_code=lang,
+                        root_dir=root_path,
+                    )
+
+                    actionable_links.append(
+                        (alt_text, link, linked_abs, candidate_translated)
+                    )
+
+                if not actionable_links:
+                    logger.debug(f"No actionable .ipynb links in {md_translated}")
+                    continue  # no in-root .ipynb links -> not a candidate
+
+                # This file is a candidate
+                total_matched += 1
+
+                # Compute translated_md_dir for later comparisons
+                translations_dir = root_path / "translations"
+                translated_md_dir = (
+                    translations_dir
+                    / lang
+                    / original_md_path.relative_to(root_path).parent
+                )
+
+                needs_update = False
+                all_missing = True
+
+                for (
+                    alt_text,
+                    link,
+                    linked_abs,
+                    candidate_translated,
+                ) in actionable_links:
+                    if (
+                        candidate_translated is None
+                        or not candidate_translated.exists()
+                    ):
+                        # There is at least one link without translated counterpart
+                        already_translated = False
+                        continue
+
+                    all_missing = False
+                    # Build expected updated link relative to translated_md_dir
+                    expected_link = os.path.relpath(
+                        candidate_translated, translated_md_dir
+                    ).replace(os.path.sep, "/")
+                    if parsed := urlparse(link):
+                        # preserve existing query/fragment when comparing
+                        if parsed.query:
+                            expected_link += f"?{parsed.query}"
+                        if parsed.fragment:
+                            expected_link += f"#{parsed.fragment}"
+
+                    if link != expected_link:
+                        needs_update = True
+                        already_translated = False
+
+                if needs_update:
+                    total_candidates_updatable += 1
+                    logger.debug(f"[Candidate-UPDATE] {md_translated}")
+                elif all_missing:
+                    total_candidates_missing += 1
+                    logger.debug(f"[Candidate-MISSING] {md_translated}")
+                else:
+                    total_candidates_already += 1
+                    logger.debug(f"[Candidate-ALREADY] {md_translated}")
+
+                if fallback_to_original:
+                    updated = update_notebook_links(
+                        markdown_string=content,
+                        md_file_path=original_md_path,
+                        language_code=lang,
+                        translations_dir=translations_dir,
+                        root_dir=root_path,
+                        use_translated_notebook=True,
+                    )
+                else:
+                    updated = migrate_notebook_links(
+                        markdown_string=content,
+                        md_file_path=original_md_path,
+                        language_code=lang,
+                        root_dir=root_path,
+                    )
+
+                if updated != content:
+                    total_changed += 1
+                    if dry_run:
+                        click.echo(f"[DRY-RUN] Would update: {md_translated}")
+                    else:
+                        try:
+                            md_translated.write_text(updated, encoding="utf-8")
+                            logger.info(f"Updated links in: {md_translated}")
+                        except Exception as e:
+                            logger.error(f"Failed to write {md_translated}: {e}")
+
+        # Summary (concise by default; detailed when --debug)
+        if debug:
+            click.echo(
+                (
+                    f"Scanned: {total_scanned}, Candidates: {total_matched} "
+                    f"(updatable: {total_candidates_updatable}, already: {total_candidates_already}, missing: {total_candidates_missing}), "
+                    f"Changed: {total_changed}"
+                )
+            )
+        else:
+            click.echo(
+                f"Scanned: {total_scanned}, Candidates: {total_matched}, Changed: {total_changed}"
+            )
+
+    except Exception as e:
+        if debug:
+            logger.exception("Error during migrate-links")
+        raise click.ClickException(str(e))
+
+
+if __name__ == "__main__":
+    migrate_links_command()

--- a/src/co_op_translator/utils/common/file_utils.py
+++ b/src/co_op_translator/utils/common/file_utils.py
@@ -100,6 +100,47 @@ def get_actual_image_path(
     return actual_image_path
 
 
+def map_original_to_translated(
+    original_abs: Path,
+    language_code: str,
+    root_dir: Path,
+    translations_dir: Path | None = None,
+) -> Path | None:
+    """
+    Map an absolute path of an original file under root_dir to its translated counterpart.
+
+    Rules:
+    - If original_abs is not under root_dir, return None.
+    - The translated candidate path is translations/<lang>/<original_rel_from_root>.
+    - If the candidate exists on disk, return it; otherwise return None.
+
+    Args:
+        original_abs (Path): Absolute path to the original file.
+        language_code (str): Language code (e.g., 'ko').
+        root_dir (Path): Project root.
+        translations_dir (Path | None): Override translations dir; default root_dir / 'translations'.
+
+    Returns:
+        Path | None: Absolute path to translated file if it exists, else None.
+    """
+    original_abs = Path(original_abs).resolve()
+    root_dir = Path(root_dir).resolve()
+    translations_dir = (
+        Path(translations_dir).resolve()
+        if translations_dir
+        else (root_dir / "translations").resolve()
+    )
+
+    try:
+        original_rel = original_abs.relative_to(root_dir)
+    except ValueError:
+        # Outside project root
+        return None
+
+    candidate = (translations_dir / language_code / original_rel).resolve()
+    return candidate if candidate.exists() else None
+
+
 def get_unique_id(file_path: str | Path, root_dir: Path) -> str:
     """
     Generate a unique identifier (hash) for the given file path, based on the relative path to the root directory.

--- a/src/co_op_translator/utils/llm/markdown_utils.py
+++ b/src/co_op_translator/utils/llm/markdown_utils.py
@@ -481,7 +481,7 @@ def update_notebook_links(
             or "@" in link
             or link.endswith((".com", ".org", ".net"))
         ):
-            logger.info(f"Skipped {link} as it is an email or web URL")
+            logger.debug(f"Skipped {link} as it is an email or web URL")
             continue
 
         path = parsed.path
@@ -534,12 +534,12 @@ def update_notebook_links(
             # Choose target (translated if available and enabled, else original)
             if use_translated_notebook and candidate_translated.exists():
                 target_abs = candidate_translated
-                logger.info(
+                logger.debug(
                     f"Using translated notebook link for {path} -> {candidate_translated}"
                 )
             else:
                 target_abs = original_linked_abs
-                logger.info(f"Using original notebook link for {path}")
+                logger.debug(f"Using original notebook link for {path}")
 
             # Build relative link from translated markdown dir to target
             updated_link = os.path.relpath(target_abs, translated_md_dir).replace(
@@ -555,7 +555,7 @@ def update_notebook_links(
             old_markup = f"[{alt_text}]({link})"
             new_markup = f"[{alt_text}]({updated_link})"
             markdown_string = markdown_string.replace(old_markup, new_markup)
-            logger.info(f"Updated notebook link: {new_markup}")
+            logger.debug(f"Updated notebook link: {new_markup}")
 
         except Exception as e:
             logger.error(f"Error processing notebook link {link}: {e}")

--- a/src/co_op_translator/utils/llm/markdown_utils.py
+++ b/src/co_op_translator/utils/llm/markdown_utils.py
@@ -18,6 +18,7 @@ from co_op_translator.utils.common.file_utils import (
     generate_translated_filename,
     get_actual_image_path,
     get_filename_and_extension,
+    map_original_to_translated,
 )
 
 logger = logging.getLogger(__name__)
@@ -317,6 +318,248 @@ def update_links(
     markdown_string = update_readme_translation_links(
         markdown_string, language_code, translations_dir
     )
+
+    return markdown_string
+
+
+def migrate_notebook_links(
+    markdown_string: str,
+    md_file_path: Path,
+    language_code: str,
+    root_dir: Path,
+) -> str:
+    """
+    Migration-only notebook link updater.
+
+    - Targets only links to .ipynb files in markdown content.
+    - If a translated notebook exists under translations/<lang>/, rewrite link
+      to the translated notebook relative to the translated markdown location.
+    - If not, leave the original link as-is (no normalization or fallback rewrite).
+    - Preserves query strings and fragments.
+    - Skips web/email links.
+    """
+    link_pattern = r"\[(.*?)\]\((.*?)\)"
+    matches = re.findall(link_pattern, markdown_string)
+
+    for alt_text, link in matches:
+        parsed = urlparse(link)
+        # Skip web/email links
+        if (
+            parsed.scheme in ("mailto", "http", "https")
+            or "@" in link
+            or link.endswith((".com", ".org", ".net"))
+        ):
+            logger.debug(f"Skipping web/email link: {link}")
+            continue
+
+        path = parsed.path
+        _, ext = get_filename_and_extension(path)
+        if ext.lower() != ".ipynb":
+            logger.debug(f"Skipping non-notebook link: {link}")
+            continue
+
+        try:
+            # Resolve absolute original linked notebook path
+            if path.startswith("/"):
+                original_linked_abs = (root_dir / path.lstrip("/")).resolve()
+            else:
+                original_linked_abs = (md_file_path.parent / path).resolve()
+                # If outside root, try resolving relative to translated MD dir and map back to root
+                try:
+                    _ = original_linked_abs.relative_to(root_dir)
+                except ValueError:
+                    translated_md_dir = (
+                        root_dir
+                        / "translations"
+                        / language_code
+                        / md_file_path.relative_to(root_dir).parent
+                    )
+                    alt_abs = (translated_md_dir / path).resolve()
+                    try:
+                        rel_to_lang = alt_abs.relative_to(
+                            (root_dir / "translations") / language_code
+                        )
+                        original_linked_abs = (root_dir / rel_to_lang).resolve()
+                        _ = original_linked_abs.relative_to(root_dir)
+                    except Exception:
+                        # If not under translations/<lang>, but under root, accept as-is
+                        try:
+                            _ = alt_abs.relative_to(root_dir)
+                            original_linked_abs = alt_abs
+                        except Exception:
+                            # Still not within root, skip this link
+                            logger.debug(
+                                f"Link outside root after alt resolution: {link}"
+                            )
+                            continue
+
+            # Map to translated counterpart if it exists
+            candidate_translated = map_original_to_translated(
+                original_abs=original_linked_abs,
+                language_code=language_code,
+                root_dir=root_dir,
+            )
+            if not candidate_translated:
+                logger.debug(
+                    f"No translated notebook found for: {original_linked_abs} (lang={language_code})"
+                )
+                # No translated notebook -> leave link unchanged
+                continue
+
+            if not candidate_translated.exists():
+                # No translated notebook -> leave link unchanged
+                continue
+
+            # Translated markdown directory (for relative link computation)
+            translations_dir = root_dir / "translations"
+            translated_md_dir = (
+                translations_dir
+                / language_code
+                / md_file_path.relative_to(root_dir).parent
+            )
+
+            # Build relative link from translated markdown dir to translated notebook
+            updated_link = os.path.relpath(
+                candidate_translated, translated_md_dir
+            ).replace(os.path.sep, "/")
+
+            # Preserve query/fragment
+            if parsed.query:
+                updated_link += f"?{parsed.query}"
+            if parsed.fragment:
+                updated_link += f"#{parsed.fragment}"
+
+            old_markup = f"[{alt_text}]({link})"
+            new_markup = f"[{alt_text}]({updated_link})"
+            if old_markup == new_markup:
+                logger.debug(f"Already correct, no change: {old_markup}")
+            else:
+                markdown_string = markdown_string.replace(old_markup, new_markup)
+                logger.debug(f"Updated notebook link: {old_markup} -> {new_markup}")
+
+        except Exception as e:
+            logger.error(f"Error processing migration notebook link {link}: {e}")
+            continue
+
+    return markdown_string
+
+
+def update_notebook_links(
+    markdown_string: str,
+    md_file_path: Path,
+    language_code: str,
+    translations_dir: Path,
+    root_dir: Path,
+    use_translated_notebook: bool = True,
+) -> str:
+    """
+    Update links to .ipynb files in markdown content.
+
+    If a translated notebook exists under translations/<lang>/, update the link to point to it.
+    Otherwise (or if disabled), ensure the link correctly points to the original notebook
+    from the translated markdown location. Preserves query strings and fragments.
+
+    Args:
+        markdown_string (str): The markdown content to process
+        md_file_path (Path): Path to the markdown file being processed (original file path)
+        language_code (str): Target language code
+        translations_dir (Path): Directory containing translations
+        root_dir (Path): Root directory of the project
+        use_translated_notebook (bool): Whether to use translated notebooks when available
+
+    Returns:
+        str: Updated markdown content with modified notebook links
+    """
+    link_pattern = r"\[(.*?)\]\((.*?)\)"
+    matches = re.findall(link_pattern, markdown_string)
+
+    for alt_text, link in matches:
+        parsed = urlparse(link)
+        # Skip web/email links
+        if (
+            parsed.scheme in ("mailto", "http", "https")
+            or "@" in link
+            or link.endswith((".com", ".org", ".net"))
+        ):
+            logger.info(f"Skipped {link} as it is an email or web URL")
+            continue
+
+        path = parsed.path
+        _, ext = get_filename_and_extension(path)
+        if ext.lower() != ".ipynb":
+            # Only handle notebook links here
+            continue
+
+        try:
+            # Determine directory of the translated markdown (target doc location)
+            translated_md_dir = (
+                translations_dir
+                / language_code
+                / md_file_path.relative_to(root_dir).parent
+            )
+
+            # Resolve the original linked notebook absolute path
+            if path.startswith("/"):
+                original_linked_abs = (root_dir / path.lstrip("/")).resolve()
+            else:
+                original_linked_abs = (md_file_path.parent / path).resolve()
+                # If outside root, try resolving relative to translated MD dir and map back to root
+                try:
+                    _ = original_linked_abs.relative_to(root_dir)
+                except ValueError:
+                    alt_abs = (translated_md_dir / path).resolve()
+                    try:
+                        rel_to_lang = alt_abs.relative_to(
+                            translations_dir / language_code
+                        )
+                        original_linked_abs = (root_dir / rel_to_lang).resolve()
+                        _ = original_linked_abs.relative_to(root_dir)
+                    except Exception:
+                        # If not under translations/<lang>, but under root, accept as-is
+                        try:
+                            _ = alt_abs.relative_to(root_dir)
+                            original_linked_abs = alt_abs
+                        except Exception:
+                            logger.debug(
+                                f"Link outside root after alt resolution: {link}"
+                            )
+                            continue
+
+            # Compute the candidate translated notebook path
+            original_rel_from_root = original_linked_abs.relative_to(root_dir)
+            candidate_translated = (
+                translations_dir / language_code / original_rel_from_root
+            ).resolve()
+
+            # Choose target (translated if available and enabled, else original)
+            if use_translated_notebook and candidate_translated.exists():
+                target_abs = candidate_translated
+                logger.info(
+                    f"Using translated notebook link for {path} -> {candidate_translated}"
+                )
+            else:
+                target_abs = original_linked_abs
+                logger.info(f"Using original notebook link for {path}")
+
+            # Build relative link from translated markdown dir to target
+            updated_link = os.path.relpath(target_abs, translated_md_dir).replace(
+                os.path.sep, "/"
+            )
+
+            # Preserve query and fragment
+            if parsed.query:
+                updated_link += f"?{parsed.query}"
+            if parsed.fragment:
+                updated_link += f"#{parsed.fragment}"
+
+            old_markup = f"[{alt_text}]({link})"
+            new_markup = f"[{alt_text}]({updated_link})"
+            markdown_string = markdown_string.replace(old_markup, new_markup)
+            logger.info(f"Updated notebook link: {new_markup}")
+
+        except Exception as e:
+            logger.error(f"Error processing notebook link {link}: {e}")
+            continue
 
     return markdown_string
 

--- a/tests/co_op_translator/utils/llm/test_text_utils.py
+++ b/tests/co_op_translator/utils/llm/test_text_utils.py
@@ -66,7 +66,7 @@ def test_translation_response():
     """Test TranslationResponse Pydantic model."""
     translations = ["Translated line 1", "Translated line 2", "Translated line 3"]
     response = TranslationResponse(translations=translations)
-    
+
     assert response.translations == translations
     assert len(response.translations) == 3
     assert response.translations[0] == "Translated line 1"


### PR DESCRIPTION
## Purpose
- Add a CLI to migrate .ipynb links in translated Markdown to their translated notebooks.
- Align logging behavior with translate command for consistent UX.
- Document the new command in the command reference.

## Description
- CLI:
  - Added `migrate-links` in [src/co_op_translator/cli/migrate_links.py](cci:7://file:///c:/Users/sms79/dev/co-op-translator/src/co_op_translator/cli/migrate_links.py:0:0-0:0).
  - Scans translated Markdown under `translations/<lang>/...` and updates `.ipynb` links:
    - Prefer translated notebooks if present.
    - Otherwise, optionally fall back to original notebooks via `--fallback-to-original` (default: on).
  - Options:
    - `-l/--language-codes`
    - `-r/--root-dir`
    - `--dry-run`
    - `--fallback-to-original/--no-fallback-to-original`
    - `-d/--debug` (DEBUG when set; CRITICAL by default)
- Utils:
  - Added [map_original_to_translated()](cci:1://file:///c:/Users/sms79/dev/co-op-translator/src/co_op_translator/utils/common/file_utils.py:9:0-23:9) in [src/co_op_translator/utils/common/file_utils.py](cci:7://file:///c:/Users/sms79/dev/co-op-translator/src/co_op_translator/utils/common/file_utils.py:0:0-0:0) to resolve translated counterparts under `translations/<lang>/...`.
- Docs:
  - Updated [getting_started/command-reference.md](cci:7://file:///c:/Users/sms79/dev/co-op-translator/getting_started/command-reference.md:0:0-0:0) with `migrate-links` and usage examples.
- Tests:
  - [tests/co_op_translator/utils/common/test_file_utils.py](cci:7://file:///c:/Users/sms79/dev/co-op-translator/tests/co_op_translator/utils/common/test_file_utils.py:0:0-0:0): tests for [map_original_to_translated](cci:1://file:///c:/Users/sms79/dev/co-op-translator/src/co_op_translator/utils/common/file_utils.py:9:0-23:9).
  - [tests/co_op_translator/utils/llm/test_markdown_utils.py](cci:7://file:///c:/Users/sms79/dev/co-op-translator/tests/co_op_translator/utils/llm/test_markdown_utils.py:0:0-0:0): tests for notebook link updates (prefer translated; fallback to original).

## Related Issue


## Does this introduce a breaking change?
- [ ] Yes
- [x] No

## Type of change
- [ ] Bugfix
- [x] Feature
- [x] Code style update (logging alignment)
- [ ] Refactoring (no functional or API changes)
- [x] Documentation content changes
- [ ] Other

## Checklist
- [x] I have thoroughly tested my changes
- [x] All existing tests pass
- [x] I have added new tests where applicable
- [x] I followed the Co-op Translator coding conventions
- [x] I updated documentation where necessary

## Additional context
- Example commands:
  - `migrate-links -l "ko"`
  - `migrate-links -l "ko" --dry-run`
  - `migrate-links -l "ko" --no-fallback-to-original`