### PR TITLE
Core: Support HTML <img> links in markdown and fix disclaimer prompt split

### DIFF
--- a/src/co_op_translator/core/llm/markdown_translator.py
+++ b/src/co_op_translator/core/llm/markdown_translator.py
@@ -9,6 +9,7 @@ from co_op_translator.utils.llm.markdown_utils import (
     generate_prompt_template,
     replace_code_blocks,
     restore_code_blocks,
+    SPLIT_DELIMITER,
 )
 from co_op_translator.config.font_config import FontConfig
 from co_op_translator.config.llm_config.config import LLMConfig
@@ -217,10 +218,16 @@ class MarkdownTranslator(ABC):
             Translated disclaimer text
         """
         language_name = self.font_config.get_language_name(output_lang)
-        disclaimer_prompt = f""" Translate the following text to {language_name} ({output_lang}).
-
-        **Disclaimer**:
-        This document has been translated using AI translation service [Co-op Translator](https://github.com/Azure/co-op-translator). While we strive for accuracy, please be aware that automated translations may contain errors or inaccuracies. The original document in its native language should be considered the authoritative source. For critical information, professional human translation is recommended. We are not liable for any misunderstandings or misinterpretations arising from the use of this translation."""
+        system_text = f"Translate the following text to {language_name} ({output_lang})."
+        user_text = (
+            "**Disclaimer**:\n"
+            "This document has been translated using AI translation service [Co-op Translator](https://github.com/Azure/co-op-translator). "
+            "While we strive for accuracy, please be aware that automated translations may contain errors or inaccuracies. "
+            "The original document in its native language should be considered the authoritative source. "
+            "For critical information, professional human translation is recommended. "
+            "We are not liable for any misunderstandings or misinterpretations arising from the use of this translation."
+        )
+        disclaimer_prompt = system_text + SPLIT_DELIMITER + user_text
 
         disclaimer = await self._run_prompt(disclaimer_prompt, "disclaimer prompt", 1)
 

--- a/src/co_op_translator/utils/llm/markdown_utils.py
+++ b/src/co_op_translator/utils/llm/markdown_utils.py
@@ -53,7 +53,7 @@ def generate_prompt_template(
         1. DO NOT add '''markdown or any other tags around the translation
         2. Make sure the translation does not sound too literal
         3. Translate comments as well
-        4. This file is written in Markdown format - do not treat it as XML or HTML
+        4. Preserve inline HTML (e.g., <a>, <img>) exactly; do not convert to Markdown; translate only visible text (e.g., link text, alt/title); do not change tag names, attributes, or URLs/paths.
         5. Do not translate:
            - [!NOTE], [!WARNING], [!TIP], [!IMPORTANT], [!CAUTION]
            - Variable names, function names, class names


### PR DESCRIPTION
## Purpose

Improve translation reliability for disclaimers and ensure correct handling of inline HTML `<img>` tags inside Markdown files.  
This solves broken image paths and ensures that the disclaimer message is consistently generated and translated across languages.

## Description

- **markdown_translator.py**
  - Refactored `generate_disclaimer` to use `system_text` + `user_text` format with `SPLIT_DELIMITER` for more predictable prompt structure.
  - Updated disclaimer text to be clearly formatted with line breaks and consistent Markdown syntax.
- **markdown_utils.py**
  - Added HTML `<img>` tag support to `update_image_links` to preserve tag attributes while rewriting `src` paths.
  - Enhanced prompt template rules to explicitly instruct preserving inline HTML tags.

These changes prevent accidental modification of HTML tags and improve translation quality.

## Related Issue

Fixes #234
Fixes #227 

## Does this introduce a breaking change?

When developers merge from main and run the server, `azd up`, or `azd deploy`, will this produce an error?

- [ ] Yes  
- [x] No  

Confirmed by running locally in an older environment — no errors or crashes were observed.

## Type of change

- [x] Bugfix  
- [x] Feature (HTML `<img>` path rewriting)  
- [ ] Code style update  
- [ ] Refactoring  
- [ ] Documentation content changes  
- [ ] Other... Please describe:

## Checklist

- [x] **I have thoroughly tested my changes**: Verified translation output and image path rewriting manually on sample Markdown files.
- [x] **All existing tests pass**
- [ ] **I have added new tests** (to be added in a follow-up PR for HTML image handling)
- [x] **I have followed the Co-op Translator coding conventions**
- [x] **I have documented my changes** (updated inline docstrings and comments)

## Additional context

- Example: `<img src="./media/example.png" alt="Sample" />` is now preserved as-is, with `src` path rewritten relative to the translated Markdown file.  
- Verified that disclaimers translate correctly into `ja`, `ko`, and `fr` without formatting loss.
