### PR TITLE
Core: Preserve Mermaid fence boundaries during translation

### DIFF
--- a/src/co_op_translator/utils/llm/code_comment_translator.py
+++ b/src/co_op_translator/utils/llm/code_comment_translator.py
@@ -166,7 +166,53 @@ async def _translate_mermaid_block(
     prompt = instruction + SPLIT_DELIMITER + code_block
 
     translated = await run_prompt(prompt, "mermaid", 1)
-    return translated or code_block
+    if not translated:
+        return code_block
+
+    return _normalize_mermaid_fence_boundaries(translated, code_block)
+
+
+def _normalize_mermaid_fence_boundaries(
+    translated_block: str, original_block: str
+) -> str:
+    """Keep translated Mermaid fences parseable after LLM post-processing.
+
+    LLMs sometimes preserve the fence markers but collapse the newline before or
+    after the closing fence, producing invalid Markdown like ``end```Text``.
+    Normalize only the fence boundaries; leave the diagram body untouched.
+    """
+    original_lines = original_block.splitlines(keepends=True)
+    if not original_lines:
+        return translated_block
+
+    opening_line = original_lines[0]
+    fence_match = re.match(r"^(\s*)(`{3,}|~{3,})", opening_line)
+    if not fence_match:
+        return translated_block
+
+    fence_marker = fence_match.group(2)
+    normalized = translated_block
+
+    if not normalized.lstrip().startswith(fence_marker):
+        inner = normalized.strip("\r\n")
+        normalized = opening_line + inner
+        if inner and not inner.endswith(("\n", "\r")):
+            normalized += "\n"
+        normalized += fence_marker
+
+    escaped_marker = re.escape(fence_marker)
+    normalized = re.sub(
+        rf"([^\r\n])({escaped_marker})(?=\s*(?:\r?\n|$))",
+        r"\1\n\2",
+        normalized,
+    )
+
+    if original_block.endswith(("\r\n", "\n", "\r")) and not normalized.endswith(
+        ("\r\n", "\n", "\r")
+    ):
+        normalized += "\n"
+
+    return normalized
 
 
 def _extract_language_from_fence(fence_line: str) -> str:

--- a/tests/co_op_translator/core/llm/test_markdown_translator.py
+++ b/tests/co_op_translator/core/llm/test_markdown_translator.py
@@ -36,6 +36,20 @@ graph TD;
 """
 
 
+TEST_MD_WITH_MERMAID_AND_PARAGRAPH = """
+# Sample Markdown
+
+```mermaid
+graph TD
+    ServerA --> KnowledgeA
+    subgraph Server A
+        KnowledgeA[Knowledge]
+    end
+```
+Universal connector text.
+"""
+
+
 TEST_MD_WITH_DETAILS = """
 # Sample Details
 
@@ -273,6 +287,45 @@ async def test_translate_markdown_translates_mermaid_block(
     assert "[es]Decision[/es]" in result
     assert "[es]Do it[/es]" in result
     assert "[es]Stop[/es]" in result
+
+
+@pytest.mark.asyncio
+async def test_translate_markdown_keeps_mermaid_closing_fence_separate_from_text(
+    real_markdown_translator, tmp_path
+):
+    """Mermaid fence boundaries must survive translation before paragraph text."""
+    test_file = tmp_path / "example_mermaid_paragraph.md"
+    test_file.write_text(TEST_MD_WITH_MERMAID_AND_PARAGRAPH)
+
+    async def fake_prompt(prompt, index, total):
+        if "Mermaid diagram code" in prompt:
+            _, code_block = prompt.split(SPLIT_DELIMITER, 1)
+            return code_block.replace("Knowledge", "知識").replace("\n```\n", "```")
+        if "Sample Markdown" in prompt:
+            _, body = prompt.split(SPLIT_DELIMITER, 1)
+            return body.replace("# Sample Markdown", "# サンプル Markdown").replace(
+                "Universal connector text.", "ユニバーサルコネクターにより"
+            )
+        if "Disclaimer" in prompt.lower():
+            return "Aviso Legal: Este es un documento traducido."
+        return prompt
+
+    with patch.object(
+        real_markdown_translator, "_run_prompt", new_callable=AsyncMock
+    ) as mock_run_prompt:
+        mock_run_prompt.side_effect = fake_prompt
+
+        result = await real_markdown_translator.translate_markdown(
+            document=TEST_MD_WITH_MERMAID_AND_PARAGRAPH,
+            language_code="ja",
+            md_file_path=test_file,
+            add_metadata=False,
+            add_disclaimer=False,
+        )
+
+    assert "end\n```\nユニバーサルコネクターにより" in result
+    assert "end```" not in result
+    assert "```ユニバーサル" not in result
 
 
 @pytest.mark.asyncio

--- a/tests/co_op_translator/utils/llm/test_code_comment_translator.py
+++ b/tests/co_op_translator/utils/llm/test_code_comment_translator.py
@@ -103,6 +103,41 @@ async def test_translate_comments_in_code_blocks_mermaid_block():
 
 
 @pytest.mark.asyncio
+async def test_translate_comments_in_code_blocks_mermaid_restores_fence_newlines():
+    """Mermaid translation must keep closing fences on their own lines."""
+
+    placeholder_map = {
+        "@@CODE_BLOCK_0@@": (
+            "```mermaid\n"
+            "graph TD\n"
+            "    subgraph Server A\n"
+            "        KnowledgeA[Knowledge]\n"
+            "    end\n"
+            "```\n"
+        )
+    }
+
+    async def fake_run_prompt(prompt, index, total):
+        if "Mermaid diagram code" in prompt:
+            _, code_block = prompt.split(SPLIT_DELIMITER, 1)
+            return code_block.replace("Knowledge", "知識").replace("\n```\n", "```")
+        return prompt
+
+    result_map = await translate_comments_in_code_blocks(
+        placeholder_map,
+        language_code="ja",
+        language_name="Japanese",
+        is_rtl=False,
+        run_prompt=fake_run_prompt,
+    )
+
+    translated_block = result_map["@@CODE_BLOCK_0@@"]
+
+    assert "end\n```\n" in translated_block
+    assert "end```" not in translated_block
+
+
+@pytest.mark.asyncio
 async def test_translate_comments_in_code_blocks_non_code_block_unchanged():
     """Non-fenced or unsupported language blocks should be returned unchanged."""
 


### PR DESCRIPTION
## Purpose

Fix Mermaid diagram translations that became unrenderable when the translated fenced block lost the newline around the closing code fence.

## Description

This change fixes a Markdown restoration bug in the Mermaid-specific translation path.

Previously, Mermaid blocks were sent through a dedicated LLM translation flow and the translated block was restored almost verbatim. In some cases, the model preserved the Mermaid content but collapsed the newline before or after the closing fence, producing invalid Markdown like `end```...`, which caused GitHub Mermaid rendering to fail.

This PR:
- normalizes Mermaid fence boundaries before restoring translated Mermaid blocks
- preserves valid fenced block structure even when the model returns collapsed fence newlines
- adds regression coverage for both the Mermaid block helper and the full Markdown translation flow
- verifies that prose following a Mermaid block remains outside the fence

## Related Issue

Fixes #400

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

- [ ] Yes
- [x] No

## Type of change

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (e.g., formatting, local variables)
- [ ] Refactoring (no functional or API changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Checklist

Before submitting your pull request, please confirm the following:

- [x] **I have thoroughly tested my changes**: I confirm that I have run the code and manually tested all affected areas.
- [x] **All existing tests pass**: I have run all tests and confirmed that nothing is broken.
- [x] **I have added new tests** (if applicable): I have written tests that cover the new functionality introduced by my code changes.
- [x] **I have followed the Co-op Translators coding conventions**: My code adheres to the style guide and coding conventions outlined in the repository.
- [ ] **I have documented my changes** (if applicable): I have updated the documentation to reflect the changes where necessary.

## Additional context

I also ran an end-to-end markdown-only translation against a Mermaid-heavy local sample under `test_repo/test2` and verified that:
- Mermaid fences remain intact
- translated labels render inside Mermaid blocks
- prose after the diagram stays outside the closing fence
