### PR TITLE
Improve image translation prompt generation and add line-number stripping utility

### DIFF
--- a/tests/co_op_translator/utils/llm/test_text_utils.py
+++ b/tests/co_op_translator/utils/llm/test_text_utils.py
@@ -1,6 +1,7 @@
 from co_op_translator.utils.llm.text_utils import (
     remove_code_backticks,
     gen_image_translation_prompt,
+    strip_line_number_prefix,
     TranslationResponse,
 )
 
@@ -20,7 +21,7 @@ def test_remove_code_backticks():
 
 
 def test_gen_image_translation_prompt():
-    """Test generating image translation prompts without numbering."""
+    """Test generating image translation prompts with numbered lines."""
     text_data = ["Line 1", "Line 2", "Line 3"]
     language_code = "ko"
     language_name = "Korean"
@@ -30,15 +31,30 @@ def test_gen_image_translation_prompt():
     assert isinstance(prompt, str)
     assert language_code in prompt
     assert language_name in prompt
-    assert "Keep exact same number of lines" in prompt
-    assert "preserve original formatting" in prompt
-    assert "Line 1\n" in prompt
-    assert "Line 2\n" in prompt
-    assert "Line 3\n" in prompt
-    # Ensure no numbering is added
-    assert "1. Line 1" not in prompt
-    assert "2. Line 2" not in prompt
-    assert "3. Line 3" not in prompt
+    # Check for new prompt format
+    assert "EXACTLY 3 items" in prompt
+    assert "without line numbers" in prompt
+    # Check numbered lines are included
+    assert "1. Line 1" in prompt
+    assert "2. Line 2" in prompt
+    assert "3. Line 3" in prompt
+
+
+def test_strip_line_number_prefix():
+    """Test stripping line number prefixes from text."""
+    test_cases = [
+        ("[1] Hello", "Hello"),
+        ("[12] World", "World"),
+        ("1. Hello", "Hello"),
+        ("12. World", "World"),
+        ("No prefix", "No prefix"),
+        ("[1]  Extra space", "Extra space"),
+        ("1.  Extra space", "Extra space"),
+    ]
+
+    for input_text, expected in test_cases:
+        result = strip_line_number_prefix(input_text)
+        assert result == expected, f"Failed for input: {input_text}"
 
 
 def test_gen_image_translation_prompt_empty():


### PR DESCRIPTION
# PR Title
Improve image translation prompt generation and add line-number stripping utility

## Purpose
Enhance the image translation prompt to support structured, numbered input while ensuring predictable model outputs.  
Add a reusable utility to strip line-number prefixes from OCR/vision model output.

## Description
This PR updates `gen_image_translation_prompt` to:

- Automatically number input lines for clarity.
- Enforce strict output rules (e.g., “EXACTLY N items”, no line numbers, preserve symbols).
- Correctly handle empty inputs.
- Simplify and clarify prompt formatting for LLMs.

Additionally:

- Introduces `LINE_NUMBER_PREFIX_PATTERN` and `strip_line_number_prefix` to normalize input text by removing prefixes like `1.`, `12.`, `[1]`, `[12]`, etc.
- Updates and expands the test suite:
  - Adapts existing prompt-generation tests to the new numbered-line format.
  - Adds full test coverage for the new `strip_line_number_prefix` utility.

## Related Issue
<!-- Add issue reference if applicable -->

## Does this introduce a breaking change?
- [x] Yes — `gen_image_translation_prompt` output format has changed, which could break consumers expecting the previous unnumbered formatting.
- [ ] No

## Type of change
- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactoring
- [ ] Documentation update
- [ ] Other

## Checklist
- [x] I have thoroughly tested my changes.
- [x] All existing tests pass.
- [x] I have added new tests where applicable.
- [x] I have followed the Co-op Translators coding conventions.
- [x] I have documented my changes where necessary.

## Additional context
These changes improve reliability when translating OCR/vision-extracted text where automatic numbering is crucial for structured LLM outputs and avoiding hallucinated or missing items.
