### PR TITLE
Docs: Improve contributor setup guidance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to Co-op Translator
 
-This project welcomes contributions and suggestions.  Most contributions require you to agree to a
+This project welcomes contributions and suggestions. Most contributions require you to agree to a
 Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us
 the rights to use your contribution. For details, visit https://cla.opensource.microsoft.com.
 
@@ -8,53 +8,81 @@ When you submit a pull request, a CLA bot will automatically determine whether y
 a CLA and decorate the PR appropriately (e.g., status check, comment). Simply follow the instructions
 provided by the bot. You will only need to do this once across all repos using our CLA.
 
+## New contributor quick start
+
+1. Fork the repository and create a branch in your fork.
+2. Pick a focused issue, such as a documentation typo, a test improvement, or a small bug fix.
+3. Read the relevant guide before editing:
+   - [Installation guide](./getting_started/command-line-guide/install-package.md)
+   - [Configuration reference](./docs/configuration.md)
+   - [CLI reference](./docs/cli.md)
+4. Make the smallest complete change that addresses the issue.
+5. Run the relevant checks before opening a pull request.
+6. Open a pull request and mention the issue number it addresses.
+
+Helpful GitHub resources:
+
+- [Fork a repository](https://docs.github.com/en/get-started/quickstart/fork-a-repo)
+- [Create a pull request](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request)
+
 ## Development environment setup
 
-To set up the development environment for this project, we recommend using Poetry for managing dependencies. We use `pyproject.toml` to manage project dependencies, and therefore, to install dependencies, you should use Poetry.
+Co-op Translator supports Python 3.10 through 3.12. We recommend Poetry for repository development because it reads the dependency groups from `pyproject.toml`. Use the pip path only when you need an editable local install outside Poetry.
 
-### Create a virtual environment
+### Poetry setup
 
-#### Using pip
-
-```bash
-python -m venv .venv
-```
-
-#### Using Poetry
-
-```bash
-poetry init
-```
-
-### Activate the virtual environment
-
-#### For both pip and Poetry
-
-- Windows:
-
-    ```bash
-    .venv\Scripts\activate.bat
-    ```
-
-- Mac/Linux:
-
-    ```bash
-    source .venv/bin/activate
-    ```
-
-#### Using Poetry
-
-```bash
-poetry shell
-```
-
-### Installing the Package and required Packages
-
-#### Using Poetry (from pyproject.toml)
+Install Poetry, then run the following commands from the repository root:
 
 ```bash
 poetry install
+poetry run translate --help
 ```
+
+### pip setup
+
+Create and activate a virtual environment, then install development dependencies and the editable package.
+
+Windows:
+
+```powershell
+python -m venv .venv
+.venv\Scripts\activate
+python -m pip install --upgrade pip
+pip install -r requirements-dev.txt
+pip install -e .
+translate --help
+```
+
+macOS / Linux:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+python -m pip install --upgrade pip
+pip install -r requirements-dev.txt
+pip install -e .
+translate --help
+```
+
+### Environment variables
+
+1. Create an `.env` file in the root directory by copying the provided `.env.template` file.
+2. Configure either Azure OpenAI or OpenAI.
+3. Configure Azure AI Vision only when testing image translation.
+
+See the [configuration reference](./docs/configuration.md) for the current variable names and command requirements.
+
+### Quick checks
+
+Run the checks that match your change:
+
+```bash
+poetry run black .
+poetry run ruff check .
+poetry run pytest -m "not api_key_required"
+```
+
+If you are using the pip setup, omit `poetry run`.
 
 ### Manual testing
 
@@ -76,23 +104,23 @@ Before submitting a PR, it's important to test the translation functionality wit
     pip install -e .
     ```
 
-4. Run Co-op Translator on your test documents:
+4. Run Co-op Translator on your test documents. Translation commands require provider credentials in `.env`.
     ```bash
-    python -m co_op_translator --language-codes ko --root-dir test_docs
+    translate -l "ko" -md -r test_docs
     ```
 
-5. Check the translated files in `test_docs/translations` and `test_docs/translated_images` to verify:
+5. Run deterministic review checks. This command does not require API credentials.
+    ```bash
+    co-op-review -l "ko" -r test_docs
+    ```
+
+6. Check the translated files in `test_docs/translations` and `test_docs/translated_images` to verify:
    - The translation quality
    - The metadata comments are correct
    - The original markdown structure is preserved
    - Links and images are working properly
 
 This manual testing helps ensure that your changes work well in real-world scenarios.
-
-### Environment variables
-
-1. Create an `.env` file in the root directory by copying the provided `.env.template` file.
-1. Fill in the environment variables as guided.
 
 > [!TIP]
 >
@@ -102,7 +130,7 @@ This manual testing helps ensure that your changes work well in real-world scena
 >
 > #### GitHub Codespaces
 >
-> You can run this samples virtually by using GitHub Codespaces and no additional settings or setup are required.
+> You can run this sample virtually by using GitHub Codespaces. No additional local setup is required.
 >
 > The button will open a web-based VS Code instance in your browser:
 >
@@ -190,14 +218,14 @@ To run Co-op Translator using Poetry in your environment, follow these steps:
 
 1. Navigate to the directory where you want to perform translation tests or create a temporary folder for testing purposes.
 
-2. Execute the following command. Replace `-l ko` with the language code you wish to translate into. The `-d` flag indicates debug mode.
+2. Execute the following command. Replace `ko` with the language code you wish to translate into. The `-d` flag enables debug mode.
 
     ```bash
-    poetry run co-op-translator translate -l ko -d
+    poetry run translate -l "ko" -md -r test_docs -d
     ```
 
 > [!NOTE]
-> Ensure your Poetry environment is activated (poetry shell) before running the command.
+> Translation commands require provider credentials in `.env`. For deterministic checks without API credentials, run `poetry run co-op-review -l "ko" -r test_docs`.
 
 ## Contribute a new language
 

--- a/README.md
+++ b/README.md
@@ -113,7 +113,9 @@ docker run --rm -it --env-file .env -v "${PWD}:/work" ghcr.io/azure/co-op-transl
 
 ## Minimal setup
 
-1. Assert that you have a supported Python version (currently 3.10-3.12). In poetry (pyproject.toml) this is handeled automatically.
+For a beginner-friendly walkthrough, see the [installation guide](./getting_started/command-line-guide/install-package.md).
+
+1. Use a supported Python version: 3.10 through 3.12. Poetry enforces this for repository development.
 2. Create a `.env` file using the template: [.env.template](./.env.template)
 3. Configure one LLM provider (Azure OpenAI or OpenAI)
 4. (Optional) For image translation (`-img`), configure Azure AI Vision

--- a/getting_started/command-line-guide/command-line-guide.md
+++ b/getting_started/command-line-guide/command-line-guide.md
@@ -2,12 +2,12 @@
 
 ## Prerequisites
 
-- **Python 3.10 or higher**: Required for running the Co-op Translator.
+- **Python 3.10 through 3.12**: Required for running Co-op Translator.
 
 ## Table of Contents
 
-1. [Create an '.env' file in the root directory](./create-env-file.md)
+1. [Create a `.env` file in the root directory](./create-env-file.md)
    - Include necessary keys for the chosen language model service.
-   - If Azure Computer Vision keys are omitted or `-md` is specified, the translator will operate in Markdown-only mode.
-1. [Install the Co-op translator package](./install-package.md)
+   - Configure Azure AI Vision only when you need image translation. Use `-md` or `-nb` for text-only runs.
+1. [Install the Co-op Translator package](./install-package.md)
 1. [Translate your project using Co-op Translator](./translator-your-project.md)

--- a/getting_started/command-line-guide/create-env-file.md
+++ b/getting_started/command-line-guide/create-env-file.md
@@ -3,11 +3,11 @@
 In this tutorial, we will guide you through setting up your environment variables for Azure services using an *.env* file. Environment variables allow you to securely manage sensitive credentials, such as API keys, without hard-coding them into your codebase.
 
 > [!IMPORTANT]
-> - Only one language model service (Azure OpenAI or OpenAI) needs to be configured. Fill in the environment variables for your preferred service. If environment variables for multiple language models are set, the co-op translator will select one based on priority.
-> - If Computer Vision environment variables are not set, the translator will automatically switch to [Markdown-only mode](./markdown-only-mode.md).
+> - Configure either Azure OpenAI or OpenAI. You do not need both.
+> - Azure AI Vision is required only for image translation. If Vision variables are not set, run text-only commands such as `translate -l "ko" -md` or `translate -l "ko" -nb`.
 
 > [!NOTE]
-> This guide primarily focuses on Azure services, but you can choose any supported language model from the [supported models and services list](../README.md#-supported-models-and-services).
+> This guide focuses on the local `.env` file. For the current provider matrix and command requirements, see the [configuration reference](../../docs/configuration.md).
 
 ## Create the *.env* file
 
@@ -44,7 +44,7 @@ In the root directory of your project, create a file named *.env*. This file wil
     OPENAI_API_KEY="your_openai_api_key"
     OPENAI_ORG_ID="your_openai_org_id"
     OPENAI_CHAT_MODEL_ID="your_chat_model_id(ex. gpt-4o)"
-    OPENAI_BASE_URL="https://api.openai.com/v1 (If you don't have a custom base URL, you can delete this lin, then it will use the default base URL)"
+    OPENAI_BASE_URL="https://api.openai.com/v1" # Optional. Remove this line to use the default OpenAI base URL.
 
     # Optional fallback sets: duplicate the full OPENAI_* set with suffix _1/_2 (same index for all variables)
     ```

--- a/getting_started/command-line-guide/install-package.md
+++ b/getting_started/command-line-guide/install-package.md
@@ -1,82 +1,79 @@
-# Install the Co-op translator package
+# Install Co-op Translator
 
-The **Co-op Translator** is a command-line interface (CLI) tool designed to help you translate all the markdown files and images in your project into multiple languages. This tutorial will guide you through configuring the translator and running it for various use cases.
+Co-op Translator supports Python 3.10 through 3.12. Use a virtual environment so the CLI dependencies stay separate from your system Python packages.
 
-### Create a virtual environment
+## Install from PyPI
 
-You can create a virtual environment using either `pip` or `Poetry`. Type one of the following commands inside your terminal.
+Use this path when you want to run the published CLI in your own documentation project.
 
-#### Using pip
+### Windows
+
+```powershell
+python -m venv .venv
+.venv\Scripts\activate
+python -m pip install --upgrade pip
+pip install co-op-translator
+translate --help
+```
+
+### macOS / Linux
 
 ```bash
 python -m venv .venv
+source .venv/bin/activate
+python -m pip install --upgrade pip
+pip install co-op-translator
+translate --help
 ```
 
-#### Using Poetry
+After installation, create a `.env` file and configure one language model provider before running translation. See [Create a `.env` file](./create-env-file.md) and the full [configuration reference](../../docs/configuration.md).
+
+## Install from a repository clone
+
+Use this path when you want to contribute to Co-op Translator itself.
+
+1. Fork the repository on GitHub.
+2. Clone your fork:
+
+   ```bash
+   git clone https://github.com/<your-account>/co-op-translator.git
+   cd co-op-translator
+   ```
+
+3. Install dependencies with Poetry:
+
+   ```bash
+   poetry install
+   poetry run translate --help
+   ```
+
+If you prefer pip for local development, install the development requirements and then install the package in editable mode:
 
 ```bash
-poetry init
+python -m venv .venv
+source .venv/bin/activate
+python -m pip install --upgrade pip
+pip install -r requirements-dev.txt
+pip install -e .
+translate --help
 ```
 
-### Activate the virtual environment
+On Windows, replace `source .venv/bin/activate` with:
 
-After creating the virtual environment, you'll need to activate it. The steps differ based on your operating system. Type the following command inside your terminal.
-
-#### For both pip and Poetry
-
-- Windows:
-
-    ```bash
-    .venv\Scripts\activate
-    ```
-
-- Mac/Linux:
-
-    ```bash
-    source .venv/bin/activate
-    ```
-
-#### Using Poetry
-
-1. If you created the environment with Poetry, type the following command inside your terminal to activate it.
-
-    ```bash
-    poetry shell
-    ```
-
-### Installing the Package and required Packages
-
-Once your virtual environment is set up and activated, the next step is to install the necessary dependencies.
-
-### Quick install
-
-Install via Co-Op Translator via pip
-
-```
-pip install co-op-translator
-```
-Or 
-
-Install via poetry
-```
-poetry add co-op-translator
+```powershell
+.venv\Scripts\activate
 ```
 
-#### Using pip (from requirements.txt) if you clone this repo 
+## First translation check
 
-> [!NOTE]
-> Please do NOT do this if you install co-op translator via the quick install.
+Run a narrow Markdown-only command first. This confirms that the CLI, credentials, and output folder are working before you add notebooks or images.
 
-1. If you're using pip, type the following command inside your terminal. It will automatically install the required packages specified in the `requirements.txt` file:
+```bash
+translate -l "ko" -md
+```
 
-    ```bash
-    pip install -r requirements.txt
-    ```
+Image translation requires Azure AI Vision credentials in addition to an LLM provider:
 
-#### Using Poetry (from pyproject.toml)
-
-1. If you're using Poetry, type the following command inside your terminal. It will automatically install the required packages specified in the `pyproject.toml` file:
-
-    ```bash
-    poetry install
-    ```
+```bash
+translate -l "ko" -img
+```

--- a/tests/co_op_translator/test_docs_issue_45.py
+++ b/tests/co_op_translator/test_docs_issue_45.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parents[2]
+
+ISSUE_45_DOCS = [
+    ROOT_DIR / "README.md",
+    ROOT_DIR / "CONTRIBUTING.md",
+    ROOT_DIR / "getting_started" / "command-line-guide" / "command-line-guide.md",
+    ROOT_DIR / "getting_started" / "command-line-guide" / "install-package.md",
+    ROOT_DIR / "getting_started" / "command-line-guide" / "create-env-file.md",
+]
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def test_issue_45_known_typos_and_stale_phrases_do_not_reappear() -> None:
+    combined = "\n".join(_read(path) for path in ISSUE_45_DOCS)
+
+    stale_phrases = [
+        "intial",
+        "handeled",
+        "delete this lin",
+        "Co-Op Translator",
+        "Co-op translator package",
+        "poetry init",
+        "co-op-translator translate",
+        "Markdown-only mode",
+        "markdown-only-mode.md",
+        "supported models and services list",
+        "Azure Computer Vision",
+        "Python 3.10 or higher",
+    ]
+
+    for phrase in stale_phrases:
+        assert phrase not in combined
+
+
+def test_contributing_links_new_contributors_to_setup_and_pr_resources() -> None:
+    contributing = _read(ROOT_DIR / "CONTRIBUTING.md")
+
+    expected_links = [
+        "[Installation guide](./getting_started/command-line-guide/install-package.md)",
+        "[Configuration reference](./docs/configuration.md)",
+        "[CLI reference](./docs/cli.md)",
+        "[Fork a repository](https://docs.github.com/en/get-started/quickstart/fork-a-repo)",
+        "[Create a pull request](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request)",
+    ]
+
+    for link in expected_links:
+        assert link in contributing
+
+
+def test_install_guide_keeps_beginner_setup_paths() -> None:
+    install_guide = _read(
+        ROOT_DIR / "getting_started" / "command-line-guide" / "install-package.md"
+    )
+
+    expected_sections = [
+        "## Install from PyPI",
+        "## Install from a repository clone",
+        "Python 3.10 through 3.12",
+        "pip install co-op-translator",
+        "poetry install",
+        "pip install -e .",
+        'translate -l "ko" -md',
+    ]
+
+    for section in expected_sections:
+        assert section in install_guide


### PR DESCRIPTION
## Summary

- Fix README setup wording and link the beginner installation guide.
- Add a new contributor quick start to CONTRIBUTING with setup, check, fork, and PR links.
- Rewrite the command-line installation guide into PyPI and repository-clone paths.
- Clean stale command-line guide wording around Vision configuration and old Markdown-only references.
- Add a docs regression test for the typo/stale-phrase cluster from #45.

## Validation

- `python -m black --check tests/co_op_translator/test_docs_issue_45.py`
- `python -m ruff check tests/co_op_translator/test_docs_issue_45.py`
- `python -m pytest tests/co_op_translator/test_docs_issue_45.py -q`
- `mkdocs build --strict`
- `git diff --check`

Closes #45