### PR TITLE
Core: Add Language-Specific Markdown Templates and Improve Markdown Preservation Logic

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ license = "MIT"
 readme = "README.md"
 keywords = ["translator", "translation","azure", "openai", "gpt"]
 packages = [{ include = "co_op_translator", from = "src" }]
-include = ["src/co_op_translator/fonts/*", "src/co_op_translator/templates/*"]
+include = ["src/co_op_translator/fonts/*", "src/co_op_translator/templates/**/*"]
 documentation = "https://github.com/Azure/co-op-translator/tree/main/getting_started"
 
 [tool.poetry.scripts]

--- a/src/co_op_translator/core/llm/markdown_translator.py
+++ b/src/co_op_translator/core/llm/markdown_translator.py
@@ -253,7 +253,9 @@ class MarkdownTranslator(ABC):
 
         language_name = self.font_config.get_language_name(output_lang)
         system_text = (
-            f"Translate the following text to {language_name} ({output_lang})."
+            f"Translate the following text to {language_name} ({output_lang}). "
+            "Preserve Markdown syntax and tokens exactly as written; "
+            "if links are present, keep Markdown link structure [text](URL) and do not rewrite links as plain text."
         )
         user_text = template_text
         disclaimer_prompt = system_text + SPLIT_DELIMITER + user_text

--- a/src/co_op_translator/templates/language/ja.md
+++ b/src/co_op_translator/templates/language/ja.md
@@ -1,0 +1,15 @@
+Japanese mode: preserve Markdown tokens strictly.
+
+Rules (must follow):
+1) Keep Markdown links exactly: [text](URL) -> [translated text](same URL).
+2) NEVER rewrite links as plain text (e.g., 「text」（URL）, text (URL)).
+3) Translate only link text; keep Markdown structure and URL unchanged.
+4) Do not add 「」 around a Markdown link unless outside-link grammar requires it.
+
+STRUCTURE IS MORE IMPORTANT THAN STYLE.
+Do not optimize Japanese naturalness if Markdown tokens would change.
+
+Example
+Source: This document uses [Co-op Translator](https://github.com/Azure/co-op-translator).
+Correct: 本書類は [Co-op Translator](https://github.com/Azure/co-op-translator) を使用しています。
+Incorrect: 本書類は「Co-op Translator」（https://github.com/Azure/co-op-translator）を使用しています。

--- a/tests/co_op_translator/utils/llm/test_markdown_utils.py
+++ b/tests/co_op_translator/utils/llm/test_markdown_utils.py
@@ -139,6 +139,23 @@ def test_generate_prompt_template():
     assert document_chunk in prompt
 
 
+def test_generate_prompt_template_includes_japanese_language_template():
+    """Japanese prompt should include strict markdown-preservation template text."""
+    document_chunk = "This document uses [Co-op Translator](https://github.com/Azure/co-op-translator)."
+
+    prompt = generate_prompt_template("ja", "Japanese", document_chunk, False)
+
+    assert "STRUCTURE IS MORE IMPORTANT THAN STYLE." in prompt
+    assert "NEVER rewrite links as plain text" in prompt
+
+
+def test_generate_prompt_template_without_language_template_for_non_configured_language():
+    """Languages without a dedicated template should use the default prompt only."""
+    prompt = generate_prompt_template("ko", "Korean", "Test content", False)
+
+    assert "STRUCTURE IS MORE IMPORTANT THAN STYLE." not in prompt
+
+
 def test_count_links_in_markdown():
     """Test counting links in markdown content."""
     content = """


### PR DESCRIPTION
## Purpose

This PR introduces support for language-specific Markdown prompt templates (beginning with Japanese) and strengthens Markdown-preservation rules used when generating LLM prompts. It ensures links, structure, and formatting remain stable during translation while improving test coverage for these behaviors.

## Description

### Key changes:
- **Enhanced packaging include rules** in `pyproject.toml` to correctly bundle nested template directories.
- **Updated disclaimer generation logic** to append stricter Markdown safety instructions.
- **Added a new Japanese prompt template** (`ja.md`) enforcing strict Markdown token preservation.
- **Added language-specific template loading** in `markdown_utils.py`, injecting template content into constructed prompts when available.
- **Improved test coverage**:
  - Tests verifying disclaimer prompt includes new Markdown-preservation instructions.
  - Tests confirming Japanese template inclusion and fallback behavior for non-configured languages.
  - Tests validating prompt structure generation and link counting behavior.

These changes ensure translation requests maintain valid Markdown structure, especially for links.

## Related Issue

<!-- Link any related issues if applicable -->
(If this resolves a specific issue, add: *Fixes #ISSUE_NUMBER*)

Fixes #363 
Fixes #235


## Does this introduce a breaking change?

- [ ] Yes  
- [x] No  

The changes are additive and do not affect existing APIs. Packaging paths are expanded but remain backward-compatible.

## Type of change

- [ ] Bugfix  
- [x] Feature  
- [ ] Code style update  
- [ ] Refactoring  
- [ ] Documentation content changes  
- [ ] Other...

## Checklist

- [x] **I have thoroughly tested my changes**  
- [x] **All existing tests pass**  
- [x] **I have added new tests** where appropriate  
- [x] **I have followed the Co-op Translators coding conventions**  
- [x] **I have documented my changes** via the new `ja.md` template and improved tests  

## Additional context

These updates improve translation reliability for languages requiring strict formatting constraints (starting with Japanese) and fix packaging issues that previously omitted nested template files.