### PR TITLE
Core: Resolve custom output dirs relative to root_dir when given as relative paths

### DIFF
--- a/src/co_op_translator/core/project/project_translator.py
+++ b/src/co_op_translator/core/project/project_translator.py
@@ -48,16 +48,25 @@ class ProjectTranslator:
         """
         self.language_codes = language_codes.split()
         self.root_dir = Path(root_dir).resolve()
-        self.translations_dir = (
-            Path(translations_dir).resolve()
-            if translations_dir is not None
-            else self.root_dir / "translations"
-        )
-        self.image_dir = (
-            Path(image_dir).resolve()
-            if image_dir is not None
-            else self.root_dir / "translated_images"
-        )
+        # Resolve translations_dir relative to root_dir when a relative path is provided.
+        if translations_dir is not None:
+            t_dir = Path(translations_dir)
+            if t_dir.is_absolute():
+                self.translations_dir = t_dir.resolve()
+            else:
+                self.translations_dir = (self.root_dir / t_dir).resolve()
+        else:
+            self.translations_dir = self.root_dir / "translations"
+
+        # Resolve image_dir relative to root_dir when a relative path is provided.
+        if image_dir is not None:
+            i_dir = Path(image_dir)
+            if i_dir.is_absolute():
+                self.image_dir = i_dir.resolve()
+            else:
+                self.image_dir = (self.root_dir / i_dir).resolve()
+        else:
+            self.image_dir = self.root_dir / "translated_images"
 
         # Default translation types if not specified (safe fallback for direct API usage)
         if translation_types is None:

--- a/tests/co_op_translator/core/project/test_project_translator.py
+++ b/tests/co_op_translator/core/project/test_project_translator.py
@@ -211,3 +211,43 @@ async def test_project_translator_custom_output_directories(temp_project_dir):
         assert (
             translator.directory_manager.translations_dir == translator.translations_dir
         )
+
+
+@pytest.mark.asyncio
+async def test_project_translator_relative_output_directories(temp_project_dir):
+    with (
+        patch(
+            "co_op_translator.core.llm.text_translator.TextTranslator"
+        ) as mock_text_translator,
+        patch(
+            "co_op_translator.core.llm.markdown_translator.MarkdownTranslator"
+        ) as mock_markdown_translator,
+        patch(
+            "co_op_translator.core.vision.image_translator.ImageTranslator"
+        ) as mock_image_translator,
+        patch(
+            "co_op_translator.core.llm.jupyter_notebook_translator.JupyterNotebookTranslator"
+        ) as mock_jupyter_translator,
+        patch(
+            "co_op_translator.config.llm_config.config.LLMConfig.get_available_provider"
+        ) as mock_get_provider,
+    ):
+        mock_text_translator.create.return_value = MagicMock()
+        mock_markdown_translator.create.return_value = MagicMock()
+        mock_image_translator.create.return_value = MagicMock()
+        mock_jupyter_translator.create.return_value = MagicMock()
+        mock_get_provider.return_value = LLMProvider.AZURE_OPENAI
+
+        translator = ProjectTranslator(
+            "ko ja",
+            root_dir=temp_project_dir,
+            translation_types=["markdown", "notebook", "images"],
+            translations_dir="content/i18n",
+            image_dir="public/translated_media",
+        )
+
+        expected_translations = (temp_project_dir / "content" / "i18n").resolve()
+        expected_images = (temp_project_dir / "public" / "translated_media").resolve()
+
+        assert translator.translations_dir == expected_translations
+        assert translator.image_dir == expected_images


### PR DESCRIPTION
## Purpose

This PR ensures that **custom output directories (`translations_dir`, `image_dir`) are always resolved correctly relative to `root_dir` when provided as relative paths**.  
This eliminates path inconsistencies across CLI and API usage, especially when users supply non-absolute custom output dirs.

## Description

Previously, `translations_dir` and `image_dir` were always resolved with `Path(...).resolve()`, which incorrectly treated relative paths as absolute based only on the current working directory.  
This led to incorrect output locations whenever `root_dir` differed from the current process directory.

This update introduces proper resolution logic:

- If a custom path is **absolute**, use it directly.
- If the path is **relative**, resolve it under `root_dir` (expected behavior for API/CLI consumers).
- Includes full test coverage validating relative resolution for both translations and images.

This makes output directory behavior predictable, consistent, and safe across environments (CLI, API, GitHub Actions, Localizeflow integration).

## Related Issue

<!-- None explicitly referenced, but fixes inconsistent directory resolution behavior -->

## Does this introduce a breaking change?

- [ ] Yes  
- [x] No  

The change only corrects relative path handling and aligns it with intuitive/expected behavior.  
No existing absolute-path configurations break, and relative-path users gain correct behavior.

## Type of change

- [ ] Bugfix  
- [x] Feature  
- [ ] Code style update  
- [ ] Refactoring  
- [ ] Documentation content changes  
- [ ] Other...  

## Checklist

- [x] **I have thoroughly tested my changes**  
- [x] **All existing tests pass**  
- [x] **I have added new tests**  
- [x] **I have followed the Co-op Translator coding conventions**  
- [x] **I have documented my changes** (where appropriate)

## Additional context

Adds a new test:  
`test_project_translator_relative_output_directories`, verifying correct handling of:

- `translations_dir="content/i18n"`
- `image_dir="public/translated_media"`

Ensuring both resolve correctly under `root_dir`.