### PR TITLE
Use markdown-it-py to robustly detect fenced code blocks and prevent placeholder desync

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1671,6 +1671,31 @@ files = [
 ]
 
 [[package]]
+name = "markdown-it-py"
+version = "3.0.0"
+description = "Python port of markdown-it. Markdown parsing, done right!"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "markdown-it-py-3.0.0.tar.gz", hash = "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb"},
+    {file = "markdown_it_py-3.0.0-py3-none-any.whl", hash = "sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1"},
+]
+
+[package.dependencies]
+mdurl = ">=0.1,<1.0"
+
+[package.extras]
+benchmarking = ["psutil", "pytest", "pytest-benchmark"]
+code-style = ["pre-commit (>=3.0,<4.0)"]
+compare = ["commonmark (>=0.9,<1.0)", "markdown (>=3.4,<4.0)", "mistletoe (>=1.0,<2.0)", "mistune (>=2.0,<3.0)", "panflute (>=2.3,<3.0)"]
+linkify = ["linkify-it-py (>=1,<3)"]
+plugins = ["mdit-py-plugins"]
+profiling = ["gprof2dot"]
+rtd = ["jupyter_sphinx", "mdit-py-plugins", "myst-parser", "pyyaml", "sphinx", "sphinx-copybutton", "sphinx-design", "sphinx_book_theme"]
+testing = ["coverage", "pytest", "pytest-cov", "pytest-regressions"]
+
+[[package]]
 name = "markupsafe"
 version = "3.0.2"
 description = "Safely add untrusted strings to HTML/XML markup."
@@ -1813,6 +1838,18 @@ files = [
 
 [package.dependencies]
 traitlets = "*"
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+description = "Markdown URL utilities"
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+files = [
+    {file = "mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8"},
+    {file = "mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba"},
+]
 
 [[package]]
 name = "more-itertools"
@@ -4228,4 +4265,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.13"
-content-hash = "097cd715b7560950d915075a7934f9ad2661d6e3f2d62877c400bd0c9cf7ef19"
+content-hash = "59356a78ae6b430a22ee5376d147509b07da3fb1d34db56f7b6b39c24a339202"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,6 +90,7 @@ arabic-reshaper = "^3.0.0"
 python-bidi = "^0.6.6"
 az-ai-healthcheck = { version = "^0.1.5", extras = ["vision"] }
 ai-healthcheck = "^0.1.1"
+markdown-it-py = "^3.0.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.3.2"


### PR DESCRIPTION
## Purpose
Improve detection and handling of fenced code blocks in Markdown so that:
- Code chunks are never split during chunking.
- Placeholder insertion/restoration is stable and order-preserving.
- Single/unmatched fences (e.g., a lone ``` in text) do not corrupt placeholder order or chunk boundaries.

## Description
This PR replaces regex-based code-block detection with a spec-compliant parser using markdown-it-py.

- Regex `r"```[\s\S]*?```"` previously used in replace_code_blocks() and indirectly in chunking fails with unmatched fences and various edge cases (e.g., `~~~`, variable fence length, info strings).
- Using markdown-it-py yields consistent, spec-conformant behavior and fixes placeholder order issues and accidental code splits.

Before:
- A single unmatched ``` in the document could derail placeholder ordering and lead to broken chunking.

After:
- Only well-formed fenced blocks are replaced and treated as atomic during chunking.
- Unmatched/partial fences remain as plain text and no longer cause placeholder desynchronization.

## Related Issue
- Fixes #221  (``` not handled correctly)

## Does this introduce a breaking change?
- [ ] Yes
- [x] No

Notes:
- Behavior changes are strictly bug fixes and robustness improvements.
- Consumers should run dependency install to fetch `markdown-it-py`.

## Type of change
- [x] Bugfix
- [x] Refactoring (no functional API changes)
- [ ] Feature
- [ ] Code style update
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Checklist
- [ ] I have thoroughly tested my changes
- [ ] All existing tests pass
- [ ] I have added new tests (if applicable)
- [x] I have followed the Co-op Translator coding conventions
- [ ] I have documented my changes (if applicable)

## Additional context
- The parser-based approach also unlocks future enhancements:
  - Language-aware handling via `token.info` (e.g., mode-specific rules for `python`, `bash`, etc.).
  - Optional handling for `~~~` fences and variable-length fences without extra complexity.
- Suggested follow-up: add targeted tests for:
  - Single unmatched fence,
  - Mixed ``` and ~~~ fences,
  - Variable fence lengths,
  - Very long code blocks to ensure atomic chunking.