### PR TITLE
Core: Add Per-Language Image Metadata System, Outdated Image Detection, and Automated Retranslation

### DIFF
--- a/src/co_op_translator/core/project/directory_manager.py
+++ b/src/co_op_translator/core/project/directory_manager.py
@@ -9,6 +9,7 @@ from co_op_translator.utils.common.file_utils import (
 from pathlib import PurePosixPath
 from co_op_translator.utils.common.metadata_utils import (
     extract_metadata_from_content,
+    remove_image_metadata,
 )
 from co_op_translator.config.constants import (
     SUPPORTED_MARKDOWN_EXTENSIONS,
@@ -406,6 +407,8 @@ class DirectoryManager:
                                 logger.debug(
                                     f"Removed image with unsupported language code: {image_file}"
                                 )
+                                # Remove from central metadata file
+                                remove_image_metadata(image_file, image_dir)
                             except Exception as e:
                                 logger.warning(
                                     f"Failed to delete image with unsupported language {image_file}: {e}"
@@ -448,6 +451,8 @@ class DirectoryManager:
                                 image_file.unlink()
                                 removed_count += 1
                                 logger.debug(f"Removed orphaned image: {image_file}")
+                                # Remove from central metadata file
+                                remove_image_metadata(image_file, image_dir)
                             except Exception as e:
                                 logger.warning(
                                     f"Failed to delete orphaned image {image_file}: {e}"

--- a/tests/co_op_translator/core/project/test_translation_manager.py
+++ b/tests/co_op_translator/core/project/test_translation_manager.py
@@ -237,6 +237,8 @@ async def test_translate_project_async_with_outdated(
         return_value=[(test_md, temp_project_dir / "translations" / "ko" / "test.md")]
     )
     mock_translation_manager.retranslate_outdated_files = AsyncMock()
+    mock_translation_manager.get_outdated_images = MagicMock(return_value=[])
+    mock_translation_manager.retranslate_outdated_images = AsyncMock()
     # Ensure translate_* methods return the expected (modified_count, errors) tuple
     mock_translation_manager.translate_all_markdown_files = AsyncMock(
         return_value=(0, [])


### PR DESCRIPTION
# Add Per-Language Image Metadata System, Outdated Image Detection, and Automated Retranslation

## Purpose

This PR introduces a robust, hash-based metadata system for translated images, enabling the translator to detect outdated image translations, clean up orphaned metadata, and automatically retranslate modified images. This aligns image translation behavior with existing markdown and notebook translation metadata.

## Description

### Key Enhancements
- **Per-language `.co-op-translator.json` metadata files**
  - Stored in each `translated_images/<lang>/` directory.
  - Track original file hash, translation timestamp, and other metadata.
- **Reliable detection of outdated translations**
  - Added `is_image_up_to_date()` to verify if translated images match the current original image hash.
- **Automated retranslation of outdated images**
  - Added `get_outdated_images()` and `retranslate_outdated_images()` in `TranslationManager`.
  - Integrated outdated image detection into `translate_project_async()`.
- **Orphan metadata cleanup**
  - Added `cleanup_orphan_image_metadata()` to remove metadata entries for deleted images.
- **Image translation operations now save metadata**
  - Both normal and fallback translation paths call `save_image_metadata()`.
- **Thread-safe metadata writing**
  - Per-file locks prevent concurrent write conflicts.
- **Directory manager integration**
  - Metadata entries are removed when images are deleted or deemed unsupported.

### Testing
A comprehensive test suite was added:
- Tests for creating, reading, updating, and deleting image metadata.
- Tests for outdated image detection and orphan cleanup.
- Tests for integration with translation manager logic.
- Multi-language metadata isolation tests.

## Related Issue

(If applicable, reference an issue such as metadata consistency improvements or image retranslation reliability.)

## Does this introduce a breaking change?

- [ ] Yes  
- [x] No  

Metadata is newly added but does not affect existing projects; metadata files are created automatically when needed.

## Type of change

- [ ] Bugfix  
- [x] Feature  
- [ ] Code style update  
- [x] Refactoring  
- [ ] Documentation content changes  
- [ ] Other  

## Checklist

- [x] I have thoroughly tested my changes  
- [x] All existing tests pass  
- [x] I have added new tests  
- [x] I have followed the Co-op Translators coding conventions  
- [x] I have documented my changes where appropriate  

## Additional context

This PR significantly improves image translation reliability by giving images a dedicated metadata tracking system consistent with other content types. It fixes issues where updated source images were not properly detected and ensures metadata remains accurate even when files are manually removed.
