### PR TITLE
Docs: Document supported Python versions (3.10–3.12) in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 _Easily automate the translation of your educational GitHub content into multiple languages to reach a global audience._
 
+![Python 3.10–3.12](https://img.shields.io/badge/python-3.10--3.12-blue)
 [![Python package](https://img.shields.io/pypi/v/co-op-translator?color=4BA3FF)](https://pypi.org/project/co-op-translator/)
 [![License: MIT](https://img.shields.io/github/license/azure/co-op-translator?color=4BA3FF)](https://github.com/azure/co-op-translator/blob/main/LICENSE)
 [![Downloads](https://static.pepy.tech/badge/co-op-translator)](https://pepy.tech/project/co-op-translator)
@@ -65,12 +66,13 @@ docker run --rm -it --env-file .env -v "${PWD}:/work" ghcr.io/azure/co-op-transl
 
 ## Minimal setup
 
-1. Create a `.env` file using the template: [.env.template](./.env.template)
-2. Configure one LLM provider (Azure OpenAI or OpenAI)
-3. (Optional) For image translation (`-img`), configure Azure AI Vision
-4. (Recommended) Clean up any previous translations to avoid conflicts (e.g., `translations/`)
-5. (Recommended) Add a translation section to your README using the [README languages template](./getting_started/README_languages_template.md)
-6. See: [Set up Azure AI](./getting_started/set-up-azure-ai.md)
+1. Assert that you have a supported Python version (currently 3.10-3.12). In poetry (pyproject.toml) this is handeled automatically.
+2. Create a `.env` file using the template: [.env.template](./.env.template)
+3. Configure one LLM provider (Azure OpenAI or OpenAI)
+4. (Optional) For image translation (`-img`), configure Azure AI Vision
+5. (Recommended) Clean up any previous translations to avoid conflicts (e.g., `translations/`)
+6. (Recommended) Add a translation section to your README using the [README languages template](./getting_started/README_languages_template.md)
+7. See: [Set up Azure AI](./getting_started/set-up-azure-ai.md)
 
 ## Usage
 


### PR DESCRIPTION
fix for https://github.com/Azure/co-op-translator/issues/294
- supported python version (3.10-3.12) set in banner and also in text

## Purpose

document supported python version to avoid build error.

## Description

supported python version (3.10-3.12) set in banner and also in text

## Related Issue

fix for https://github.com/Azure/co-op-translator/issues/294

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

- [ ] Yes
- [X] No

## Type of change

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (e.g., formatting, local variables)
- [ ] Refactoring (no functional or API changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Checklist

Before submitting your pull request, please confirm the following:

- [X] **I have thoroughly tested my changes**: I confirm that I have run the code and manually tested all affected areas.
- [X] **All existing tests pass**: I have run all tests and confirmed that nothing is broken.
- [X] **I have added new tests** (if applicable): I have written tests that cover the new functionality introduced by my code changes.
- [X] **I have followed the Co-op Translators coding conventions**: My code adheres to the style guide and coding conventions outlined in the repository.
- [X] **I have documented my changes** (if applicable): I have updated the documentation to reflect the changes where necessary.

## Additional context

<!-- Add any additional context or screenshots if applicable -->
