### PR TITLE
Core: Include language-specific prompt template in disclaimer generation

### DIFF
--- a/src/co_op_translator/core/llm/markdown_translator.py
+++ b/src/co_op_translator/core/llm/markdown_translator.py
@@ -9,6 +9,7 @@ from co_op_translator.utils.llm.markdown_utils import (
     process_markdown,
     update_links,
     generate_prompt_template,
+    _read_language_prompt_template,
     replace_code_blocks,
     restore_code_blocks,
     SPLIT_DELIMITER,
@@ -257,6 +258,9 @@ class MarkdownTranslator(ABC):
             "Preserve Markdown syntax and tokens exactly as written; "
             "if links are present, keep Markdown link structure [text](URL) and do not rewrite links as plain text."
         )
+        language_template = _read_language_prompt_template(output_lang)
+        if language_template:
+            system_text += f"\n\n{language_template}"
         user_text = template_text
         disclaimer_prompt = system_text + SPLIT_DELIMITER + user_text
 

--- a/tests/co_op_translator/core/llm/test_markdown_translator.py
+++ b/tests/co_op_translator/core/llm/test_markdown_translator.py
@@ -85,6 +85,8 @@ async def test_generate_disclaimer_includes_markdown_safety_rules(real_markdown_
     assert len(captured_prompts) == 1
     assert "Preserve Markdown syntax and tokens exactly as written" in captured_prompts[0]
     assert "keep Markdown link structure [text](URL)" in captured_prompts[0]
+    assert "Japanese mode: preserve Markdown tokens strictly." in captured_prompts[0]
+    assert "NEVER rewrite links as plain text" in captured_prompts[0]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Purpose
Ensure that language-specific translation rules are applied when generating disclaimers in Markdown translations.

## Description
This change enhances the `generate_disclaimer` method by incorporating language-specific prompt templates into the system prompt. The function now reads a language template using `_read_language_prompt_template(output_lang)` and appends it to the system prompt if available. This ensures that additional translation constraints (such as strict Markdown preservation rules for specific languages) are respected during disclaimer generation.

Additionally, the corresponding unit test has been updated to verify that the language-specific instructions are included in the generated prompt. The test now asserts the presence of the Japanese-specific rule (`"Japanese mode: preserve Markdown tokens strictly."`) and a stricter link preservation instruction (`"NEVER rewrite links as plain text"`).

These updates help maintain consistent translation behavior across languages and prevent Markdown structures or links from being altered during translation.

## Related Issue

#363

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

- [ ] Yes
- [x] No

## Type of change

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (e.g., formatting, local variables)
- [ ] Refactoring (no functional or API changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Checklist

Before submitting your pull request, please confirm the following:

- [x] **I have thoroughly tested my changes**: I confirm that I have run the code and manually tested all affected areas.
- [x] **All existing tests pass**: I have run all tests and confirmed that nothing is broken.
- [x] **I have added new tests** (if applicable): I have written tests that cover the new functionality introduced by my code changes.
- [x] **I have followed the Co-op Translators coding conventions**: My code adheres to the style guide and coding conventions outlined in the repository.
- [x] **I have documented my changes** (if applicable): I have updated the documentation to reflect the changes where necessary.

## Additional context
This change improves translation quality and Markdown fidelity by allowing language-specific translation guidance to be dynamically included in disclaimer prompts.