### PR TITLE
Core: Move translation rules to system messages to prevent prompt leakage

### DIFF
--- a/src/co_op_translator/utils/llm/markdown_utils.py
+++ b/src/co_op_translator/utils/llm/markdown_utils.py
@@ -24,6 +24,9 @@ from co_op_translator.utils.common.file_utils import (
 logger = logging.getLogger(__name__)
 
 
+SPLIT_DELIMITER = "\n\n===SYSTEM_USER_SPLIT===\n\n"
+
+
 def generate_prompt_template(
     language_code: str, language_name: str, document_chunk: str, is_rtl: bool
 ) -> str:
@@ -64,7 +67,9 @@ def generate_prompt_template(
     else:
         prompt += "Please write the output from left to right.\n"
 
-    prompt += "\n" + document_chunk
+    # Explicit delimiter between system rules and user content
+    prompt += SPLIT_DELIMITER
+    prompt += document_chunk
 
     return prompt
 


### PR DESCRIPTION
We now send translation rules as a system instruction and user content as the user message, avoiding prompt leakage (instructions leaking into outputs) and improving output cleanliness across providers.

Key changes
- utils/llm/markdown_utils.py
  - Added SPLIT_DELIMITER and updated generate_prompt_template() to emit a single prompt string with a clear delimiter between rules (system) and content (user).
  - Preserved RTL/LTR guidance within the system instruction.
- core/llm/providers/openai/markdown_translator.py
  - Switched to role-based messaging via Semantic Kernel ChatHistory.
  - Split prompt by SPLIT_DELIMITER, then add_system_message/add_user_message.
- core/llm/providers/azure/markdown_translator.py
  - Same role-based system/user split and ChatHistory usage as OpenAI.
- core/llm/markdown_translator.py
  - Wiring remains compatible with current prompt generation; strict split enforced (no fallback).

Why this change
- Prevent instruction echoing in model outputs (prompt leakage).
- Make role intent explicit (system: translation rules, user: source text).
- Improve stability across providers while keeping minimal surface changes to call sites.
## Purpose

Move translation rules from the user prompt into system instructions to prevent prompt leakage (instructions appearing in model outputs). This improves the cleanliness and consistency of translated content across providers.

## Description

This PR updates the markdown translation flow so that:
- System instructions (translation rules, RTL/LTR direction) are sent as a system message.
- The source document chunk is sent as a user message.

To achieve this with minimal surface change:
- Provider implementations split the prompt by this delimiter and add messages to the chat as `system` (rules) and `user` (content).

Net effect: rules no longer leak into the translated output, improving translation quality while preserving the existing CLI and higher-level behavior.

## Related Issue

N/A (preventative enhancement for prompt leakage)

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

- [ ] Yes
- [x] No

Notes:
- Public CLI and external behavior remain compatible.
- Internals of provider message construction changed, but tests pass and the user-facing API is unchanged.

## Type of change

- [x] Feature
- [ ] Bugfix
- [ ] Code style update (e.g., formatting, local variables)
- [x] Refactoring (no functional or API changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Checklist

Before submitting your pull request, please confirm the following:

- [x] I have thoroughly tested my changes: I confirm that I have run the code and manually tested all affected areas.
- [x] All existing tests pass: I have run all tests and confirmed that nothing is broken.
- [ ] I have added new tests (if applicable): (Not required; behavior validated via existing test suite and manual runs.)
- [x] I have followed the Co-op Translators coding conventions: My code adheres to the style guide and coding conventions outlined in the repository.
- [x] I have documented my changes (if applicable): Inline comments and commit message explain the change and rationale.

