### PR TITLE
Core: Add glossary support to programmatic API

### DIFF
--- a/src/co_op_translator/api/translation.py
+++ b/src/co_op_translator/api/translation.py
@@ -13,6 +13,7 @@ from co_op_translator.config.llm_config.config import LLMConfig
 from co_op_translator.config.vision_config.config import VisionConfig
 from co_op_translator.core.project.language_migrator import LanguageFolderMigrator
 from co_op_translator.core.project.project_translator import ProjectTranslator
+from co_op_translator.glossary import glossary_terms_scope
 from co_op_translator.utils.common.file_utils import (
     render_updated_readme_languages_table,
     render_updated_readme_other_courses,
@@ -67,6 +68,7 @@ def run_translation(
     root_dirs: Iterable[str] | None = None,
     groups: Iterable[tuple[str, str | None]] | None = None,
     repo_url: str | None = None,
+    glossaries: Iterable[str] | None = None,
     dry_run: bool = False,
 ) -> None:
     """Programmatic translation entrypoint mirroring the translate CLI options."""
@@ -289,7 +291,9 @@ def run_translation(
 
             try:
                 if update_readme_other_courses(readme_path):
-                    click.echo("✅ Updated README 'Other courses' section from template.")
+                    click.echo(
+                        "✅ Updated README 'Other courses' section from template."
+                    )
             except Exception as e:  # pragma: no cover
                 logger.warning(f"Failed to update README 'Other courses': {e}")
 
@@ -449,80 +453,83 @@ def run_translation(
             else:
                 os.environ["TQDM_DISABLE"] = previous
 
-    aggregate_template = {
-        "markdown": 0,
-        "notebook": 0,
-        "images": 0,
-        "outdated_markdown": 0,
-        "outdated_notebook": 0,
-        "outdated_images": 0,
-        "outdated": 0,
-        "total": 0,
-        "words": 0,
-    }
-    translation_types_for_summary: list[str] = []
-    if markdown:
-        translation_types_for_summary.append("markdown")
-    if images:
-        translation_types_for_summary.append("images")
-    if notebook:
-        translation_types_for_summary.append("notebook")
-    if not translation_types_for_summary:
-        translation_types_for_summary = ["markdown", "notebook", "images"]
+    with glossary_terms_scope(glossaries):
+        aggregate_template = {
+            "markdown": 0,
+            "notebook": 0,
+            "images": 0,
+            "outdated_markdown": 0,
+            "outdated_notebook": 0,
+            "outdated_images": 0,
+            "outdated": 0,
+            "total": 0,
+            "words": 0,
+        }
+        translation_types_for_summary: list[str] = []
+        if markdown:
+            translation_types_for_summary.append("markdown")
+        if images:
+            translation_types_for_summary.append("images")
+        if notebook:
+            translation_types_for_summary.append("notebook")
+        if not translation_types_for_summary:
+            translation_types_for_summary = ["markdown", "notebook", "images"]
 
-    execution_targets: list[tuple[str, str | None, str | None]] = []
-    if groups is not None:
-        for per_root, per_translations in list(groups):
-            per_translations_dir: str | None = per_translations
-            per_lang_subdir: str | None = None
-            if per_translations is not None:
-                base_part, suffix = _split_lang_placeholder(per_translations)
-                per_translations_dir = base_part or None
-                per_lang_subdir = suffix
-            execution_targets.append((per_root, per_translations_dir, per_lang_subdir))
-    elif root_dirs is not None:
-        for per_root in list(root_dirs):
-            execution_targets.append((per_root, translations_dir, None))
-    else:
-        execution_targets.append((root_dir, translations_dir, None))
+        execution_targets: list[tuple[str, str | None, str | None]] = []
+        if groups is not None:
+            for per_root, per_translations in list(groups):
+                per_translations_dir: str | None = per_translations
+                per_lang_subdir: str | None = None
+                if per_translations is not None:
+                    base_part, suffix = _split_lang_placeholder(per_translations)
+                    per_translations_dir = base_part or None
+                    per_lang_subdir = suffix
+                execution_targets.append(
+                    (per_root, per_translations_dir, per_lang_subdir)
+                )
+        elif root_dirs is not None:
+            for per_root in list(root_dirs):
+                execution_targets.append((per_root, translations_dir, None))
+        else:
+            execution_targets.append((root_dir, translations_dir, None))
 
-    aggregated_estimate = dict(aggregate_template)
-    for per_root, per_translations_dir, per_lang_subdir in execution_targets:
-        group_estimate = _compute_estimate_for_group(
-            language_codes=language_codes,
-            root_dir=per_root,
-            update=update,
-            markdown=markdown,
-            images=images,
-            notebook=notebook,
-            add_disclaimer=add_disclaimer,
-            translations_dir=per_translations_dir,
-            image_dir=image_dir,
-            lang_subdir=per_lang_subdir,
-            repo_url=repo_url,
-        )
-        aggregated_estimate = _merge_estimates(aggregated_estimate, group_estimate)
-
-    _echo_estimate_summary(aggregated_estimate, translation_types_for_summary)
-
-    multi_group_mode = len(execution_targets) > 1
-
-    for per_root, per_translations_dir, per_lang_subdir in execution_targets:
-        with _tqdm_disabled(multi_group_mode):
-            _run_single_group(
+        aggregated_estimate = dict(aggregate_template)
+        for per_root, per_translations_dir, per_lang_subdir in execution_targets:
+            group_estimate = _compute_estimate_for_group(
                 language_codes=language_codes,
                 root_dir=per_root,
                 update=update,
-                images=images,
                 markdown=markdown,
+                images=images,
                 notebook=notebook,
-                debug=debug,
-                save_logs=save_logs,
-                yes=yes,
                 add_disclaimer=add_disclaimer,
                 translations_dir=per_translations_dir,
                 image_dir=image_dir,
                 lang_subdir=per_lang_subdir,
                 repo_url=repo_url,
-                dry_run=dry_run,
             )
+            aggregated_estimate = _merge_estimates(aggregated_estimate, group_estimate)
+
+        _echo_estimate_summary(aggregated_estimate, translation_types_for_summary)
+
+        multi_group_mode = len(execution_targets) > 1
+
+        for per_root, per_translations_dir, per_lang_subdir in execution_targets:
+            with _tqdm_disabled(multi_group_mode):
+                _run_single_group(
+                    language_codes=language_codes,
+                    root_dir=per_root,
+                    update=update,
+                    images=images,
+                    markdown=markdown,
+                    notebook=notebook,
+                    debug=debug,
+                    save_logs=save_logs,
+                    yes=yes,
+                    add_disclaimer=add_disclaimer,
+                    translations_dir=per_translations_dir,
+                    image_dir=image_dir,
+                    lang_subdir=per_lang_subdir,
+                    repo_url=repo_url,
+                    dry_run=dry_run,
+                )

--- a/src/co_op_translator/glossary.py
+++ b/src/co_op_translator/glossary.py
@@ -1,4 +1,5 @@
-from typing import Iterable
+from contextlib import contextmanager
+from typing import Iterable, Iterator
 
 _glossary_terms: list[str] = []
 
@@ -7,6 +8,9 @@ def normalize_glossary_terms(glossary_terms: Iterable[str] | None) -> list[str]:
     """Normalize glossary terms into a de-duplicated ordered list of strings."""
     if not glossary_terms:
         return []
+
+    if isinstance(glossary_terms, str):
+        glossary_terms = [glossary_terms]
 
     normalized: list[str] = []
     seen: set[str] = set()
@@ -30,6 +34,17 @@ def set_glossary_terms(glossary_terms: Iterable[str] | None) -> None:
 def get_glossary_terms() -> list[str]:
     """Return the current process-wide glossary terms."""
     return list(_glossary_terms)
+
+
+@contextmanager
+def glossary_terms_scope(glossary_terms: Iterable[str] | None) -> Iterator[None]:
+    """Temporarily set glossary terms for one translation API invocation."""
+    previous_terms = get_glossary_terms()
+    set_glossary_terms(glossary_terms)
+    try:
+        yield
+    finally:
+        set_glossary_terms(previous_terms)
 
 
 def _build_glossary_lines() -> list[str]:

--- a/tests/co_op_translator/test_api.py
+++ b/tests/co_op_translator/test_api.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from co_op_translator.api import translation as api
+from co_op_translator.glossary import get_glossary_terms, set_glossary_terms
 
 
 @pytest.mark.asyncio
@@ -310,3 +311,59 @@ async def test_run_translation_dry_run_uses_virtual_readme_without_writing(tmp_p
     assert readme_path.read_text(encoding="utf-8") == original_readme
     api.update_readme_languages_table.assert_not_called()
     api.update_readme_other_courses.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_run_translation_accepts_glossaries_and_restores_previous_terms(tmp_path):
+    root_dir = tmp_path
+
+    api.Config.check_configuration = MagicMock(return_value=None)
+    api.LLMConfig.validate_connectivity = MagicMock(return_value=None)
+    api.setup_logging = MagicMock(return_value=None)
+
+    project_translator_instance = MagicMock()
+    project_translator_class = MagicMock(return_value=project_translator_instance)
+    api.ProjectTranslator = project_translator_class
+
+    observed_terms: list[list[str]] = []
+
+    def fake_estimate_tokens(*args, **kwargs):
+        observed_terms.append(get_glossary_terms())
+        return {
+            "markdown": 10,
+            "notebook": 0,
+            "images": 0,
+            "outdated_markdown": 0,
+            "outdated_notebook": 0,
+            "outdated_images": 0,
+            "outdated": 0,
+            "total": 10,
+        }
+
+    api.estimate_translation_tokens = MagicMock(side_effect=fake_estimate_tokens)
+    api.estimate_translation_words = MagicMock(
+        return_value={
+            "markdown": 5,
+            "notebook": 0,
+            "images": 0,
+            "outdated": 0,
+            "total": 5,
+        }
+    )
+
+    set_glossary_terms(["Existing Term"])
+    try:
+        api.run_translation(
+            language_codes="ko",
+            root_dir=str(root_dir),
+            markdown=True,
+            glossaries=[" Co-op Translator ", "Co-op Translator", "Azure AI"],
+        )
+
+        assert observed_terms == [["Co-op Translator", "Azure AI"]]
+        assert get_glossary_terms() == ["Existing Term"]
+        project_translator_instance.translate_project.assert_called_once_with(
+            update=False,
+        )
+    finally:
+        set_glossary_terms([])


### PR DESCRIPTION
## Purpose

Add first-class glossary support to the Co-op Translator programmatic API so external integrations, including Localizeflow, can pass glossary terms directly through `co_op_translator.api.run_translation`.

## Description

This change updates the public `run_translation` API to accept a `glossaries` argument and applies those terms during the full translation invocation, including token estimation and execution.

The implementation reuses the existing glossary prompt-injection path already used by Markdown and image translation prompts. It also adds a scoped glossary context so terms are active only for the current API call and previous process-wide glossary state is restored afterward. This prevents glossary terms from leaking between separate programmatic invocations.

Changes include:

- Added `glossaries: Iterable[str] | None` to `co_op_translator.api.run_translation`
- Added `glossary_terms_scope` to temporarily set and restore glossary terms
- Improved glossary normalization so a single string is treated as one glossary term instead of an iterable of characters
- Added API coverage to verify glossary terms are normalized, applied, and restored after the run

## Related Issue

N/A

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

- [ ] Yes
- [x] No

## Type of change

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (e.g., formatting, local variables)
- [ ] Refactoring (no functional or API changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Checklist

Before submitting your pull request, please confirm the following:

- [x] **I have thoroughly tested my changes**: I confirm that I have run the code and manually tested all affected areas.
- [x] **All existing tests pass**: I have run all tests and confirmed that nothing is broken.
- [x] **I have added new tests** (if applicable): I have written tests that cover the new functionality introduced by my code changes.
- [x] **I have followed the Co-op Translators coding conventions**: My code adheres to the style guide and coding conventions outlined in the repository.
- [x] **I have documented my changes** (if applicable): No documentation update was required for this internal programmatic API compatibility change.
