### PR TITLE
Resolved #209: Add a separator line before the "Disclaimer" text.

### DIFF
--- a/src/co_op_translator/core/llm/markdown_translator.py
+++ b/src/co_op_translator/core/llm/markdown_translator.py
@@ -149,7 +149,7 @@ class MarkdownTranslator(ABC):
             result = metadata_comment + result
         if add_disclaimer:
             disclaimer = await self.generate_disclaimer(language_code)
-            result = result + "\n\n" + disclaimer
+            result = result + "\n\n---\n\n" + disclaimer
 
         return result
 
@@ -219,7 +219,7 @@ class MarkdownTranslator(ABC):
         language_name = self.font_config.get_language_name(output_lang)
         disclaimer_prompt = f""" Translate the following text to {language_name} ({output_lang}).
 
-        **Disclaimer**: 
+        **Disclaimer**:
         This document has been translated using AI translation service [Co-op Translator](https://github.com/Azure/co-op-translator). While we strive for accuracy, please be aware that automated translations may contain errors or inaccuracies. The original document in its native language should be considered the authoritative source. For critical information, professional human translation is recommended. We are not liable for any misunderstandings or misinterpretations arising from the use of this translation."""
 
         disclaimer = await self._run_prompt(disclaimer_prompt, "disclaimer prompt", 1)


### PR DESCRIPTION
## Purpose

This PR resolves issue #209 by adding a separator line before the "Disclaimer" text for better readability.

## Description

A separator (`---`) has been added to visually distinguish the disclaimer section from the content above it.

## Related Issue

Fixes #209

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Type of change

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (e.g., formatting, local variables)
- [ ] Refactoring (no functional or API changes)
- [x] Documentation content changes
- [ ] Other... Please describe:

## Checklist

Before submitting your pull request, please confirm the following:

- [x] **I have thoroughly tested my changes**: I confirm that I have run the code and manually tested all affected areas.
- [x] **All existing tests pass**: I have run all tests and confirmed that nothing is broken.
- [ ] **I have added new tests** (if applicable): I have written tests that cover the new functionality introduced by my code changes.
- [x] **I have followed the Co-op Translators coding conventions**: My code adheres to the style guide and coding conventions outlined in the repository.
- [ ] **I have documented my changes** (if applicable): I have updated the documentation to reflect the changes where necessary.

## Additional context

N/A
