### PR TITLE
Core: Add deterministic translation review workflow

### DIFF
--- a/.github/workflows/co-op-review.yml
+++ b/.github/workflows/co-op-review.yml
@@ -13,6 +13,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write
 
 concurrency:
   group: co-op-review-${{ github.ref }}
@@ -48,6 +49,53 @@ jobs:
         run: poetry install --with dev --no-interaction
 
       - name: Run co-op review
+        id: co_op_review
         run: |
           git fetch origin "${{ github.base_ref }}" --depth=1
-          poetry run co-op-review --changed-from "origin/${{ github.base_ref }}" --format github | tee "$GITHUB_STEP_SUMMARY"
+          set +e
+          poetry run co-op-review --changed-from "origin/${{ github.base_ref }}" --format github > co-op-review-summary.md
+          status=$?
+          cat co-op-review-summary.md
+          cat co-op-review-summary.md >> "$GITHUB_STEP_SUMMARY"
+          exit "$status"
+
+      - name: Comment on co-op review failure
+        if: failure() && github.event.pull_request.head.repo.full_name == github.repository
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require("fs");
+            const marker = "<!-- co-op-review-failure -->";
+            const summary = fs.readFileSync("co-op-review-summary.md", "utf8");
+            const body = [
+              marker,
+              summary,
+              "",
+              "_This comment is updated only when co-op review fails. Passing runs are reported in the check summary._",
+            ].join("\n");
+
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number,
+              per_page: 100,
+            });
+            const existing = comments.find((comment) => comment.body?.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body,
+              });
+            }

--- a/.github/workflows/co-op-review.yml
+++ b/.github/workflows/co-op-review.yml
@@ -1,0 +1,53 @@
+name: Co-op review
+
+on:
+  pull_request:
+    paths:
+      - "**/*.md"
+      - "**/*.mdx"
+      - "**/*.ipynb"
+      - "translations/**"
+      - ".github/workflows/co-op-review.yml"
+      - "src/co_op_translator/review/**"
+      - "src/co_op_translator/cli/review.py"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: co-op-review-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    env:
+      AZURE_OPENAI_API_KEY: dummy
+      AZURE_OPENAI_ENDPOINT: https://example.openai.azure.com/
+      AZURE_OPENAI_MODEL_NAME: gpt-4o
+      AZURE_OPENAI_CHAT_DEPLOYMENT_NAME: dummy
+      AZURE_OPENAI_API_VERSION: 2024-12-01-preview
+      AZURE_AI_SERVICE_API_KEY: dummy
+      AZURE_AI_SERVICE_ENDPOINT: https://example.cognitiveservices.azure.com/
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install Poetry
+        run: python -m pip install --upgrade pip poetry
+
+      - name: Install dependencies
+        run: poetry install --with dev --no-interaction
+
+      - name: Run co-op review
+        run: |
+          git fetch origin "${{ github.base_ref }}" --depth=1
+          poetry run co-op-review --changed-from "origin/${{ github.base_ref }}" --format github | tee "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -97,6 +97,9 @@ source .venv/bin/activate
 pip install co-op-translator
 # Translate
 translate -l "ko ja fr" -md
+
+# Review translated content without API keys
+co-op-review -l "ko ja"
 ```
 
 Docker:
@@ -145,6 +148,12 @@ Only notebooks:
 translate -l "zh" -nb
 ```
 
+Review translation structure and freshness without API credentials:
+
+```bash
+co-op-review -l "ko ja"
+```
+
 More flags: [Command reference](./getting_started/command-reference.md)
 
 ## Features
@@ -153,6 +162,7 @@ More flags: [Command reference](./getting_started/command-reference.md)
 - Keeps translations in sync with source changes
 - Works locally (CLI) or in CI (GitHub Actions)
 - Uses Azure OpenAI or OpenAI; optional Azure AI Vision for images
+- Reviews translation structure and freshness with deterministic checks
 - Preserves Markdown formatting and structure
 
 ## Docs

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,14 +1,16 @@
 # Python API
 
-The stable public Python API is intentionally small. The package exports `run_translation` from `co_op_translator.api`; most lower-level modules under `core`, `config`, and `utils` are implementation details used by the CLI and API entry point.
+The stable public Python API is intentionally small. The package exports `run_translation` and `run_review` from `co_op_translator.api`; most lower-level modules under `core`, `config`, `review`, and `utils` are implementation details used by the CLI and API entry points.
 
 ```python
-from co_op_translator.api import run_translation
+from co_op_translator.api import run_review, run_translation
 ```
 
-## Public entry point
+## Public entry points
 
 ::: co_op_translator.api.run_translation
+
+::: co_op_translator.api.run_review
 
 ## Typical usage
 
@@ -89,7 +91,35 @@ run_translation(
 )
 ```
 
-## Parameters
+Run deterministic review checks without API credentials:
+
+```python
+from co_op_translator.api import run_review
+
+run_review(
+    language_codes="ko ja",
+    root_dir="./my-course",
+    markdown=True,
+    notebook=True,
+)
+```
+
+Review only files changed against a base ref and print GitHub-flavored output:
+
+```python
+from co_op_translator.api import run_review
+
+run_review(
+    language_codes="ko",
+    root_dir="./my-course",
+    markdown=True,
+    notebook=True,
+    changed_from="origin/main",
+    output_format="github",
+)
+```
+
+## Translation parameters
 
 | Parameter | Type | Default | Purpose |
 | --- | --- | --- | --- |
@@ -112,6 +142,28 @@ run_translation(
 | `dry_run` | `bool` | `False` | Estimate translation volume and preview migration behavior without writing files. |
 
 If none of `markdown`, `notebook`, or `images` are set, the API translates all supported types: Markdown, notebooks, and images.
+
+## Review parameters
+
+`run_review` intentionally mirrors the `run_translation` signature where possible so automation can switch between translation and review workflows with minimal branching.
+
+| Parameter | Type | Default | Purpose |
+| --- | --- | --- | --- |
+| `language_codes` | `str \| Iterable[str]` | `"all"` | Target language folders to review. Space-separated strings and iterables are accepted. `"all"` reviews every discovered translation language. |
+| `root_dir` | `str` | `"."` | Project root for a single review target. Ignored when `root_dirs` or `groups` are supplied. |
+| `markdown` | `bool` | `False` | Include Markdown and MDX source files. |
+| `notebook` | `bool` | `False` | Include Jupyter notebook source files. |
+| `images` | `bool` | `False` | Reserved for parity with translation options. Link references to images are checked from Markdown. |
+| `translations_dir` | `str \| None` | `None` | Custom text translation output directory. Relative paths resolve against each root. |
+| `root_dirs` | `Iterable[str] \| None` | `None` | Multiple roots that share the same output settings. |
+| `groups` | `Iterable[tuple[str, str \| None]] \| None` | `None` | Explicit `(root_dir, translations_dir)` pairs. Takes precedence over `root_dirs`. |
+| `changed_from` | `str \| None` | `None` | Git ref used to limit review to changed source files. |
+| `output_format` | `str` | `"text"` | Review output format. Supported values are `"text"` and `"github"`. |
+| `fail_on_warnings` | `bool` | `False` | Treat warnings as failures in addition to errors. |
+| `debug` | `bool` | `False` | Enable debug logging. |
+| `save_logs` | `bool` | `False` | Save DEBUG-level log files under the root `logs/` directory. |
+
+If none of `markdown`, `notebook`, or `images` are set, the API reviews Markdown, notebooks, and image link references where applicable. Review does not call an LLM provider and does not require API keys.
 
 ## Configuration requirements
 
@@ -145,6 +197,8 @@ AZURE_AI_SERVICE_API_KEY="..."
 AZURE_AI_SERVICE_ENDPOINT="https://<resource>.cognitiveservices.azure.com/"
 ```
 
+`run_review` is deterministic and does not require Azure OpenAI, OpenAI, or Azure AI Vision configuration.
+
 ## Behavior notes
 
 - The API prints progress and estimate summaries through Click, matching the CLI user experience.
@@ -152,10 +206,14 @@ AZURE_AI_SERVICE_ENDPOINT="https://<resource>.cognitiveservices.azure.com/"
 - `groups` are processed sequentially. A single aggregate estimate is printed before work begins.
 - When image translation is selected, missing Vision configuration raises an error before translation starts.
 - Existing alias-based language folders are detected and can be migrated to canonical language folder names as part of the run.
+- `run_review` fails on missing translated files, missing or stale translation metadata, malformed Markdown frontmatter/code fences, and invalid translated notebook JSON.
+- `run_review` reports missing local Markdown and image link targets as warnings by default.
 
 ## Internal call path
 
 The API delegates to the same core implementation used by the CLI:
+
+Translation:
 
 1. `co_op_translator.api.translation.run_translation`
 2. `co_op_translator.config.Config`, `LLMConfig`, and `VisionConfig`
@@ -163,13 +221,22 @@ The API delegates to the same core implementation used by the CLI:
 4. `co_op_translator.core.project.TranslationManager`
 5. Markdown, notebook, text, and image translators under `co_op_translator.core`
 
