### PR TITLE
Core: Migrate notebook image links and suppress markdown-it debug logs

### DIFF
--- a/src/co_op_translator/core/project/translation_manager.py
+++ b/src/co_op_translator/core/project/translation_manager.py
@@ -578,7 +578,7 @@ class TranslationManager:
         all_errors = []
 
         try:
-            # Migrate legacy translated image filenames and update markdown links
+            # Migrate legacy translated image filenames and update markdown/notebook links
             try:
                 rename_map = migrate_translated_image_filenames(
                     self.image_dir, self.language_codes
@@ -587,10 +587,14 @@ class TranslationManager:
                     migrated_md = self.directory_manager.migrate_markdown_image_links(
                         rename_map
                     )
+                    migrated_nb = self.directory_manager.migrate_notebook_image_links(
+                        rename_map
+                    )
                     logger.info(
-                        "Migrated %d image files and updated %d markdown files",
+                        "Migrated %d image files and updated %d markdown and %d notebook files",
                         len(rename_map),
                         migrated_md,
+                        migrated_nb,
                     )
             except Exception as e:
                 logger.warning(f"Image filename/link migration skipped: {e}")

--- a/src/co_op_translator/utils/common/logging_utils.py
+++ b/src/co_op_translator/utils/common/logging_utils.py
@@ -52,6 +52,9 @@ def setup_logging(
 
     logger.setLevel(root_level)
 
+    markdown_it_logger = logging.getLogger("markdown_it")
+    markdown_it_logger.setLevel(logging.INFO)
+
     # Console handler
     console_handler = logging.StreamHandler(stream=sys.stderr)
     console_handler.setLevel(logging.DEBUG if debug else logging.CRITICAL)

--- a/tests/co_op_translator/core/project/test_translation_manager.py
+++ b/tests/co_op_translator/core/project/test_translation_manager.py
@@ -249,6 +249,9 @@ async def test_translate_project_async_with_outdated(
     mock_translation_manager.directory_manager.migrate_markdown_image_links = (
         MagicMock(return_value=0)
     )
+    mock_translation_manager.directory_manager.migrate_notebook_image_links = (
+        MagicMock(return_value=0)
+    )
     mock_translation_manager.translation_types = ["markdown", "notebook", "images"]
     mock_translation_manager.translate_project_async = (
         TranslationManager.translate_project_async.__get__(mock_translation_manager)


### PR DESCRIPTION
## Purpose

This PR adds support for migrating image links inside Jupyter notebook (`.ipynb`) markdown cells, ensuring consistency with the existing markdown migration functionality. It also introduces improved logging behavior by explicitly configuring the `markdown_it` logger. Tests have been added and updated to cover new functionality.

## Description

This change introduces the following:

- **New `migrate_notebook_image_links` method** in `DirectoryManager` that:
  - Scans translated `.ipynb` files.
  - Updates markdown cell image references based on a provided rename map.
  - Writes updated notebook files back to disk.
  - Mirrors the logic of existing markdown file migration.

- **Updates to `TranslationManager.translate_project_async`**:
  - Integrates notebook migration in the overall image migration pipeline.
  - Enhances logging to reflect markdown and notebook file updates.

- **Logging improvements**:
  - Adds explicit configuration for the `markdown_it` logger, reducing noise and ensuring consistent log levels.

- **New and updated tests**:
  - `test_migrate_notebook_image_links` added to verify notebook migrations.
  - Translation manager tests updated to include the new migration call.
  - Ensures cross-platform path tests still function correctly.

These changes ensure translated notebooks remain in sync with updated image filenames and improve overall consistency across translation formats.

## Related Issue

<!-- Add the issue reference here if applicable -->
None specified.

## Does this introduce a breaking change?

- [ ] Yes  
- [x] No  

No breaking changes are expected. This adds new functionality without altering existing APIs. The migration only affects translated notebooks, which previously were not handled.

## Type of change

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactoring
- [ ] Documentation content changes
- [ ] Other...

## Checklist

- [x] **I have thoroughly tested my changes**
- [x] **All existing tests pass**
- [x] **I have added new tests where applicable**
- [x] **I have followed the Co-op Translators coding conventions**
- [x] **I have documented my changes where necessary**

## Additional context

This enhancement fills a functional gap where notebook markdown cells could retain outdated image names after image renaming operations. The added test coverage ensures reliability across environments.
