### PR TITLE
Core: Prevent list-item chunk splits around code placeholders

### DIFF
--- a/tests/co_op_translator/utils/llm/test_markdown_utils.py
+++ b/tests/co_op_translator/utils/llm/test_markdown_utils.py
@@ -175,6 +175,20 @@ def test_split_markdown_content():
     assert all(isinstance(chunk, str) for chunk in chunks)
 
 
+def test_split_markdown_content_keeps_list_item_with_code_placeholder():
+    """List item text and indented code placeholder should stay in the same chunk."""
+    content = """- Step 1: run this command\n    @@CODE_BLOCK_0@@\n\nParagraph after list item.\n"""
+
+    class MockTokenizer:
+        def encode(self, text):
+            return [0] * len(text)
+
+    chunks = split_markdown_content(content, 30, MockTokenizer())
+
+    assert len(chunks) >= 1
+    assert any("- Step 1" in chunk and "@@CODE_BLOCK_0@@" in chunk for chunk in chunks)
+
+
 @pytest.fixture
 def complex_dir_structure(tmp_path):
     """Create a more complex directory structure for testing nested paths."""


### PR DESCRIPTION
# Core: Prevent list-item chunk splits around code placeholders

## Purpose

Markdown splitting previously allowed list-item bullets and their associated indented code placeholders (e.g., `@@CODE_BLOCK_X@@`) to be separated into different chunks. This caused downstream LLM formatting or translation steps to lose structural integrity. This PR ensures that list-item blocks—including nested or indented code placeholders—remain intact during markdown chunking.

## Description

- Added `_group_lines_preserving_list_items` to detect and group:
  - Markdown list items (`-`, `*`, `+`, numbered lists),
  - Their continuation lines,
  - Indented code placeholders such as `@@CODE_BLOCK_0@@`.
- Updated `split_markdown_content` logic to process grouped list-item blocks as atomic units.
- Fixed token-counting behavior by ensuring `line_with_break` uses the correct text form when counting.
- Updated tests with:
  - `test_split_markdown_content_keeps_list_item_with_code_placeholder` to validate that list-item and its placeholder stay in the same chunk.
- This results in more stable chunking behavior for translation and LLM processing.

## Related Issue

<!-- Add if applicable, e.g., Fixes #370 -->

#357
#239

## Does this introduce a breaking change?

- [ ] Yes  
- [x] No  

## Type of change

- [x] Bugfix  
- [ ] Feature  
- [ ] Code style update  
- [ ] Refactoring  
- [ ] Documentation content changes  
- [ ] Other...

## Checklist

- [x] **I have thoroughly tested my changes**
- [x] **All existing tests pass**
- [x] **I have added new tests**
- [x] **I have followed the Co-op Translators coding conventions**
- [x] **I have documented my changes** (N/A or added where needed)

## Additional context

This fix is especially important for preserving markdown semantics when chunking large documents for LLM translation, ensuring that list-item structures—including nested content and placeholder blocks—are never broken apart.