+Review:
+
+1. `co_op_translator.api.review.run_review`
+2. `co_op_translator.review.targets.build_review_targets`
+3. `co_op_translator.review.runner.ReviewRunner`
+4. Deterministic checks under `co_op_translator.review.checks`
+
 The following classes are useful for maintainers, but are not exported as the package-level stable API.
 
 | Class | Module | Responsibility |
 | --- | --- | --- |
 | `ProjectTranslator` | `co_op_translator.core.project.project_translator` | Coordinates project-level translation, directory management, per-language metadata normalization, and delegation to Markdown, notebook, and image translators. |
-| `TranslationManager` | `co_op_translator.core.project.translation_manager` | Performs the async file processing work for Markdown, notebooks, images, stale detection, and translation metadata updates. |
+| `TranslationManager` | `co_op_translator.core.project.translation` | Performs the async file processing work for Markdown, notebooks, images, stale detection, and translation metadata updates. |
 | `ProjectEvaluator` | `co_op_translator.core.project.project_evaluator` | Finds translated Markdown pairs, evaluates translation quality, and reads confidence metadata for low-confidence repair workflows. |
+| `ReviewRunner` | `co_op_translator.review.runner` | Coordinates deterministic review checks across source files, target languages, and configured translation roots. |
+| `ReviewTarget` | `co_op_translator.review.targets` | Describes a source root and the translation output directory reviewed for that root. |
 | `LanguageFolderMigrator` | `co_op_translator.core.project.language_migrator` | Detects legacy alias language folders and prepares canonical BCP 47 folder migration plans. |
 | `Config` | `co_op_translator.config.base_config` | Loads `.env` files and checks whether required LLM and optional Vision providers are configured. |
 | `LLMConfig` | `co_op_translator.config.llm_config.config` | Auto-detects Azure OpenAI or OpenAI, validates required environment variables, and runs provider connectivity checks. |

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,10 +1,11 @@
 # CLI Reference
 
-Co-op Translator installs three command-line entry points:
+Co-op Translator installs four command-line entry points:
 
 - `translate`
 - `evaluate`
 - `migrate-links`
+- `co-op-review`
 
 The dispatch logic lives in `co_op_translator.__main__`, which selects the command implementation based on the invoked script name.
 
@@ -118,6 +119,51 @@ evaluate -l "ja" -D
 | `-D`, `--deep` | No | LLM-based evaluation only. |
 
 By default, `evaluate` uses both rule-based and LLM-based evaluation. Results are written into translation metadata and summarized in the console.
+
+## co-op-review
+
+Run deterministic translation maintenance checks without API credentials.
+
+```bash
+co-op-review -l "ko"
+```
+
+### Common examples
+
+Review Korean and Japanese translations from the current directory:
+
+```bash
+co-op-review -l "ko ja"
+```
+
+Review a specific project root:
+
+```bash
+co-op-review -l "fr" -r ./my-course
+```
+
+Review only source files changed against a base ref:
+
+```bash
+co-op-review -l "ko" --changed-from origin/main
+```
+
+Print GitHub-flavored Markdown output for CI summaries:
+
+```bash
+co-op-review -l "ko ja" --changed-from origin/main --format github
+```
+
+### Options
+
+| Option | Required | Description |
+| --- | --- | --- |
+| `-l`, `--language-code` | No | Language code to review. Can be passed multiple times or as a space-separated value. Defaults to all discovered translation languages. |
+| `-r`, `--root-dir` | No | Project root. Defaults to the current directory. |
+| `--changed-from` | No | Git ref used to limit review to changed source files. |
+| `--format` | No | Output format: `text` or `github`. Defaults to `text`. |
+
+`co-op-review` currently checks for missing translated files, missing or stale translation metadata, Markdown frontmatter and code fence integrity, invalid translated notebook JSON, and missing local Markdown or image link targets. Missing links are warnings by default; structural and freshness problems fail the command.
 
 ## migrate-links
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -44,7 +44,7 @@ The tool auto-detects providers in this order:
 1. Azure OpenAI
 2. OpenAI
 
-If neither provider is configured, `translate`, `evaluate`, `migrate-links`, and `run_translation` fail during configuration checks.
+If neither provider is configured, `translate`, `evaluate`, `migrate-links`, and `run_translation` fail during configuration checks. `co-op-review` and `run_review` are deterministic maintenance checks and do not require provider credentials.
 
 ## Azure OpenAI
 
@@ -114,8 +114,10 @@ Each set must be complete. The health check selects a working set before transla
 | `translate` with no type flags | Yes | Yes | Default mode includes Markdown, notebooks, and images. |
 | `evaluate` | Yes | No | Uses LLM evaluation unless `--fast` is selected. |
 | `migrate-links` | Yes | No | Performs link migration, but still runs shared configuration checks. |
+| `co-op-review` | No | No | Runs deterministic translation structure, freshness, Markdown, notebook, and local link checks. |
 | `run_translation(markdown=True)` | Yes | No | Programmatic Markdown translation. |
 | `run_translation(images=True)` | Yes | Yes | Programmatic image translation. |
+| `run_review(...)` | No | No | Programmatic deterministic review. |
 
 ## Output directories
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,8 +3,8 @@
   <h1>Co-op Translator Documentation</h1>
   <p class="home-lede">
     Configure an LLM provider, choose your target languages, and use Co-op
-    Translator from the CLI or Python API to keep translated project content
-    synchronized with the source.
+    Translator from the CLI or Python API to translate and review project
+    content as the source changes.
   </p>
   <a class="home-link" href="cli/">Start with the CLI -></a>
 </section>
@@ -22,14 +22,14 @@
   <a class="quickstart-card" href="cli/">
     <span class="quickstart-step">Step 2</span>
     <strong>Translate with CLI</strong>
-    <span>Run translation, evaluation, and link migration commands.</span>
+    <span>Run translation, evaluation, review, and link migration commands.</span>
     <em>Open guide -></em>
   </a>
 
   <a class="quickstart-card" href="api/">
     <span class="quickstart-step">Step 3</span>
     <strong>Python API</strong>
-    <span>Call <code>run_translation</code> from scripts and automation.</span>
+    <span>Call <code>run_translation</code> and <code>run_review</code> from scripts and automation.</span>
     <em>Open guide -></em>
   </a>
 

--- a/docs/maintainer-guide.md
+++ b/docs/maintainer-guide.md
@@ -13,14 +13,14 @@ co_op_translator.api
 Currently, that package exports:
 
 ```python
-from co_op_translator.api import run_translation
+from co_op_translator.api import run_review, run_translation
 ```
 
 When adding new public APIs, update:
 
 - `src/co_op_translator/api/__init__.py`
 - `docs/api.md`
-- `tests/co_op_translator/test_api.py`
+- relevant API tests under `tests/co_op_translator/`, such as `test_api.py` or `test_review_api.py`
 
 Avoid documenting lower-level `core` modules as stable API unless the project intends to support them directly.
 
@@ -33,6 +33,7 @@ The package defines these Poetry scripts:
 translate = "co_op_translator.__main__:main"
 evaluate = "co_op_translator.__main__:main"
 migrate-links = "co_op_translator.__main__:main"
