### PR TITLE
Core: Preserve current-document markdown links

### DIFF
--- a/src/co_op_translator/utils/llm/markdown_utils.py
+++ b/src/co_op_translator/utils/llm/markdown_utils.py
@@ -1248,10 +1248,15 @@ def update_untranslated_file_links(
 
     for alt_text, link in file_matches:
         parsed_url = urlparse(link)
+        path = parsed_url.path
 
-        # Keep same-document anchors untouched (e.g., [Section](#section)).
-        if parsed_url.fragment and not parsed_url.path:
-            logger.info(f"Skipping internal anchor link {link}")
+        # Keep same-document links untouched. Some LLMs occasionally emit
+        # empty/current-page links while preserving TOCs; treating those as
+        # files rewrites them to the source directory path.
+        if path in ("", ".", "./") or (
+            path == "/" and (parsed_url.fragment or parsed_url.query)
+        ):
+            logger.info(f"Skipping same-document link {link}")
             continue
 
         if (
@@ -1262,7 +1267,6 @@ def update_untranslated_file_links(
             logger.info(f"Skipped {link} as it is an email or web URL")
             continue
 
-        path = parsed_url.path
         original_filename, file_ext = get_filename_and_extension(path)
 
         if file_ext in SUPPORTED_IMAGE_EXTENSIONS:

--- a/tests/co_op_translator/utils/llm/test_markdown_utils.py
+++ b/tests/co_op_translator/utils/llm/test_markdown_utils.py
@@ -129,6 +129,30 @@ def test_update_untranslated_file_links_skips_internal_anchor_links(temp_dir):
     assert "../.." not in result
 
 
+@pytest.mark.parametrize(
+    "link",
+    ["", ".", "./", "?tab=readme", ".#section-one", "./#section-one", "/#section-one"],
+)
+def test_update_untranslated_file_links_skips_current_document_links(temp_dir, link):
+    """Current-document links should not be rewritten to the source directory."""
+    md_file_path = temp_dir / "docs" / "README.md"
+    md_file_path.parent.mkdir(exist_ok=True)
+    md_file_path.touch()
+
+    translations_dir = temp_dir / "translations"
+    translations_dir.mkdir(exist_ok=True)
+    (translations_dir / "ja").mkdir(exist_ok=True)
+
+    test_markdown = f"- [Section]({link})"
+
+    result = update_untranslated_file_links(
+        test_markdown, md_file_path, "ja", translations_dir, temp_dir
+    )
+
+    assert result == test_markdown
+    assert "../" not in result
+
+
 def test_process_markdown():
     """Test processing markdown content into chunks."""
     content = "# Test\n" * 100  # Create large content


### PR DESCRIPTION
## Summary

This PR fixes incorrect rewriting of current-document markdown links during untranslated file link handling.

## What changed

- Skip rewriting for current-document markdown links during untranslated file link processing
- Prevent TOC and current-page anchor links from being converted into source-directory relative paths
- Added regression coverage for edge cases including:
  - Empty links
  - Dot (`.`) links
  - Query-only links
  - Current-page anchor links

## Why

Previously, links that pointed to the current document (such as TOC anchors or same-page references) could be incorrectly rewritten as relative paths to untranslated source files.

This resulted in broken links like:
`../../../../../../md/.../Phi3`

The fix ensures that same-document links are correctly preserved and not treated as external or untranslated file references.

## Validation

Executed targeted test suites:

- `python -m pytest tests/co_op_translator/utils/llm/test_markdown_utils.py -q --basetemp=test_docs/pytest_anchor_fix` → `43 passed`
- `python -m pytest --basetemp=test_docs/pytest_anchor_full` → `242 passed`

## Notes

Fixes cases where translated TOC links were incorrectly rewritten when the link target referred to the current document rather than an untranslated file.