### PR TITLE
Refactor test helper to create language-specific image subdirectories

### DIFF
--- a/src/co_op_translator/utils/common/file_utils.py
+++ b/src/co_op_translator/utils/common/file_utils.py
@@ -392,14 +392,15 @@ def reset_translation_directories(
         shutil.rmtree(image_dir)
         logger.info(f"Removed existing translated_images directory: {image_dir}")
 
-    # Create new directories
+    # Create new directories for each language
     for lang_code in language_codes:
         lang_dir = translations_dir / lang_code
         lang_dir.mkdir(parents=True, exist_ok=True)
         logger.info(f"Created directory for {lang_code}: {lang_dir}")
 
-    image_dir.mkdir(parents=True, exist_ok=True)
-    logger.info(f"Created translated_images directory: {image_dir}")
+        image_lang_dir = image_dir / lang_code
+        image_lang_dir.mkdir(parents=True, exist_ok=True)
+        logger.info(f"Created image directory for {lang_code}: {image_lang_dir}")
 
 
 def delete_translated_images_by_language_code(language_code: str, image_dir: Path):
@@ -410,18 +411,21 @@ def delete_translated_images_by_language_code(language_code: str, image_dir: Pat
         language_code (str): The language code to filter files by (e.g., 'ko').
         image_dir (Path): The directory where translated images are stored (e.g., './translated_images').
     """
-    image_dir = Path(image_dir)
+    """
+    Delete the entire image directory for the specified language code, including all its contents.
 
-    if not image_dir.exists():
-        logger.warning(f"Directory {image_dir} does not exist. No images to delete.")
+    Args:
+        language_code (str): The language code whose image folder should be deleted (e.g., 'ko').
+        image_dir (Path): The directory where translated images are stored (e.g., './translated_images').
+    """
+    image_lang_dir = Path(image_dir) / language_code
+
+    if not image_lang_dir.exists():
+        logger.warning(f"Directory {image_lang_dir} does not exist. No images to delete.")
         return
 
-    # Iterate through all files in the directory
-    for image_file in image_dir.iterdir():
-        # Check if the language code is part of the filename
-        if image_file.is_file() and f".{language_code}" in image_file.name:
-            logger.info(f"Deleting image file: {image_file}")
-            image_file.unlink()
+    shutil.rmtree(image_lang_dir)
+    logger.info(f"Deleted the image directory and all files for language: {language_code}")
 
 
 def delete_translated_markdown_files_by_language_code(

--- a/tests/co_op_translator/utils/common/test_file_utils_image_dir.py
+++ b/tests/co_op_translator/utils/common/test_file_utils_image_dir.py
@@ -1,0 +1,40 @@
+import shutil
+import tempfile
+from pathlib import Path
+import pytest
+from co_op_translator.utils.common.file_utils import (
+    reset_translation_directories,
+    delete_translated_images_by_language_code,
+)
+
+def create_dummy_image(lang_dir, fname):
+    f = lang_dir / fname
+    f.write_text("dummy image content")
+    return f
+
+def test_image_dir_language_subfolders():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        translations_dir = Path(tmpdir) / "translations"
+        image_dir = Path(tmpdir) / "translated_images"
+        langs = ["fr", "de"]
+        reset_translation_directories(translations_dir, image_dir, langs)
+        for lang in langs:
+            assert (translations_dir / lang).is_dir()
+            assert (image_dir / lang).is_dir()
+
+def test_delete_translated_images_by_language_code():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        image_dir = Path(tmpdir) / "translated_images"
+        langs = ["fr", "de"]
+        # Setup dirs and dummy files
+        reset_translation_directories(Path(tmpdir) / "translations", image_dir, langs)
+        for lang in langs:
+            lang_dir = image_dir / lang
+            lang_dir.mkdir(parents=True, exist_ok=True)
+            create_dummy_image(lang_dir, f"img1.{lang}.png")
+            create_dummy_image(lang_dir, f"img2.{lang}.jpg")
+            assert any(lang_dir.iterdir())
+        # Delete 'fr' images
+        delete_translated_images_by_language_code("fr", image_dir)
+        assert not (image_dir / "fr").exists()
+        assert (image_dir / "de").is_dir() and any((image_dir / "de").iterdir())


### PR DESCRIPTION
## Purpose

currently all translated images are stored in one common directory. I the long run this can result in scalability problems.
This PR fixes the problem 

## Description

storing a large amount of files in one directory can cause problems. SVN e.g. had also such problems on the serverside.
Also github runs into issues, displaying diffs, logs etc if there are more than about 1000 files in a folder.

## Related Issue


## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

- [ ] Yes
- [ X] No

## Type of change

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (e.g., formatting, local variables)
- [ ] Refactoring (no functional or API changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Checklist

Before submitting your pull request, please confirm the following:

- [X] **I have thoroughly tested my changes**: I confirm that I have run the code and manually tested all affected areas.
- [X] **All existing tests pass**: I have run all tests and confirmed that nothing is broken.
- [X] **I have added new tests** (if applicable): I have written tests that cover the new functionality introduced by my code changes.
- [X] **I have followed the Co-op Translators coding conventions**: My code adheres to the style guide and coding conventions outlined in the repository.
- [X] **I have documented my changes** (if applicable): I have updated the documentation to reflect the changes where necessary.

## Additional context

<img width="1293" height="728" alt="image" src="https://github.com/user-attachments/assets/ff082a91-d806-4900-b075-1324972ad837" />
