### PR TITLE
Add Estonian (et) language mapping

### DIFF
--- a/src/co_op_translator/fonts/font_language_mappings.yml
+++ b/src/co_op_translator/fonts/font_language_mappings.yml
@@ -151,3 +151,6 @@ lt:
 ta:
   name: "Tamil"
   font: "NotoSansTamil-Medium.ttf"
+et:
+  name: "Estonian"
+  font: "NotoSans-Medium.ttf"  


### PR DESCRIPTION
## Purpose

Add support for the Estonian language (et) in the font_language_mapping.yml file. 
This allows the Co-op Translator system to recognize Estonian and use the correct font.

## Description

- Added `et` entry to `font_language_mapping.yml`:
  ```yaml
  et:
    name: "Estonian"
    font: "NotoSans-Medium.ttf"

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

- [ ] Yes
- [ ] No

## Type of change

- [ ] Bugfix
- [x ] Feature
- [ ] Code style update (e.g., formatting, local variables)
- [ ] Refactoring (no functional or API changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Checklist

Before submitting your pull request, please confirm the following:

- [ ] **I have thoroughly tested my changes**: I confirm that I have run the code and manually tested all affected areas.
- [ ] **All existing tests pass**: I have run all tests and confirmed that nothing is broken.
- [ ] **I have added new tests** (if applicable): I have written tests that cover the new functionality introduced by my code changes.
- [x ] **I have followed the Co-op Translators coding conventions**: My code adheres to the style guide and coding conventions outlined in the repository.
- [x ] **I have documented my changes** (if applicable): I have updated the documentation to reflect the changes where necessary.

## Additional context

<!-- Add any additional context or screenshots if applicable -->
