### PR TITLE
Core: Avoid bootstrapping text metadata for manual translations

### DIFF
--- a/src/co_op_translator/core/project/translation_manager.py
+++ b/src/co_op_translator/core/project/translation_manager.py
@@ -1407,13 +1407,10 @@ class TranslationManager:
                         else None
                     )
                     if not legacy_hash:
-                        save_text_metadata_for_source(
-                            lang_dir,
-                            original_file,
-                            lang_code,
-                            root_dir=self.root_dir,
-                        )
-                        migrated += 1
+                        # If there is no legacy inline metadata, do not synthesize
+                        # a fresh metadata record from the current source hash.
+                        # Doing so would incorrectly mark unknown/manual translations
+                        # as up-to-date and skip retranslation.
                         continue
 
                     extra_fields = {"original_hash": legacy_hash}

--- a/tests/co_op_translator/core/project/test_translation_manager.py
+++ b/tests/co_op_translator/core/project/test_translation_manager.py
@@ -245,6 +245,32 @@ def test_is_translation_outdated_walks_up_to_lang_dir(tmp_path):
     assert "lesson-1/README.md" in data
 
 
+def test_migrate_legacy_inline_text_metadata_skips_files_without_legacy_block(tmp_path):
+    root_dir = tmp_path
+    translations_dir = root_dir / "translations"
+    lang_dir = translations_dir / "ko"
+
+    source_file = root_dir / "guide.md"
+    source_file.write_text("# Source\n", encoding="utf-8")
+
+    translated_file = lang_dir / "guide.md"
+    translated_file.parent.mkdir(parents=True, exist_ok=True)
+    translated_file.write_text("# Manual translated content\n", encoding="utf-8")
+
+    manager = MagicMock()
+    manager.root_dir = root_dir
+    manager.translations_dir = translations_dir
+    manager.language_codes = ["ko"]
+    manager._migrate_legacy_inline_text_metadata = (
+        TranslationManager._migrate_legacy_inline_text_metadata.__get__(manager)
+    )
+
+    migrated = manager._migrate_legacy_inline_text_metadata()
+
+    assert migrated == 0
+    assert not (lang_dir / ".co-op-translator.json").exists()
+
+
 @pytest.mark.asyncio
 async def test_retranslate_outdated_files(mock_translation_manager, temp_project_dir):
     """Tests retranslation of outdated files."""


### PR DESCRIPTION
# Core: Avoid bootstrapping text metadata for manual translations

## Purpose

This change prevents the system from automatically generating new text-metadata records when no legacy inline metadata block exists. Previously, the migration process synthesized metadata using the current source hash, which incorrectly marked manually translated files as “up-to-date,” causing them to be skipped during retranslation.

## Description

- Updated `_migrate_legacy_inline_text_metadata` to **skip** synthesizing text metadata when a translation file lacks a legacy inline metadata block.
- Ensures manual translations are not inadvertently treated as valid or current.
- Added a new test (`test_migrate_legacy_inline_text_metadata_skips_files_without_legacy_block`) validating that:
  - No metadata file is created,
  - `migrated` count remains `0` for such files.
- This improves accuracy during migration and preserves expected behavior for manually maintained translations.

## Related Issue

<!-- Add link if applicable, e.g. Fixes #123 -->

## Does this introduce a breaking change?

- [ ] Yes  
- [x] No  

## Type of change

- [ ] Bugfix  
- [x] Feature  
- [ ] Code style update  
- [ ] Refactoring  
- [ ] Documentation content changes  
- [ ] Other...

## Checklist

- [x] **I have thoroughly tested my changes**
- [x] **All existing tests pass**
- [x] **I have added new tests**
- [x] **I have followed the Co-op Translators coding conventions**
- [x] **I have documented my changes** (where necessary)

## Additional context

This prevents metadata pollution during migration and ensures correct handling of unknown/manual translation files going forward.