+co-op-review = "co_op_translator.__main__:main"
 ```
 
 `src/co_op_translator/__main__.py` dispatches by script name:
@@ -40,6 +41,7 @@ migrate-links = "co_op_translator.__main__:main"
 - `translate` calls `co_op_translator.cli.translate.translate_command`
 - `evaluate` calls `co_op_translator.cli.evaluate.evaluate_command`
 - `migrate-links` calls `co_op_translator.cli.migrate_links.migrate_links_command`
+- `co-op-review` calls `co_op_translator.cli.review.review_command`
 
 When adding or changing CLI options, update:
 
@@ -61,6 +63,20 @@ The high-level translation flow is:
 7. Update README language/course sections when applicable.
 8. Delegate project translation to `ProjectTranslator`.
 9. `ProjectTranslator` delegates file processing to `TranslationManager`.
+
+## Review flow
+
+The deterministic review flow is:
+
+1. Parse CLI arguments or API parameters.
+2. Normalize requested language codes.
+3. Build one or more review targets from `root_dir`, `root_dirs`, or `groups`.
+4. Optionally limit source files with `--changed-from`.
+5. Run deterministic checks for structure, translation freshness, Markdown integrity, and local link/image paths.
+6. Print either text output or GitHub-flavored Markdown.
+7. Exit with a failure when review errors are found.
+
+The review flow does not require API keys and should remain suitable for pull request CI. The pull request workflow writes a check summary on every run and only posts a PR comment when `co-op-review` fails.
 
 ## Documentation site
 

--- a/getting_started/command-reference.md
+++ b/getting_started/command-reference.md
@@ -23,6 +23,10 @@ evaluate -l "language_code" -c 0.8           | Evaluates translations with custo
 evaluate -l "language_code" -f               | Fast evaluation mode (rule-based only, no LLM)
 evaluate -l "language_code" -D               | Deep evaluation mode (LLM-based only, more thorough but slower)
 evaluate -l "language_code" --save-logs, -s  | Save DEBUG-level logs to files under <root_dir>/logs/
+co-op-review -l "language_code"              | Runs deterministic translation review checks without API credentials.
+co-op-review -l "language_codes" -r "root_dir" | Reviews translations from a specific project root.
+co-op-review -l "language_codes" --changed-from origin/main | Reviews only source files changed against a Git ref.
+co-op-review -l "language_codes" --format github | Prints GitHub-flavored Markdown output for CI summaries.
 migrate-links -l "language_codes"             | Reprocess translated Markdown files to update links to notebooks (.ipynb). Prefers translated notebooks when available; otherwise can fall back to original notebooks.
 migrate-links -l "language_codes" -r          | Specify the project root directory (default: current directory).
 migrate-links -l "language_codes" --dry-run   | Show which files would change without writing changes.
@@ -84,3 +88,18 @@ migrate-links -l "all" -y                      | Process all languages and auto-
   3. Fast evaluation (rule-based only): evaluate -l "ko" -f
 
   4. Deep evaluation (LLM-based only): evaluate -l "ko" -D
+
+### Co-op Review Examples
+
+> [!NOTE]
+> `co-op-review` is deterministic and does not call an LLM provider. It is suitable for CI checks that should run on every pull request.
+
+  1. Review all discovered Korean translations: co-op-review -l "ko"
+
+  2. Review multiple languages: co-op-review -l "ko ja"
+
+  3. Review a specific project root: co-op-review -l "ko" -r "./my_project"
+
+  4. Review only changed source files in a pull request: co-op-review -l "ko" --changed-from origin/main
+
+  5. Emit GitHub-flavored Markdown for workflow summaries: co-op-review -l "ko" --changed-from origin/main --format github

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ documentation = "https://github.com/Azure/co-op-translator/tree/main/getting_sta
 translate = "co_op_translator.__main__:main"
 evaluate = "co_op_translator.__main__:main"
 migrate-links = "co_op_translator.__main__:main"
+co-op-review = "co_op_translator.__main__:main"
 
 [tool.poetry.dependencies]
 python = ">=3.10,<3.13"

--- a/src/co_op_translator/__main__.py
+++ b/src/co_op_translator/__main__.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from co_op_translator.cli.translate import translate_command
 from co_op_translator.cli.evaluate import evaluate_command
 from co_op_translator.cli.migrate_links import migrate_links_command
+from co_op_translator.cli.review import review_command
 
 logger = logging.getLogger(__name__)
 
@@ -19,11 +20,13 @@ def main():
     Main entry point function that routes to the appropriate command.
     This function is used by the command-line scripts.
     """
-    script_name = Path(sys.argv[0]).name
+    script_name = Path(sys.argv[0]).stem
     if script_name == "evaluate":
         evaluate_command()
     elif script_name == "migrate-links":
         migrate_links_command()
+    elif script_name == "co-op-review":
+        review_command()
     else:
         translate_command()
 

--- a/src/co_op_translator/api/__init__.py
+++ b/src/co_op_translator/api/__init__.py
@@ -1,5 +1,6 @@
 """Public programmatic API for Co-op Translator."""
 
 from co_op_translator.api.translation import run_translation
+from co_op_translator.api.review import run_review
 
-__all__ = ["run_translation"]
+__all__ = ["run_review", "run_translation"]

--- a/src/co_op_translator/api/review.py
+++ b/src/co_op_translator/api/review.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Iterable
+
+import click
+
+from co_op_translator.review.models import ReviewSummary
+from co_op_translator.review.runner import ReviewConfig, ReviewRunner
+from co_op_translator.review.targets import build_review_targets
+from co_op_translator.utils.common.lang_utils import normalize_language_codes
+from co_op_translator.utils.common.logging_utils import setup_logging
+
+logger = logging.getLogger(__name__)
+
+
+def _build_review_types(markdown: bool, images: bool, notebook: bool) -> list[str]:
+    review_types: list[str] = []
+    if markdown:
+        review_types.append("markdown")
+    if images:
+        review_types.append("images")
+    if notebook:
+        review_types.append("notebook")
+    if not review_types:
+        review_types = ["markdown", "notebook", "images"]
+    return review_types
+
+
+def _source_extensions_for_review_types(review_types: list[str]) -> set[str]:
+    source_extensions: set[str] = set()
+    if "markdown" in review_types:
+        source_extensions.update({".md", ".mdx"})
+    if "notebook" in review_types:
+        source_extensions.add(".ipynb")
+    return source_extensions
+
+
+def _normalize_review_languages(language_codes: str | Iterable[str]) -> list[str]:
+    if isinstance(language_codes, str):
+        if language_codes == "all":
+            return []
+        raw_codes = [code for code in language_codes.split() if code]
+    else:
+        raw_codes = [code for code in language_codes if code]
+    return normalize_language_codes(raw_codes) if raw_codes else []
+
+
+def run_review(
+    language_codes: str | Iterable[str] = "all",
+    root_dir: str = ".",
+    update: bool = False,
+    images: bool = False,
+    markdown: bool = False,
+    notebook: bool = False,
+    debug: bool = False,
+    save_logs: bool = False,
+    yes: bool = True,
+    add_disclaimer: bool = False,
+    translations_dir: str | None = None,
+    image_dir: str | None = None,
+    root_dirs: Iterable[str] | None = None,
+    groups: Iterable[tuple[str, str | None]] | None = None,
+    repo_url: str | None = None,
+    glossaries: Iterable[str] | None = None,
+    dry_run: bool = False,
+    changed_from: str | None = None,
+    output_format: str = "text",
+    fail_on_warnings: bool = False,
+) -> ReviewSummary:
+    """Programmatic deterministic review entrypoint.
+
+    The signature intentionally mirrors ``run_translation`` where possible so
+    automation can switch between translate and review workflows with minimal
+    branching. Review ignores mutating translation-only options such as
+    ``update``, ``yes``, ``add_disclaimer``, ``repo_url``, ``glossaries``, and
+    ``dry_run``.
+    """
+    del update, yes, add_disclaimer, image_dir, repo_url, glossaries, dry_run
+
+    root_path = Path(root_dir).resolve()
+    if not root_path.exists():
+        raise ValueError(f"Root directory does not exist: {root_dir}")
+    if not root_path.is_dir():
+        raise ValueError(f"Root path is not a directory: {root_dir}")
+
+    log_file_path = setup_logging(
+        root_path, debug=debug, save_logs=save_logs, command_name="co-op-review"
+    )
+    if debug:
+        logging.debug("Debug mode enabled.")
+    if save_logs and log_file_path is not None:
+        click.echo(f"Logs will be saved to: {log_file_path}")
+
+    review_types = _build_review_types(markdown, images, notebook)
+    logger.info("Review mode: %s", ", ".join(review_types))
+
+    targets = build_review_targets(
+        root_dir=root_path,
+        translations_dir=translations_dir,
+        root_dirs=root_dirs,
+        groups=groups,
+    )
+    languages = _normalize_review_languages(language_codes)
+
+    summary = ReviewRunner(
+        ReviewConfig(
+            root_dir=root_path,
+            languages=languages,
+            changed_from=changed_from,
+            targets=targets,
+            source_extensions=_source_extensions_for_review_types(review_types),
+        )
+    ).run()
+
+    if output_format == "github":
+        click.echo(summary.to_github_markdown())
+    elif output_format == "text":
+        click.echo(summary.to_text())
+    else:
+        raise ValueError(f"Unsupported review output format: {output_format}")
+
+    if summary.error_count or (fail_on_warnings and summary.warning_count):
+        raise RuntimeError(
+            "co-op-review found "
+            f"{summary.error_count} error(s) and {summary.warning_count} warning(s)."
+        )
+
+    return summary

--- a/src/co_op_translator/cli/review.py
+++ b/src/co_op_translator/cli/review.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import click
 
-from co_op_translator.review.runner import ReviewConfig, ReviewRunner
+from co_op_translator.api.review import run_review
 
 
 def _split_language_options(values: tuple[str, ...]) -> list[str]:
@@ -52,19 +52,14 @@ def review_command(
     if not root_path.is_dir():
         raise click.ClickException(f"Root path is not a directory: {root_dir}")
 
-    config = ReviewConfig(
-        root_dir=root_path,
-        languages=_split_language_options(language_code),
-        changed_from=changed_from,
-    )
-    summary = ReviewRunner(config).run()
-
-    if output_format == "github":
-        click.echo(summary.to_github_markdown())
-    else:
-        click.echo(summary.to_text())
-
-    if summary.error_count:
-        raise click.ClickException(
-            f"co-op-review found {summary.error_count} blocking issue(s)."
+    try:
+        run_review(
+            language_codes=_split_language_options(language_code) or "all",
+            root_dir=str(root_path),
+            markdown=True,
+            notebook=True,
+            changed_from=changed_from,
+            output_format=output_format,
         )
+    except RuntimeError as exc:
+        raise click.ClickException(str(exc)) from exc

--- a/src/co_op_translator/cli/review.py
+++ b/src/co_op_translator/cli/review.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import click
+
+from co_op_translator.review.runner import ReviewConfig, ReviewRunner
+
+
+def _split_language_options(values: tuple[str, ...]) -> list[str]:
+    languages: list[str] = []
+    for value in values:
+        languages.extend(part for part in value.split() if part)
+    return languages
+
+
+@click.command(name="co-op-review")
+@click.option(
+    "--root-dir",
+    "-r",
+    default=".",
+    help="Root directory of the project to review.",
+)
+@click.option(
+    "--language-code",
+    "-l",
+    multiple=True,
+    help='Language code to review. Can be passed multiple times or as "ko ja".',
+)
+@click.option(
+    "--changed-from",
+    help="Git ref to diff against. When provided, only changed source files are reviewed.",
+)
+@click.option(
+    "--format",
+    "output_format",
+    type=click.Choice(["text", "github"]),
+    default="text",
+    show_default=True,
+    help="Output format.",
+)
+def review_command(
+    root_dir: str,
+    language_code: tuple[str, ...],
+    changed_from: str | None,
+    output_format: str,
+) -> None:
+    """Run deterministic translation review checks without API credentials."""
+    root_path = Path(root_dir).resolve()
+    if not root_path.exists():
+        raise click.ClickException(f"Root directory does not exist: {root_dir}")
+    if not root_path.is_dir():
+        raise click.ClickException(f"Root path is not a directory: {root_dir}")
+
+    config = ReviewConfig(
+        root_dir=root_path,
+        languages=_split_language_options(language_code),
+        changed_from=changed_from,
+    )
+    summary = ReviewRunner(config).run()
+
+    if output_format == "github":
+        click.echo(summary.to_github_markdown())
+    else:
+        click.echo(summary.to_text())
+
+    if summary.error_count:
+        raise click.ClickException(
+            f"co-op-review found {summary.error_count} blocking issue(s)."
+        )

--- a/src/co_op_translator/review/__init__.py
+++ b/src/co_op_translator/review/__init__.py
@@ -1,0 +1,12 @@
+"""Deterministic review checks for translated project content."""
+
+from co_op_translator.review.models import ReviewIssue, ReviewSeverity, ReviewSummary
+from co_op_translator.review.runner import ReviewConfig, ReviewRunner
+
+__all__ = [
+    "ReviewConfig",
+    "ReviewIssue",
+    "ReviewRunner",
+    "ReviewSeverity",
+    "ReviewSummary",
+]

--- a/src/co_op_translator/review/__init__.py
+++ b/src/co_op_translator/review/__init__.py
@@ -2,6 +2,7 @@
 
 from co_op_translator.review.models import ReviewIssue, ReviewSeverity, ReviewSummary
 from co_op_translator.review.runner import ReviewConfig, ReviewRunner
+from co_op_translator.review.targets import ReviewTarget
 
 __all__ = [
     "ReviewConfig",
@@ -9,4 +10,5 @@ __all__ = [
     "ReviewRunner",
     "ReviewSeverity",
     "ReviewSummary",
+    "ReviewTarget",
 ]

--- a/src/co_op_translator/review/checks/__init__.py
+++ b/src/co_op_translator/review/checks/__init__.py
@@ -1,0 +1,1 @@
+"""Individual deterministic co-op review checks."""

--- a/src/co_op_translator/review/checks/freshness.py
+++ b/src/co_op_translator/review/checks/freshness.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from co_op_translator.review.checks.structure import expected_translation_path
 from co_op_translator.review.models import ReviewIssue, ReviewSeverity
+from co_op_translator.review.targets import ReviewTarget
 from co_op_translator.utils.common.metadata_utils import (
     calculate_file_hash,
     read_text_metadata_for_source,
@@ -11,17 +11,17 @@ from co_op_translator.utils.common.metadata_utils import (
 
 
 def check_translation_freshness(
-    root_dir: Path, source_files: list[Path], languages: list[str]
+    target: ReviewTarget, source_files: list[Path], languages: list[str]
 ) -> list[ReviewIssue]:
     issues: list[ReviewIssue] = []
     for source_file in source_files:
         current_hash = calculate_file_hash(source_file)
         for language in languages:
-            translated_path = expected_translation_path(root_dir, source_file, language)
+            translated_path = target.translated_path(source_file, language)
             if not translated_path.exists():
                 continue
 
-            lang_dir = root_dir / "translations" / language
+            lang_dir = target.language_root(language)
             metadata = read_text_metadata_for_source(lang_dir, source_file)
             stored_hash = metadata.get("original_hash")
             if not stored_hash:
@@ -29,7 +29,7 @@ def check_translation_freshness(
                     ReviewIssue(
                         check="freshness",
                         severity=ReviewSeverity.ERROR,
-                        path=source_file.relative_to(root_dir),
+                        path=target.display_source_path(source_file),
                         language=language,
                         message="Missing translation metadata.",
                     )
@@ -39,7 +39,7 @@ def check_translation_freshness(
                     ReviewIssue(
                         check="freshness",
                         severity=ReviewSeverity.ERROR,
-                        path=source_file.relative_to(root_dir),
+                        path=target.display_source_path(source_file),
                         language=language,
                         message="Translation metadata is stale.",
                     )

--- a/src/co_op_translator/review/checks/freshness.py
+++ b/src/co_op_translator/review/checks/freshness.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from co_op_translator.review.checks.structure import expected_translation_path
+from co_op_translator.review.models import ReviewIssue, ReviewSeverity
+from co_op_translator.utils.common.metadata_utils import (
+    calculate_file_hash,
+    read_text_metadata_for_source,
+)
+
+
+def check_translation_freshness(
+    root_dir: Path, source_files: list[Path], languages: list[str]
+) -> list[ReviewIssue]:
+    issues: list[ReviewIssue] = []
+    for source_file in source_files:
+        current_hash = calculate_file_hash(source_file)
+        for language in languages:
+            translated_path = expected_translation_path(root_dir, source_file, language)
+            if not translated_path.exists():
+                continue
+
+            lang_dir = root_dir / "translations" / language
+            metadata = read_text_metadata_for_source(lang_dir, source_file)
+            stored_hash = metadata.get("original_hash")
+            if not stored_hash:
+                issues.append(
+                    ReviewIssue(
+                        check="freshness",
+                        severity=ReviewSeverity.ERROR,
+                        path=source_file.relative_to(root_dir),
+                        language=language,
+                        message="Missing translation metadata.",
+                    )
+                )
+            elif stored_hash != current_hash:
+                issues.append(
+                    ReviewIssue(
+                        check="freshness",
+                        severity=ReviewSeverity.ERROR,
+                        path=source_file.relative_to(root_dir),
+                        language=language,
+                        message="Translation metadata is stale.",
+                    )
+                )
+    return issues

--- a/src/co_op_translator/review/checks/links.py
+++ b/src/co_op_translator/review/checks/links.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from urllib.parse import unquote
+
+from co_op_translator.review.checks.structure import expected_translation_path
+from co_op_translator.review.models import ReviewIssue, ReviewSeverity
+
+MARKDOWN_LINK_PATTERN = re.compile(r"(!?)\[[^\]]*]\(([^)]+)\)")
+
+
+def _is_external_link(target: str) -> bool:
+    lowered = target.lower()
+    return (
+        "://" in lowered
+        or lowered.startswith("#")
+        or lowered.startswith("mailto:")
+        or lowered.startswith("tel:")
+    )
+
+
+def _clean_link_target(target: str) -> str:
+    target = target.strip().strip("<>")
+    target = target.split("#", 1)[0].split("?", 1)[0]
+    return unquote(target)
+
+
+def _target_exists(translated_path: Path, target: str) -> bool:
+    cleaned = _clean_link_target(target)
+    if not cleaned:
+        return True
+    candidate = Path(cleaned)
+    if candidate.is_absolute():
+        return candidate.exists()
+    return (translated_path.parent / candidate).exists()
+
+
+def check_local_links(
+    root_dir: Path, source_files: list[Path], languages: list[str]
+) -> list[ReviewIssue]:
+    issues: list[ReviewIssue] = []
+    for source_file in source_files:
+        if source_file.suffix.lower() == ".ipynb":
+            continue
+        for language in languages:
+            translated_path = expected_translation_path(root_dir, source_file, language)
+            if not translated_path.exists():
+                continue
+            content = translated_path.read_text(encoding="utf-8")
+            for is_image, target in MARKDOWN_LINK_PATTERN.findall(content):
+                if _is_external_link(target) or _target_exists(translated_path, target):
+                    continue
+                check_name = "image-link" if is_image else "local-link"
+                issues.append(
+                    ReviewIssue(
+                        check=check_name,
+                        severity=ReviewSeverity.WARNING,
+                        path=translated_path.relative_to(root_dir),
+                        language=language,
+                        message=f"Local target does not exist: {target}",
+                    )
+                )
+    return issues

--- a/src/co_op_translator/review/checks/links.py
+++ b/src/co_op_translator/review/checks/links.py
@@ -4,8 +4,8 @@ import re
 from pathlib import Path
 from urllib.parse import unquote
 
-from co_op_translator.review.checks.structure import expected_translation_path
 from co_op_translator.review.models import ReviewIssue, ReviewSeverity
+from co_op_translator.review.targets import ReviewTarget
 
 MARKDOWN_LINK_PATTERN = re.compile(r"(!?)\[[^\]]*]\(([^)]+)\)")
 
@@ -37,28 +37,30 @@ def _target_exists(translated_path: Path, target: str) -> bool:
 
 
 def check_local_links(
-    root_dir: Path, source_files: list[Path], languages: list[str]
+    target: ReviewTarget, source_files: list[Path], languages: list[str]
 ) -> list[ReviewIssue]:
     issues: list[ReviewIssue] = []
     for source_file in source_files:
         if source_file.suffix.lower() == ".ipynb":
             continue
         for language in languages:
-            translated_path = expected_translation_path(root_dir, source_file, language)
+            translated_path = target.translated_path(source_file, language)
             if not translated_path.exists():
                 continue
             content = translated_path.read_text(encoding="utf-8")
-            for is_image, target in MARKDOWN_LINK_PATTERN.findall(content):
-                if _is_external_link(target) or _target_exists(translated_path, target):
+            for is_image, link_target in MARKDOWN_LINK_PATTERN.findall(content):
+                if _is_external_link(link_target) or _target_exists(
+                    translated_path, link_target
+                ):
                     continue
                 check_name = "image-link" if is_image else "local-link"
                 issues.append(
                     ReviewIssue(
                         check=check_name,
                         severity=ReviewSeverity.WARNING,
-                        path=translated_path.relative_to(root_dir),
+                        path=target.display_translated_path(translated_path),
                         language=language,
-                        message=f"Local target does not exist: {target}",
+                        message=f"Local target does not exist: {link_target}",
                     )
                 )
     return issues

--- a/src/co_op_translator/review/checks/markdown_integrity.py
+++ b/src/co_op_translator/review/checks/markdown_integrity.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+from co_op_translator.review.checks.structure import expected_translation_path
+from co_op_translator.review.models import ReviewIssue, ReviewSeverity
+
+FENCE_PATTERN = re.compile(r"^\s*(```|~~~)", re.MULTILINE)
+
+
+def _has_frontmatter(content: str) -> bool:
+    return content.startswith("---\n")
+
+
+def _frontmatter_is_closed(content: str) -> bool:
+    if not _has_frontmatter(content):
+        return True
+    return content.find("\n---", 4) != -1
+
+
+def _fence_count(content: str) -> int:
+    return len(FENCE_PATTERN.findall(content))
+
+
+def _check_markdown_file(
+    root_dir: Path, source_file: Path, translated_path: Path, language: str
+) -> list[ReviewIssue]:
+    issues: list[ReviewIssue] = []
+    source_content = source_file.read_text(encoding="utf-8")
+    translated_content = translated_path.read_text(encoding="utf-8")
+    relative_path = source_file.relative_to(root_dir)
+
+    if _has_frontmatter(source_content):
+        if not _has_frontmatter(translated_content):
+            issues.append(
+                ReviewIssue(
+                    check="markdown-integrity",
+                    severity=ReviewSeverity.ERROR,
+                    path=relative_path,
+                    language=language,
+                    message="Translated file is missing source frontmatter.",
+                )
+            )
+        elif not _frontmatter_is_closed(translated_content):
+            issues.append(
+                ReviewIssue(
+                    check="markdown-integrity",
+                    severity=ReviewSeverity.ERROR,
+                    path=relative_path,
+                    language=language,
+                    message="Translated frontmatter is not closed.",
+                )
+            )
+
+    if _fence_count(source_content) != _fence_count(translated_content):
+        issues.append(
+            ReviewIssue(
+                check="markdown-integrity",
+                severity=ReviewSeverity.ERROR,
+                path=relative_path,
+                language=language,
+                message="Code fence count differs from the source file.",
+            )
+        )
+
+    return issues
+
+
+def _check_notebook_file(
+    root_dir: Path, source_file: Path, translated_path: Path, language: str
+) -> list[ReviewIssue]:
+    try:
+        json.loads(translated_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return [
+            ReviewIssue(
+                check="notebook-integrity",
+                severity=ReviewSeverity.ERROR,
+                path=source_file.relative_to(root_dir),
+                language=language,
+                message="Translated notebook is not valid JSON.",
+            )
+        ]
+    return []
+
+
+def check_markdown_integrity(
+    root_dir: Path, source_files: list[Path], languages: list[str]
+) -> list[ReviewIssue]:
+    issues: list[ReviewIssue] = []
+    for source_file in source_files:
+        for language in languages:
+            translated_path = expected_translation_path(root_dir, source_file, language)
+            if not translated_path.exists():
+                continue
+            if source_file.suffix.lower() == ".ipynb":
+                issues.extend(
+                    _check_notebook_file(
+                        root_dir, source_file, translated_path, language
+                    )
+                )
+            else:
+                issues.extend(
+                    _check_markdown_file(
+                        root_dir, source_file, translated_path, language
+                    )
+                )
+    return issues

--- a/src/co_op_translator/review/checks/markdown_integrity.py
+++ b/src/co_op_translator/review/checks/markdown_integrity.py
@@ -4,8 +4,8 @@ import json
 import re
 from pathlib import Path
 
-from co_op_translator.review.checks.structure import expected_translation_path
 from co_op_translator.review.models import ReviewIssue, ReviewSeverity
+from co_op_translator.review.targets import ReviewTarget
 
 FENCE_PATTERN = re.compile(r"^\s*(```|~~~)", re.MULTILINE)
 
@@ -25,12 +25,12 @@ def _fence_count(content: str) -> int:
 
 
 def _check_markdown_file(
-    root_dir: Path, source_file: Path, translated_path: Path, language: str
+    target: ReviewTarget, source_file: Path, translated_path: Path, language: str
 ) -> list[ReviewIssue]:
     issues: list[ReviewIssue] = []
     source_content = source_file.read_text(encoding="utf-8")
     translated_content = translated_path.read_text(encoding="utf-8")
-    relative_path = source_file.relative_to(root_dir)
+    relative_path = target.display_source_path(source_file)
 
     if _has_frontmatter(source_content):
         if not _has_frontmatter(translated_content):
@@ -69,7 +69,7 @@ def _check_markdown_file(
 
 
 def _check_notebook_file(
-    root_dir: Path, source_file: Path, translated_path: Path, language: str
+    target: ReviewTarget, source_file: Path, translated_path: Path, language: str
 ) -> list[ReviewIssue]:
     try:
         json.loads(translated_path.read_text(encoding="utf-8"))
@@ -78,7 +78,7 @@ def _check_notebook_file(
             ReviewIssue(
                 check="notebook-integrity",
                 severity=ReviewSeverity.ERROR,
-                path=source_file.relative_to(root_dir),
+                path=target.display_source_path(source_file),
                 language=language,
                 message="Translated notebook is not valid JSON.",
             )
@@ -87,24 +87,20 @@ def _check_notebook_file(
 
 
 def check_markdown_integrity(
-    root_dir: Path, source_files: list[Path], languages: list[str]
+    target: ReviewTarget, source_files: list[Path], languages: list[str]
 ) -> list[ReviewIssue]:
     issues: list[ReviewIssue] = []
     for source_file in source_files:
         for language in languages:
-            translated_path = expected_translation_path(root_dir, source_file, language)
+            translated_path = target.translated_path(source_file, language)
             if not translated_path.exists():
                 continue
             if source_file.suffix.lower() == ".ipynb":
                 issues.extend(
-                    _check_notebook_file(
-                        root_dir, source_file, translated_path, language
-                    )
+                    _check_notebook_file(target, source_file, translated_path, language)
                 )
             else:
                 issues.extend(
-                    _check_markdown_file(
-                        root_dir, source_file, translated_path, language
-                    )
+                    _check_markdown_file(target, source_file, translated_path, language)
                 )
     return issues

--- a/src/co_op_translator/review/checks/structure.py
+++ b/src/co_op_translator/review/checks/structure.py
@@ -1,27 +1,22 @@
 from __future__ import annotations
 
-from pathlib import Path
-
 from co_op_translator.review.models import ReviewIssue, ReviewSeverity
-
-
-def expected_translation_path(root_dir: Path, source_file: Path, language: str) -> Path:
-    return root_dir / "translations" / language / source_file.relative_to(root_dir)
+from co_op_translator.review.targets import ReviewTarget
 
 
 def check_translation_structure(
-    root_dir: Path, source_files: list[Path], languages: list[str]
+    target: ReviewTarget, source_files: list[Path], languages: list[str]
 ) -> list[ReviewIssue]:
     issues: list[ReviewIssue] = []
     for source_file in source_files:
         for language in languages:
-            translated_path = expected_translation_path(root_dir, source_file, language)
+            translated_path = target.translated_path(source_file, language)
             if not translated_path.exists():
                 issues.append(
                     ReviewIssue(
                         check="structure",
                         severity=ReviewSeverity.ERROR,
-                        path=source_file.relative_to(root_dir),
+                        path=target.display_source_path(source_file),
                         language=language,
                         message="Missing translated file.",
                     )

--- a/src/co_op_translator/review/checks/structure.py
+++ b/src/co_op_translator/review/checks/structure.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from co_op_translator.review.models import ReviewIssue, ReviewSeverity
+
+
+def expected_translation_path(root_dir: Path, source_file: Path, language: str) -> Path:
+    return root_dir / "translations" / language / source_file.relative_to(root_dir)
+
+
+def check_translation_structure(
+    root_dir: Path, source_files: list[Path], languages: list[str]
+) -> list[ReviewIssue]:
+    issues: list[ReviewIssue] = []
+    for source_file in source_files:
+        for language in languages:
+            translated_path = expected_translation_path(root_dir, source_file, language)
+            if not translated_path.exists():
+                issues.append(
+                    ReviewIssue(
+                        check="structure",
+                        severity=ReviewSeverity.ERROR,
+                        path=source_file.relative_to(root_dir),
+                        language=language,
+                        message="Missing translated file.",
+                    )
+                )
+    return issues

--- a/src/co_op_translator/review/discovery.py
+++ b/src/co_op_translator/review/discovery.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+SOURCE_EXTENSIONS = {".md", ".mdx", ".ipynb"}
+DEFAULT_EXCLUDED_DIRS = {
+    ".git",
+    ".venv",
+    "__pycache__",
+    "dist",
+    "htmlcov",
+    "logs",
+    "node_modules",
+    "site",
+    "translated_images",
+    "translations",
+    "venv",
+}
+
+
+def is_source_file(path: Path) -> bool:
+    return path.suffix.lower() in SOURCE_EXTENSIONS
+
+
+def is_excluded(path: Path, excluded_dirs: set[str]) -> bool:
+    return any(part in excluded_dirs for part in path.parts)
+
+
+def discover_languages(root_dir: Path) -> list[str]:
+    translations_dir = root_dir / "translations"
+    if not translations_dir.is_dir():
+        return []
+    return sorted(
+        path.name
+        for path in translations_dir.iterdir()
+        if path.is_dir() and not path.name.startswith(".")
+    )
+
+
+def discover_source_files(root_dir: Path, excluded_dirs: set[str]) -> list[Path]:
+    files: list[Path] = []
+    for path in root_dir.rglob("*"):
+        if not path.is_file() or not is_source_file(path):
+            continue
+        relative_path = path.relative_to(root_dir)
+        if is_excluded(relative_path, excluded_dirs):
+            continue
+        files.append(path)
+    return sorted(files)
+
+
+def discover_changed_source_files(
+    root_dir: Path, changed_from: str, excluded_dirs: set[str]
+) -> list[Path]:
+    result = subprocess.run(
+        ["git", "diff", "--name-only", "--diff-filter=ACMR", f"{changed_from}...HEAD"],
+        cwd=root_dir,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return discover_source_files(root_dir, excluded_dirs)
+
+    files: list[Path] = []
+    for line in result.stdout.splitlines():
+        relative_path = Path(line.strip())
+        if not line.strip() or not is_source_file(relative_path):
+            continue
+        if is_excluded(relative_path, excluded_dirs):
+            continue
+        full_path = root_dir / relative_path
+        if full_path.is_file():
+            files.append(full_path)
+    return sorted(files)

--- a/src/co_op_translator/review/discovery.py
+++ b/src/co_op_translator/review/discovery.py
@@ -19,16 +19,23 @@ DEFAULT_EXCLUDED_DIRS = {
 }
 
 
-def is_source_file(path: Path) -> bool:
-    return path.suffix.lower() in SOURCE_EXTENSIONS
+def is_source_file(path: Path, source_extensions: set[str] | None = None) -> bool:
+    return path.suffix.lower() in (source_extensions or SOURCE_EXTENSIONS)
 
 
 def is_excluded(path: Path, excluded_dirs: set[str]) -> bool:
     return any(part in excluded_dirs for part in path.parts)
 
 
-def discover_languages(root_dir: Path) -> list[str]:
-    translations_dir = root_dir / "translations"
+def _is_relative_to(path: Path, root: Path) -> bool:
+    try:
+        path.relative_to(root)
+        return True
+    except ValueError:
+        return False
+
+
+def discover_languages(translations_dir: Path) -> list[str]:
     if not translations_dir.is_dir():
         return []
     return sorted(
@@ -38,10 +45,12 @@ def discover_languages(root_dir: Path) -> list[str]:
     )
 
 
-def discover_source_files(root_dir: Path, excluded_dirs: set[str]) -> list[Path]:
+def discover_source_files(
+    root_dir: Path, excluded_dirs: set[str], source_extensions: set[str] | None = None
+) -> list[Path]:
     files: list[Path] = []
     for path in root_dir.rglob("*"):
-        if not path.is_file() or not is_source_file(path):
+        if not path.is_file() or not is_source_file(path, source_extensions):
             continue
         relative_path = path.relative_to(root_dir)
         if is_excluded(relative_path, excluded_dirs):
@@ -51,26 +60,30 @@ def discover_source_files(root_dir: Path, excluded_dirs: set[str]) -> list[Path]
 
 
 def discover_changed_source_files(
-    root_dir: Path, changed_from: str, excluded_dirs: set[str]
+    git_root: Path,
+    source_root: Path,
+    changed_from: str,
+    excluded_dirs: set[str],
+    source_extensions: set[str] | None = None,
 ) -> list[Path]:
     result = subprocess.run(
         ["git", "diff", "--name-only", "--diff-filter=ACMR", f"{changed_from}...HEAD"],
-        cwd=root_dir,
+        cwd=git_root,
         check=False,
         capture_output=True,
         text=True,
     )
     if result.returncode != 0:
-        return discover_source_files(root_dir, excluded_dirs)
+        return discover_source_files(source_root, excluded_dirs, source_extensions)
 
     files: list[Path] = []
     for line in result.stdout.splitlines():
         relative_path = Path(line.strip())
-        if not line.strip() or not is_source_file(relative_path):
+        if not line.strip() or not is_source_file(relative_path, source_extensions):
             continue
         if is_excluded(relative_path, excluded_dirs):
             continue
-        full_path = root_dir / relative_path
-        if full_path.is_file():
+        full_path = (git_root / relative_path).resolve()
+        if full_path.is_file() and _is_relative_to(full_path, source_root):
             files.append(full_path)
     return sorted(files)

--- a/src/co_op_translator/review/models.py
+++ b/src/co_op_translator/review/models.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+
+
+class ReviewSeverity(str, Enum):
+    ERROR = "error"
+    WARNING = "warning"
+
+
+@dataclass(frozen=True)
+class ReviewIssue:
+    check: str
+    severity: ReviewSeverity
+    message: str
+    path: Path | None = None
+    language: str | None = None
+
+    def location(self) -> str:
+        if self.path is None:
+            return "-"
+        return str(self.path).replace("\\", "/")
+
+
+@dataclass
+class ReviewSummary:
+    root_dir: Path
+    source_files: list[Path] = field(default_factory=list)
+    languages: list[str] = field(default_factory=list)
+    issues: list[ReviewIssue] = field(default_factory=list)
+
+    @property
+    def error_count(self) -> int:
+        return sum(1 for issue in self.issues if issue.severity == ReviewSeverity.ERROR)
+
+    @property
+    def warning_count(self) -> int:
+        return sum(
+            1 for issue in self.issues if issue.severity == ReviewSeverity.WARNING
+        )
+
+    def to_text(self) -> str:
+        lines = [
+            "Co-op review complete",
+            f"Source files reviewed: {len(self.source_files)}",
+            f"Languages reviewed: {', '.join(self.languages) if self.languages else '-'}",
+            f"Errors: {self.error_count}",
+            f"Warnings: {self.warning_count}",
+        ]
+        if self.issues:
+            lines.append("")
+            lines.append("Issues:")
+            for issue in self.issues:
+                language = f" [{issue.language}]" if issue.language else ""
+                lines.append(
+                    f"- {issue.severity.value.upper()} {issue.check}{language}: "
+                    f"{issue.location()} - {issue.message}"
+                )
+        return "\n".join(lines)
+
+    def to_github_markdown(self) -> str:
+        status = "passed" if self.error_count == 0 else "failed"
+        lines = [
+            "## Co-op Review",
+            "",
+            f"Status: **{status}**",
+            "",
+            "| Metric | Count |",
+            "| --- | ---: |",
+            f"| Source files reviewed | {len(self.source_files)} |",
+            f"| Languages reviewed | {len(self.languages)} |",
+            f"| Errors | {self.error_count} |",
+            f"| Warnings | {self.warning_count} |",
+        ]
+        if self.issues:
+            lines.extend(
+                [
+                    "",
+                    "| Severity | Check | Language | Path | Message |",
+                    "| --- | --- | --- | --- | --- |",
+                ]
+            )
+            for issue in self.issues:
+                lines.append(
+                    "| "
+                    f"{issue.severity.value} | "
+                    f"{issue.check} | "
+                    f"{issue.language or '-'} | "
+                    f"`{issue.location()}` | "
+                    f"{issue.message.replace('|', '\\|')} |"
+                )
+        return "\n".join(lines)

--- a/src/co_op_translator/review/models.py
+++ b/src/co_op_translator/review/models.py
@@ -83,12 +83,13 @@ class ReviewSummary:
                 ]
             )
             for issue in self.issues:
+                escaped_message = issue.message.replace("|", "\\|")
                 lines.append(
                     "| "
                     f"{issue.severity.value} | "
                     f"{issue.check} | "
                     f"{issue.language or '-'} | "
                     f"`{issue.location()}` | "
-                    f"{issue.message.replace('|', '\\|')} |"
+                    f"{escaped_message} |"
                 )
         return "\n".join(lines)

--- a/src/co_op_translator/review/runner.py
+++ b/src/co_op_translator/review/runner.py
@@ -14,6 +14,7 @@ from co_op_translator.review.discovery import (
     discover_source_files,
 )
 from co_op_translator.review.models import ReviewSummary
+from co_op_translator.review.targets import ReviewTarget, build_review_targets
 
 
 @dataclass(frozen=True)
@@ -22,6 +23,8 @@ class ReviewConfig:
     languages: list[str] = field(default_factory=list)
     changed_from: str | None = None
     excluded_dirs: set[str] = field(default_factory=lambda: set(DEFAULT_EXCLUDED_DIRS))
+    targets: list[ReviewTarget] | None = None
+    source_extensions: set[str] | None = None
 
 
 class ReviewRunner:
@@ -30,29 +33,60 @@ class ReviewRunner:
 
     def run(self) -> ReviewSummary:
         root_dir = self.config.root_dir.resolve()
-        languages = self.config.languages or discover_languages(root_dir)
-
-        if self.config.changed_from:
-            source_files = discover_changed_source_files(
-                root_dir, self.config.changed_from, self.config.excluded_dirs
-            )
-        else:
-            source_files = discover_source_files(root_dir, self.config.excluded_dirs)
+        targets = self.config.targets or build_review_targets(root_dir=root_dir)
+        languages = self.config.languages or sorted(
+            {
+                language
+                for target in targets
+                for language in discover_languages(target.translations_dir)
+            }
+        )
 
         issues = []
-        if languages:
+        source_files: list[Path] = []
+        for target in targets:
+            if self.config.changed_from:
+                target_source_files = discover_changed_source_files(
+                    root_dir,
+                    target.source_root,
+                    self.config.changed_from,
+                    self.config.excluded_dirs,
+                    self.config.source_extensions,
+                )
+            else:
+                target_source_files = discover_source_files(
+                    target.source_root,
+                    self.config.excluded_dirs,
+                    self.config.source_extensions,
+                )
+            source_files.extend(target_source_files)
+
+            if not languages:
+                continue
+
             issues.extend(
-                check_translation_structure(root_dir, source_files, languages)
+                check_translation_structure(target, target_source_files, languages)
             )
             issues.extend(
-                check_translation_freshness(root_dir, source_files, languages)
+                check_translation_freshness(target, target_source_files, languages)
             )
-            issues.extend(check_markdown_integrity(root_dir, source_files, languages))
-            issues.extend(check_local_links(root_dir, source_files, languages))
+            issues.extend(
+                check_markdown_integrity(target, target_source_files, languages)
+            )
+            issues.extend(check_local_links(target, target_source_files, languages))
 
         return ReviewSummary(
             root_dir=root_dir,
-            source_files=[path.relative_to(root_dir) for path in source_files],
+            source_files=[
+                _display_path(root_dir, path) for path in sorted(source_files)
+            ],
             languages=languages,
             issues=issues,
         )
+
+
+def _display_path(root_dir: Path, path: Path) -> Path:
+    try:
+        return path.relative_to(root_dir)
+    except ValueError:
+        return path

--- a/src/co_op_translator/review/runner.py
+++ b/src/co_op_translator/review/runner.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from co_op_translator.review.checks.freshness import check_translation_freshness
+from co_op_translator.review.checks.links import check_local_links
+from co_op_translator.review.checks.markdown_integrity import check_markdown_integrity
+from co_op_translator.review.checks.structure import check_translation_structure
+from co_op_translator.review.discovery import (
+    DEFAULT_EXCLUDED_DIRS,
+    discover_changed_source_files,
+    discover_languages,
+    discover_source_files,
+)
+from co_op_translator.review.models import ReviewSummary
+
+
+@dataclass(frozen=True)
+class ReviewConfig:
+    root_dir: Path
+    languages: list[str] = field(default_factory=list)
+    changed_from: str | None = None
+    excluded_dirs: set[str] = field(default_factory=lambda: set(DEFAULT_EXCLUDED_DIRS))
+
+
+class ReviewRunner:
+    def __init__(self, config: ReviewConfig):
+        self.config = config
+
+    def run(self) -> ReviewSummary:
+        root_dir = self.config.root_dir.resolve()
+        languages = self.config.languages or discover_languages(root_dir)
+
+        if self.config.changed_from:
+            source_files = discover_changed_source_files(
+                root_dir, self.config.changed_from, self.config.excluded_dirs
+            )
+        else:
+            source_files = discover_source_files(root_dir, self.config.excluded_dirs)
+
+        issues = []
+        if languages:
+            issues.extend(
+                check_translation_structure(root_dir, source_files, languages)
+            )
+            issues.extend(
+                check_translation_freshness(root_dir, source_files, languages)
+            )
+            issues.extend(check_markdown_integrity(root_dir, source_files, languages))
+            issues.extend(check_local_links(root_dir, source_files, languages))
+
+        return ReviewSummary(
+            root_dir=root_dir,
+            source_files=[path.relative_to(root_dir) for path in source_files],
+            languages=languages,
+            issues=issues,
+        )

--- a/src/co_op_translator/review/targets.py
+++ b/src/co_op_translator/review/targets.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+
+@dataclass(frozen=True)
+class ReviewTarget:
+    source_root: Path
+    translations_dir: Path
+    lang_subdir: Path | None = None
+
+    def language_root(self, language: str) -> Path:
+        lang_root = self.translations_dir / language
+        if self.lang_subdir:
+            lang_root = lang_root / self.lang_subdir
+        return lang_root
+
+    def translated_path(self, source_file: Path, language: str) -> Path:
+        return self.language_root(language) / source_file.relative_to(self.source_root)
+
+    def display_source_path(self, source_file: Path) -> Path:
+        try:
+            return source_file.relative_to(self.source_root)
+        except ValueError:
+            return source_file
+
+    def display_translated_path(self, translated_file: Path) -> Path:
+        try:
+            return translated_file.relative_to(self.translations_dir)
+        except ValueError:
+            return translated_file
+
+
+def split_lang_placeholder(path: str) -> tuple[str, str | None]:
+    placeholder = "<lang>"
+    if placeholder not in path:
+        return path, None
+
+    prefix, suffix = path.split(placeholder, 1)
+    prefix = prefix.rstrip("/\\")
+    suffix = suffix.lstrip("/\\")
+    return prefix, (suffix or None)
+
+
+def resolve_output_root(source_root: Path, output_root: str | None) -> Path:
+    if output_root is None:
+        return source_root / "translations"
+
+    output_path = Path(output_root)
+    if output_path.is_absolute():
+        return output_path.resolve()
+    return (source_root / output_path).resolve()
+
+
+def build_review_targets(
+    *,
+    root_dir: str | Path,
+    translations_dir: str | None = None,
+    root_dirs: Iterable[str] | None = None,
+    groups: Iterable[tuple[str, str | None]] | None = None,
+) -> list[ReviewTarget]:
+    if groups is not None:
+        targets: list[ReviewTarget] = []
+        for source_root_value, output_template in list(groups):
+            source_root = Path(source_root_value).resolve()
+            output_root = output_template
+            lang_subdir: str | None = None
+            if output_template is not None:
+                output_root, lang_subdir = split_lang_placeholder(output_template)
+            targets.append(
+                ReviewTarget(
+                    source_root=source_root,
+                    translations_dir=resolve_output_root(source_root, output_root),
+                    lang_subdir=Path(lang_subdir) if lang_subdir else None,
+                )
+            )
+        return targets
+
+    if root_dirs is not None:
+        targets = []
+        for source_root_value in list(root_dirs):
+            source_root = Path(source_root_value).resolve()
+            targets.append(
+                ReviewTarget(
+                    source_root=source_root,
+                    translations_dir=resolve_output_root(source_root, translations_dir),
+                )
+            )
+        return targets
+
+    source_root = Path(root_dir).resolve()
+    return [
+        ReviewTarget(
+            source_root=source_root,
+            translations_dir=resolve_output_root(source_root, translations_dir),
+        )
+    ]

--- a/tests/co_op_translator/review/test_runner.py
+++ b/tests/co_op_translator/review/test_runner.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from co_op_translator.cli.review import review_command
+from co_op_translator.review.models import ReviewSeverity
+from co_op_translator.review.runner import ReviewConfig, ReviewRunner
+from co_op_translator.utils.common.metadata_utils import save_text_metadata_for_source
+
+
+def _write_source(root: Path, relative_path: str, content: str = "# Hello\n") -> Path:
+    source_file = root / relative_path
+    source_file.parent.mkdir(parents=True, exist_ok=True)
+    source_file.write_text(content, encoding="utf-8")
+    return source_file
+
+
+def _write_translation(
+    root: Path, source_file: Path, language: str, content: str = "# 안녕하세요\n"
+) -> Path:
+    translated_file = root / "translations" / language / source_file.relative_to(root)
+    translated_file.parent.mkdir(parents=True, exist_ok=True)
+    translated_file.write_text(content, encoding="utf-8")
+    save_text_metadata_for_source(
+        root / "translations" / language,
+        source_file,
+        language,
+        root_dir=root,
+    )
+    return translated_file
+
+
+def test_review_runner_passes_for_fresh_translation(tmp_path):
+    source_file = _write_source(tmp_path, "README.md")
+    _write_translation(tmp_path, source_file, "ko")
+
+    summary = ReviewRunner(ReviewConfig(tmp_path, languages=["ko"])).run()
+
+    assert summary.error_count == 0
+    assert summary.warning_count == 0
+    assert summary.source_files == [Path("README.md")]
+
+
+def test_review_runner_reports_missing_translation(tmp_path):
+    _write_source(tmp_path, "README.md")
+
+    summary = ReviewRunner(ReviewConfig(tmp_path, languages=["ko"])).run()
+
+    assert summary.error_count == 1
+    issue = summary.issues[0]
+    assert issue.check == "structure"
+    assert issue.severity == ReviewSeverity.ERROR
+
+
+def test_review_runner_reports_stale_translation_metadata(tmp_path):
+    source_file = _write_source(tmp_path, "README.md", "# Hello\n")
+    _write_translation(tmp_path, source_file, "ko")
+    source_file.write_text("# Hello again\n", encoding="utf-8")
+
+    summary = ReviewRunner(ReviewConfig(tmp_path, languages=["ko"])).run()
+
+    assert summary.error_count == 1
+    assert summary.issues[0].check == "freshness"
+
+
+def test_review_runner_reports_markdown_integrity_errors(tmp_path):
+    source_file = _write_source(
+        tmp_path, "README.md", "# Hello\n\n```python\nprint(1)\n```\n"
+    )
+    _write_translation(
+        tmp_path, source_file, "ko", "# 안녕하세요\n\n```python\nprint(1)\n"
+    )
+
+    summary = ReviewRunner(ReviewConfig(tmp_path, languages=["ko"])).run()
+
+    assert summary.error_count == 1
+    assert summary.issues[0].check == "markdown-integrity"
+
+
+def test_review_runner_reports_local_link_warnings(tmp_path):
+    source_file = _write_source(tmp_path, "README.md")
+    _write_translation(tmp_path, source_file, "ko", "[missing](missing.md)\n")
+
+    summary = ReviewRunner(ReviewConfig(tmp_path, languages=["ko"])).run()
+
+    assert summary.error_count == 0
+    assert summary.warning_count == 1
+    assert summary.issues[0].check == "local-link"
+
+
+def test_review_cli_outputs_github_summary(tmp_path):
+    source_file = _write_source(tmp_path, "README.md")
+    _write_translation(tmp_path, source_file, "ko")
+
+    result = CliRunner().invoke(
+        review_command,
+        ["--root-dir", str(tmp_path), "--language-code", "ko", "--format", "github"],
+    )
+
+    assert result.exit_code == 0
+    assert "## Co-op Review" in result.output
+    assert "Status: **passed**" in result.output

--- a/tests/co_op_translator/test_review_api.py
+++ b/tests/co_op_translator/test_review_api.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from co_op_translator.api import run_review
+from co_op_translator.utils.common.metadata_utils import save_text_metadata_for_source
+
+
+def _write_source(root: Path, relative_path: str, content: str = "# Hello\n") -> Path:
+    source_file = root / relative_path
+    source_file.parent.mkdir(parents=True, exist_ok=True)
+    source_file.write_text(content, encoding="utf-8")
+    return source_file
+
+
+def _write_translation(
+    source_root: Path,
+    output_root: Path,
+    source_file: Path,
+    language: str,
+    lang_subdir: str | None = None,
+) -> Path:
+    lang_root = output_root / language
+    if lang_subdir:
+        lang_root = lang_root / lang_subdir
+    translated_file = lang_root / source_file.relative_to(source_root)
+    translated_file.parent.mkdir(parents=True, exist_ok=True)
+    translated_file.write_text("# 안녕하세요\n", encoding="utf-8")
+    save_text_metadata_for_source(
+        lang_root, source_file, language, root_dir=source_root
+    )
+    return translated_file
+
+
+def test_run_review_returns_summary_for_default_translation_layout(tmp_path):
+    source_file = _write_source(tmp_path, "README.md")
+    _write_translation(tmp_path, tmp_path / "translations", source_file, "ko")
+
+    summary = run_review(
+        language_codes="ko",
+        root_dir=str(tmp_path),
+        markdown=True,
+    )
+
+    assert summary.error_count == 0
+    assert summary.languages == ["ko"]
+    assert summary.source_files == [Path("README.md")]
+
+
+def test_run_review_supports_translation_style_groups(tmp_path):
+    docs_root = tmp_path / "docs"
+    source_file = _write_source(docs_root, "guide.md")
+    output_root = tmp_path / "i18n"
+    lang_subdir = "docusaurus-plugin-content-docs/current"
+    _write_translation(docs_root, output_root, source_file, "ko", lang_subdir)
+
+    summary = run_review(
+        language_codes="ko",
+        root_dir=str(tmp_path),
+        markdown=True,
+        groups=[
+            (
+                str(docs_root),
+                str(output_root / "<lang>" / lang_subdir),
+            )
+        ],
+        output_format="github",
+    )
+
+    assert summary.error_count == 0
+    assert summary.source_files == [Path("docs") / "guide.md"]
+
+
+def test_run_review_supports_multiple_root_dirs(tmp_path):
+    root1 = tmp_path / "content1"
+    root2 = tmp_path / "content2"
+    source1 = _write_source(root1, "one.md")
+    source2 = _write_source(root2, "two.md")
+    _write_translation(root1, root1 / "translations", source1, "ko")
+    _write_translation(root2, root2 / "translations", source2, "ko")
+
+    summary = run_review(
+        language_codes="ko",
+        root_dir=str(tmp_path),
+        markdown=True,
+        root_dirs=[str(root1), str(root2)],
+    )
+
+    assert summary.error_count == 0
+    assert summary.source_files == [
+        Path("content1") / "one.md",
+        Path("content2") / "two.md",
+    ]


### PR DESCRIPTION
## Summary

This PR adds a deterministic `co-op-review` workflow for translation PRs, plus a programmatic `run_review()` API that mirrors the shape of `run_translation()`.

The first version intentionally avoids LLM/API quality review and focuses on checks that can run reliably in CI without credentials.

## What changed

- Added a new `co-op-review` CLI entry point.
- Added `co_op_translator.api.run_review()` for programmatic review automation.
- Added reusable review target resolution for default, multi-root, and grouped output layouts.
- Added `co_op_translator.review` with focused deterministic checks:
  - translation structure
  - metadata freshness
  - markdown/notebook integrity
  - local link and image-link existence warnings
- Added GitHub summary output for PR runs.
- Added a `Co-op review` GitHub Actions workflow that reviews changed Markdown/MDX/notebook sources in PRs.
- Added tests for passing, missing, stale, malformed, warning, GitHub summary, API, multi-root, and grouped output cases.

## API shape

`run_review()` accepts the same core project-shaping inputs as `run_translation()`:

- `language_codes`
- `root_dir`
- `markdown`
- `images`
- `notebook`
- `translations_dir`
- `root_dirs`
- `groups`
- `debug`
- `save_logs`

Review-specific options include:

- `changed_from`
- `output_format`
- `fail_on_warnings`

## Behavior

Blocking errors:
- missing translated files
- missing or stale translation metadata
- malformed translated markdown/frontmatter/code fences
- invalid translated notebook JSON

Warnings only:
- missing local link or image-link targets

## Verification

- `pytest tests/co_op_translator/review/test_runner.py tests/co_op_translator/test_review_api.py -q` -> 9 passed
- `pytest -q` -> 261 passed
- Parsed `.github/workflows/co-op-review.yml` locally
- Smoke-tested `run_review(..., output_format="github")`
- Smoke-tested `co-op-review --changed-from HEAD --format github`