### PR TITLE
Core: Separate image translation pipeline

### DIFF
--- a/src/co_op_translator/api/__init__.py
+++ b/src/co_op_translator/api/__init__.py
@@ -1,9 +1,11 @@
 """Public programmatic API for Co-op Translator."""
 
 from co_op_translator.api.translation import (
+    ImageTranslationOptions,
     MarkdownTranslationOptions,
     run_translation,
     rewrite_markdown_paths,
+    translate_image_content,
     translate_markdown_content,
     translate_project,
 )
@@ -11,9 +13,11 @@ from co_op_translator.api.review import run_review
 
 __all__ = [
     "MarkdownTranslationOptions",
+    "ImageTranslationOptions",
     "rewrite_markdown_paths",
     "run_review",
     "run_translation",
+    "translate_image_content",
     "translate_markdown_content",
     "translate_project",
 ]

--- a/src/co_op_translator/api/translation.py
+++ b/src/co_op_translator/api/translation.py
@@ -8,6 +8,7 @@ from typing import Iterable, Mapping
 
 import click
 import yaml
+from PIL import Image
 
 from co_op_translator.config.base_config import Config
 from co_op_translator.config.llm_config.config import LLMConfig
@@ -15,6 +16,7 @@ from co_op_translator.config.vision_config.config import VisionConfig
 from co_op_translator.core.llm.markdown_translator import MarkdownTranslator
 from co_op_translator.core.project.language_migrator import LanguageFolderMigrator
 from co_op_translator.core.project.project_translator import ProjectTranslator
+from co_op_translator.core.vision.image_translator import ImageTranslator
 from co_op_translator.glossary import glossary_terms_scope
 from co_op_translator.utils.common.file_utils import (
     render_updated_readme_languages_table,
@@ -44,6 +46,14 @@ class MarkdownTranslationOptions:
     source_path: str | Path | None = None
 
 
+@dataclass(frozen=True)
+class ImageTranslationOptions:
+    """Options for content-only image translation."""
+
+    root_dir: str | Path = "."
+    fast_mode: bool = False
+
+
 def _coerce_markdown_translation_options(
     options: MarkdownTranslationOptions | Mapping[str, object] | None,
 ) -> MarkdownTranslationOptions:
@@ -52,6 +62,16 @@ def _coerce_markdown_translation_options(
     if isinstance(options, MarkdownTranslationOptions):
         return options
     return MarkdownTranslationOptions(**dict(options))
+
+
+def _coerce_image_translation_options(
+    options: ImageTranslationOptions | Mapping[str, object] | None,
+) -> ImageTranslationOptions:
+    if options is None:
+        return ImageTranslationOptions()
+    if isinstance(options, ImageTranslationOptions):
+        return options
+    return ImageTranslationOptions(**dict(options))
 
 
 async def translate_markdown_content(
@@ -67,6 +87,24 @@ async def translate_markdown_content(
         document,
         language_code,
         source_path=resolved_options.source_path,
+    )
+
+
+def translate_image_content(
+    image_path: str | Path,
+    language_code: str,
+    options: ImageTranslationOptions | Mapping[str, object] | None = None,
+) -> Image.Image:
+    """Translate image text and return a rendered image without saving metadata."""
+
+    resolved_options = _coerce_image_translation_options(options)
+    translator = ImageTranslator.create(
+        root_dir=resolved_options.root_dir,
+    )
+    return translator.translate_image(
+        image_path,
+        language_code,
+        fast_mode=resolved_options.fast_mode,
     )
 
 

--- a/src/co_op_translator/core/project/translation/project_file_translation.py
+++ b/src/co_op_translator/core/project/translation/project_file_translation.py
@@ -4,6 +4,8 @@ import logging
 import os
 from pathlib import Path
 
+from PIL import Image
+
 from co_op_translator.config.constants import SUPPORTED_MARKDOWN_EXTENSIONS
 from co_op_translator.utils.common.file_utils import (
     delete_translated_images_by_language_code,
@@ -17,6 +19,7 @@ from co_op_translator.utils.common.file_utils import (
 from co_op_translator.utils.common.metadata_utils import (
     is_image_up_to_date,
     is_notebook_up_to_date,
+    save_image_metadata,
     save_text_metadata_for_source,
 )
 from co_op_translator.utils.markdown.processing import compare_line_breaks
@@ -24,6 +27,7 @@ from co_op_translator.utils.markdown.path_rewriter import (
     MarkdownPathRewritePolicy,
     rewrite_markdown_paths,
 )
+from co_op_translator.utils.vision.image_utils import save_optimized_image
 
 logger = logging.getLogger(__name__)
 
@@ -65,6 +69,27 @@ class ProjectFileTranslationMixin:
             ),
         )
 
+    def _get_translated_image_path(self, image_path: Path, language_code: str) -> Path:
+        translated_filename = generate_translated_filename(
+            image_path, language_code, self.root_dir
+        )
+        return Path(self.image_dir) / language_code / translated_filename
+
+    def _save_original_image_translation(
+        self, image_path: Path, translated_path: Path, language_code: str
+    ) -> str:
+        translated_path.parent.mkdir(parents=True, exist_ok=True)
+        original_image = Image.open(image_path)
+        save_optimized_image(original_image, translated_path)
+        save_image_metadata(
+            translated_path,
+            image_path,
+            language_code,
+            self.root_dir,
+            image_dir=Path(self.image_dir),
+        )
+        return str(translated_path)
+
     async def translate_image(
         self, image_path: Path, language_code: str, fast_mode: bool = False
     ) -> str:
@@ -81,6 +106,9 @@ class ProjectFileTranslationMixin:
             Translated image path if successful, otherwise the original path
         """
         image_path = Path(image_path).resolve()
+        translated_image_path = self._get_translated_image_path(
+            image_path, language_code
+        )
         if not self.image_translator:
             logger.info(
                 f"Image translation skipped for {image_path} due to missing Azure AI Service configuration"
@@ -101,16 +129,43 @@ class ProjectFileTranslationMixin:
             return str(image_path)
 
         try:
-            translated_image_path = self.image_translator.translate_image(
-                image_path, language_code, self.image_dir, fast_mode=fast_mode
+            if translated_image_path.exists() and is_image_up_to_date(
+                image_path, translated_image_path, self.image_dir
+            ):
+                logger.info(
+                    f"Skipping image translation; up-to-date output exists: {translated_image_path}"
+                )
+                return str(translated_image_path)
+
+            translated_image = self.image_translator.translate_image(
+                image_path, language_code, fast_mode=fast_mode
             )
+            translated_image_path.parent.mkdir(parents=True, exist_ok=True)
+            save_optimized_image(translated_image, translated_image_path)
+            save_image_metadata(
+                translated_image_path,
+                image_path,
+                language_code,
+                self.root_dir,
+                image_dir=Path(self.image_dir),
+            )
+
             logger.info(
                 f"Translated image {image_path} to {language_code} and saved to {translated_image_path}"
             )
             return str(translated_image_path)
         except Exception as e:
             logger.error(f"Failed to translate image {image_path}: {e}", exc_info=True)
-            return str(image_path)
+            try:
+                return self._save_original_image_translation(
+                    image_path, translated_image_path, language_code
+                )
+            except Exception:
+                logger.error(
+                    f"Failed to save fallback image translation for {image_path}",
+                    exc_info=True,
+                )
+                return str(image_path)
 
     async def translate_markdown(self, file_path: Path, language_code: str) -> str:
         """Translate a markdown file to the specified language.
@@ -135,12 +190,10 @@ class ProjectFileTranslationMixin:
                 return str(translated_path)
 
             # Translate content first, then rewrite project-relative paths for the output target.
-            translated_content = (
-                await self.markdown_translator.translate_markdown(
-                    document,
-                    language_code,
-                    source_path=file_path,
-                )
+            translated_content = await self.markdown_translator.translate_markdown(
+                document,
+                language_code,
+                source_path=file_path,
             )
             translated_content = self._rewrite_markdown_paths_for_target(
                 translated_content,
@@ -159,12 +212,10 @@ class ProjectFileTranslationMixin:
             # Validate translation format and line break consistency
             if compare_line_breaks(document, translated_content):
                 logger.warning(f"Translation failed for {file_path}. Retrying...")
-                translated_content = (
-                    await self.markdown_translator.translate_markdown(
-                        document,
-                        language_code,
-                        source_path=file_path,
-                    )
+                translated_content = await self.markdown_translator.translate_markdown(
+                    document,
+                    language_code,
+                    source_path=file_path,
                 )
                 translated_content = self._rewrite_markdown_paths_for_target(
                     translated_content,
@@ -519,7 +570,9 @@ class ProjectFileTranslationMixin:
                 tasks, f"{'🏎️  (fast mode)' if fast_mode else '🖼️ '} Translating images"
             )
             modified_count = sum(
-                1 for r in results if r != str(image_file_path)
+                1
+                for (file_path, _lang_code), result in zip(task_info, results)
+                if result != file_path
             )  # Count successful translations
             errors = [
                 f"Failed to translate image file: {file_path} (lang: {lang_code})"

--- a/src/co_op_translator/core/vision/image_translator.py
+++ b/src/co_op_translator/core/vision/image_translator.py
@@ -1,25 +1,20 @@
-import os
 import logging
-import numpy as np
-from PIL import Image, ImageFont
+import math
+import time
+from abc import ABC, abstractmethod
+from math import hypot
 from pathlib import Path
 
-import cv2
-import math
-from math import hypot
-from tqdm import tqdm
-import time
-from PIL import Image, ImageFont, ImageDraw
 import numpy as np
-from pathlib import Path
+from PIL import Image, ImageDraw, ImageFont
+from tqdm import tqdm
+
 
 import arabic_reshaper
 from bidi.algorithm import get_display
 
 
 from co_op_translator.config.font_config import FontConfig
-from co_op_translator.config.constants import RGB_IMAGE_EXTENSIONS
-from co_op_translator.config.vision_config.config import VisionConfig
 from co_op_translator.config.vision_config.provider import VisionProvider
 from co_op_translator.utils.vision.image_utils import (
     get_dominant_color,
@@ -31,33 +26,29 @@ from co_op_translator.utils.vision.image_utils import (
     group_bounding_boxes,
     pad_text_image_to_target_aspect,
     adjust_bg_color,
-    save_optimized_image,
 )
 from azure.ai.vision.imageanalysis.models import VisualFeatures
 from co_op_translator.core.llm.text_translator import TextTranslator
-from co_op_translator.utils.common.file_utils import generate_translated_filename
-from co_op_translator.utils.common.metadata_utils import save_image_metadata
-from abc import ABC, abstractmethod
 
 logger = logging.getLogger(__name__)
 
 
 class ImageTranslator(ABC):
     def __init__(self, default_output_dir="./translated_images", root_dir="."):
-        """Initialize translator with output directory and dependencies.
+        """Initialize translator dependencies.
 
-        Sets up required components for image translation workflow including text
-        translation service and font configuration.
+        Sets up the text translation service and font configuration. The
+        default output directory is kept for compatibility, but directories are
+        created only by project-level persistence code.
 
         Args:
-            default_output_dir: Directory where translated images will be saved
+            default_output_dir: Default directory used by project orchestration
             root_dir: Root directory of the project for path calculations
         """
         self.text_translator = TextTranslator.create()
         self.font_config = FontConfig()
         self.root_dir = Path(root_dir)
         self.default_output_dir = default_output_dir
-        os.makedirs(self.default_output_dir, exist_ok=True)
 
     @abstractmethod
     def get_image_analysis_client(self):
@@ -116,18 +107,16 @@ class ImageTranslator(ABC):
                 f"Please ensure the image contains readable text."
             )
 
-    def plot_annotated_image(
+    def render_translated_image(
         self,
         image_path,
         line_bounding_boxes,
         translated_text_list,
         target_language_code,
-        destination_path=None,
         verbose=False,
         fast_mode=False,
-        original_image_path=None,
-    ):
-        """Render translated text onto original image at appropriate positions.
+    ) -> Image.Image:
+        """Render translated text onto an image and return the processed image.
 
         Uses either a fast or high-quality ("neat") rendering approach based on the
         fast_mode parameter. Handles text orientation, RTL languages, and maintains
@@ -138,17 +127,12 @@ class ImageTranslator(ABC):
             line_bounding_boxes: List of detected text regions with coordinates
             translated_text_list: List of translated texts corresponding to each region
             target_language_code: Language code determining font and text direction
-            destination_path: Directory to save the output image (optional)
             verbose: Whether to display processing progress
             fast_mode: Whether to use faster rendering (3x faster but less precise)
-            original_image_path: Path to the original image for metadata (defaults to image_path)
 
         Returns:
-            Path to the annotated image with translated text
+            PIL image with translated text rendered in place
         """
-        # Use image_path as original if not specified
-        if original_image_path is None:
-            original_image_path = image_path
         style = "fast" if fast_mode else "neat"
         logger.info("=" * 50)
         logger.info(f"Starting annotation ({style} mode) for image: {image_path} ")
@@ -190,17 +174,6 @@ class ImageTranslator(ABC):
                 processed_text_list[text_index : text_index + group_size]
             )
             text_index += group_size
-
-        # Generate output path
-        actual_image_path = Path(image_path).resolve()
-        new_filename = generate_translated_filename(
-            actual_image_path, target_language_code, self.root_dir
-        )
-        base_dir = "./translated_images_fast/" if fast_mode else "./translated_images/"
-        dest = Path(destination_path) if destination_path else Path(base_dir)
-        dest = dest / target_language_code
-        dest.mkdir(parents=True, exist_ok=True)
-        output_path = dest / new_filename
 
         # ------------------------------------- Fast Mode -------------------------------------#
         if fast_mode:
@@ -457,138 +430,50 @@ class ImageTranslator(ABC):
                 f"Total time taken to plot annotated image (Neat Mode): {elapsed_time:.4f} seconds for {image_path}"
             )
 
-        # Convert to RGB for file formats that don't support transparency
-        if output_path.suffix.lower() in RGB_IMAGE_EXTENSIONS:
-            image = image.convert("RGB")
-
-        # Save the image with optimization and update central metadata file
-        save_optimized_image(image, output_path)
-        save_image_metadata(
-            output_path,
-            Path(original_image_path),
-            target_language_code,
-            self.root_dir,
-            image_dir=Path(self.default_output_dir),
-        )
-
-        logger.info(f"Annotated image saved to {output_path}")
-        return str(output_path)
+        return image
 
     def translate_image(
-        self, image_path, target_language_code, destination_path=None, fast_mode=False
-    ):
-        """Process an image to detect, translate, and render text in target language.
+        self, image_path, target_language_code, fast_mode=False, verbose=False
+    ) -> Image.Image:
+        """Translate text in an image and return the rendered image.
 
-        Orchestrates the full image translation workflow including error handling.
-        When no text is found or errors occur, saves a copy of the original image.
+        This method performs text extraction, text translation, and in-memory image
+        rendering. It performs no output path calculation, no image saving, and no
+        metadata writes; project-level callers decide where and how to persist the
+        returned image.
 
         Args:
             image_path: Path to the image file
             target_language_code: Language code to translate text into
-            destination_path: Directory to save the output image (optional)
             fast_mode: Whether to use faster rendering with slightly lower quality
+            verbose: Whether to display rendering progress
 
         Returns:
-            Path to the result image (translated or copied original in case of errors)
+            PIL image with translated text rendered in place
         """
         image_path = Path(image_path)
 
-        try:
-            # Compute expected output path first and skip if it already exists
-            actual_image_path = Path(image_path).resolve()
-            new_filename = generate_translated_filename(
-                actual_image_path, target_language_code, self.root_dir
+        line_bounding_boxes = self.extract_line_bounding_boxes(image_path)
+        if not line_bounding_boxes:
+            logger.info(
+                f"No text detected in image '{image_path.name}': "
+                f"The image may not contain readable text or text may be too small/blurry to detect."
             )
-            if destination_path is None:
-                output_path = (
-                    Path(self.default_output_dir) / target_language_code / new_filename
-                )
-            else:
-                output_path = (
-                    Path(destination_path) / target_language_code / new_filename
-                )
+            with Image.open(image_path) as original_image:
+                return original_image.copy()
 
-            if output_path.exists():
-                logger.info(
-                    f"Skipping image translation; up-to-date output exists: {output_path}"
-                )
-                return str(output_path)
-
-            # Extract text and bounding boxes from the image
-            line_bounding_boxes = self.extract_line_bounding_boxes(image_path)
-
-            # Check if any text was recognized
-            if not line_bounding_boxes:
-                logger.info(
-                    f"No text detected in image '{image_path.name}': "
-                    f"Saving original image as translation result. "
-                    f"The image may not contain readable text or text may be too small/blurry to detect."
-                )
-
-                # Load the original image and save it with the new name and metadata
-                output_path.parent.mkdir(parents=True, exist_ok=True)
-                original_image = Image.open(image_path)
-                save_optimized_image(original_image, output_path)
-                save_image_metadata(
-                    output_path,
-                    image_path,
-                    target_language_code,
-                    self.root_dir,
-                    image_dir=Path(self.default_output_dir),
-                )
-
-                return str(
-                    output_path
-                )  # Return the new image path with original content
-
-            # Extract the text data from the bounding boxes
-            text_data = [line["text"] for line in line_bounding_boxes]
-
-            # Translate the text data into the target language
-            translated_text_list = self.text_translator.translate_image_text(
-                text_data, target_language_code
-            )
-
-            # Annotate the image with the translated text and save the result
-            return self.plot_annotated_image(
-                image_path,
-                line_bounding_boxes,
-                translated_text_list,
-                target_language_code,
-                destination_path,
-                fast_mode=fast_mode,
-                original_image_path=image_path,
-            )
-
-        except Exception as e:
-            logger.error(
-                f"Failed to translate image '{image_path.name}': {str(e)}. "
-                f"Saving original image instead."
-            )
-
-            # Load the original image and save it with the new name and metadata
-            actual_image_path = Path(image_path).resolve()
-            new_filename = generate_translated_filename(
-                actual_image_path, target_language_code, self.root_dir
-            )
-            output_path = (
-                Path(self.default_output_dir) / target_language_code / new_filename
-            )
-
-            output_path.parent.mkdir(parents=True, exist_ok=True)
-            original_image = Image.open(image_path)
-            save_optimized_image(original_image, output_path)
-            save_image_metadata(
-                output_path,
-                image_path,
-                target_language_code,
-                self.root_dir,
-                image_dir=Path(self.default_output_dir),
-            )
-
-            return str(
-                output_path
-            )  # Return the path to the original image with the new name
+        text_data = [line["text"] for line in line_bounding_boxes]
+        translated_text_list = self.text_translator.translate_image_text(
+            text_data, target_language_code
+        )
+        return self.render_translated_image(
+            image_path,
+            line_bounding_boxes,
+            translated_text_list,
+            target_language_code,
+            verbose=verbose,
+            fast_mode=fast_mode,
+        )
 
     @classmethod
     def create(
@@ -600,7 +485,7 @@ class ImageTranslator(ABC):
         implementation (currently only Azure AI Service is supported).
 
         Args:
-            default_output_dir: Directory where translated images will be saved
+            default_output_dir: Default directory used by project orchestration
             root_dir: Root directory of the project for path calculations
 
         Returns:

--- a/tests/co_op_translator/core/project/test_translation_manager.py
+++ b/tests/co_op_translator/core/project/test_translation_manager.py
@@ -3,8 +3,10 @@ from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from PIL import Image
 
 from co_op_translator.core.project.translation import TranslationManager
+from co_op_translator.utils.common.file_utils import generate_translated_filename
 from co_op_translator.utils.common.metadata_utils import calculate_file_hash
 
 
@@ -28,12 +30,16 @@ class FakeImageTranslator:
     def __init__(self):
         self.calls = []
 
-    def translate_image(self, image_path, language_code, image_dir, fast_mode=False):
-        self.calls.append((Path(image_path), language_code, Path(image_dir), fast_mode))
-        output_path = Path(image_dir) / language_code / Path(image_path).name
-        output_path.parent.mkdir(parents=True, exist_ok=True)
-        output_path.write_bytes(Path(image_path).read_bytes())
-        return output_path
+    def translate_image(self, image_path, language_code, fast_mode=False):
+        self.calls.append((Path(image_path), language_code, fast_mode))
+        return Image.new("RGB", (10, 10), "blue")
+
+
+class FakeNoTextImageTranslator(FakeImageTranslator):
+    def translate_image(self, image_path, language_code, fast_mode=False):
+        self.calls.append((Path(image_path), language_code, fast_mode))
+        with Image.open(image_path) as original_image:
+            return original_image.copy()
 
 
 class FakeNotebookTranslator:
@@ -176,11 +182,42 @@ async def test_translate_image_uses_configured_image_translator(
 
     result = await translation_manager.translate_image(image_file, "ko")
 
-    translated_path = temp_project_dir / "translated_images" / "ko" / "test.png"
+    translated_path = (
+        temp_project_dir
+        / "translated_images"
+        / "ko"
+        / generate_translated_filename(image_file.resolve(), "ko", temp_project_dir)
+    )
     assert Path(result) == translated_path
     assert translated_path.exists()
     assert translation_manager.image_translator.calls == [
-        (image_file.resolve(), "ko", temp_project_dir / "translated_images", False)
+        (image_file.resolve(), "ko", False)
+    ]
+    assert (
+        temp_project_dir / "translated_images" / "ko" / ".co-op-translator.json"
+    ).exists()
+
+
+@pytest.mark.asyncio
+async def test_translate_image_saves_original_when_no_text_detected(
+    translation_manager, temp_project_dir
+):
+    image_file = temp_project_dir / "images" / "blank.png"
+    Image.new("RGB", (10, 10), "white").save(image_file)
+    translation_manager.image_translator = FakeNoTextImageTranslator()
+
+    result = await translation_manager.translate_image(image_file, "ko")
+
+    translated_path = (
+        temp_project_dir
+        / "translated_images"
+        / "ko"
+        / generate_translated_filename(image_file.resolve(), "ko", temp_project_dir)
+    )
+    assert Path(result) == translated_path
+    assert translated_path.exists()
+    assert translation_manager.image_translator.calls == [
+        (image_file.resolve(), "ko", False)
     ]
 
 

--- a/tests/co_op_translator/core/vision/test_image_translator.py
+++ b/tests/co_op_translator/core/vision/test_image_translator.py
@@ -25,6 +25,10 @@ class MockTextTranslator(TextTranslator):
         """Mock implementation of translate_batch."""
         return [f"Translated: {text}" for text in texts]
 
+    def translate_image_text(self, text_data, target_language):
+        """Mock implementation of translate_image_text."""
+        return self.translate_batch(text_data, target_language)
+
 
 class MockImageTranslator(ImageTranslator):
     """Mock implementation of ImageTranslator for testing."""
@@ -38,8 +42,8 @@ class MockImageTranslator(ImageTranslator):
     def get_image_analysis_client(self):
         return MagicMock()
 
-    def extract_text_from_image(self, image_path):
-        """Mock implementation of extract_text_from_image."""
+    def extract_line_bounding_boxes(self, image_path):
+        """Mock implementation of extract_line_bounding_boxes."""
         return [
             {
                 "text": "LIFE IS LIKE",
@@ -48,20 +52,17 @@ class MockImageTranslator(ImageTranslator):
             }
         ]
 
-    def translate_image(self, image_path, target_language):
-        """Mock implementation of translate_image."""
-        bounding_boxes = self.extract_text_from_image(image_path)
-        texts = [box["text"] for box in bounding_boxes]
-        translated_texts = self.text_translator.translate_batch(texts, target_language)
-        return self.plot_annotated_image(
-            image_path, bounding_boxes, translated_texts, target_language
-        )
-
-    def plot_annotated_image(
-        self, image_path, bounding_boxes, translated_texts, target_language
+    def render_translated_image(
+        self,
+        image_path,
+        bounding_boxes,
+        translated_texts,
+        target_language,
+        verbose=False,
+        fast_mode=False,
     ):
-        """Mock implementation of plot_annotated_image."""
-        return Path(self.default_output_dir) / "translated_image.png"
+        """Mock implementation of render_translated_image."""
+        return Image.new("RGB", (20, 20), "white")
 
 
 @pytest.fixture
@@ -70,6 +71,19 @@ def image_translator(tmp_path):
     Fixture to provide an instance of MockImageTranslator for each test.
     """
     return MockImageTranslator(default_output_dir=tmp_path, root_dir=ROOT_DIR)
+
+
+def test_image_translator_init_does_not_create_output_dir(tmp_path):
+    class InitOnlyImageTranslator(ImageTranslator):
+        def get_image_analysis_client(self):
+            return MagicMock()
+
+    output_dir = tmp_path / "translated_images"
+
+    with patch.object(TextTranslator, "create", return_value=MockTextTranslator()):
+        InitOnlyImageTranslator(default_output_dir=output_dir, root_dir=tmp_path)
+
+    assert not output_dir.exists()
 
 
 @pytest.fixture
@@ -95,30 +109,13 @@ def mock_line_bounding_boxes():
 @patch("PIL.Image.open", return_value=MagicMock(spec=Image.Image))
 @patch("PIL.Image.Image.save")
 @patch("os.makedirs")
-def test_extract_text_from_image(
+def test_extract_line_bounding_boxes(
     mock_makedirs, mock_image_save, mock_image_open, mock_file_open, image_translator
 ):
     """
-    Test extract_text_from_image method to ensure it extracts text and bounding boxes correctly.
+    Test extract_line_bounding_boxes method to ensure it extracts text and bounding boxes correctly.
     """
-    mock_client = image_translator.get_image_analysis_client()
-    mock_result = MagicMock()
-    mock_block = MagicMock()
-    mock_line = MagicMock()
-
-    mock_line.text = "LIFE IS LIKE"
-    mock_line.bounding_polygon = [
-        MagicMock(x=41, y=111),
-        MagicMock(x=963, y=77),
-        MagicMock(x=966, y=147),
-        MagicMock(x=41, y=185),
-    ]
-    mock_line.words = [MagicMock(confidence=0.988)]
-    mock_block.lines = [mock_line]
-    mock_result.read.blocks = [mock_block]
-    mock_client.analyze_document.return_value = mock_result
-
-    bounding_boxes = image_translator.extract_text_from_image(TEST_IMAGE_PATH)
+    bounding_boxes = image_translator.extract_line_bounding_boxes(TEST_IMAGE_PATH)
 
     assert (
         len(bounding_boxes) == 1
@@ -138,40 +135,37 @@ def test_extract_text_from_image(
     ], f"Bounding box mismatch: {bounding_boxes[0]['bounding_box']}"
 
 
-@patch(
-    "co_op_translator.core.vision.image_translator.ImageTranslator.plot_annotated_image"
-)
-def test_translate_image(
-    mock_plot_annotated_image, image_translator, mock_line_bounding_boxes, tmp_path
-):
+def test_translate_image(image_translator, mock_line_bounding_boxes):
     """
-    Test translate_image method to ensure the image is correctly translated and annotated.
+    Test translate_image method to ensure image text is extracted, translated, and rendered.
     """
-    # Set up mocks
-    mock_plot_annotated_image.return_value = tmp_path / "translated_image.png"
-    image_translator.plot_annotated_image = mock_plot_annotated_image
-
-    with patch.object(
-        image_translator,
-        "extract_text_from_image",
-        return_value=mock_line_bounding_boxes,
+    with (
+        patch.object(
+            image_translator,
+            "extract_line_bounding_boxes",
+            return_value=mock_line_bounding_boxes,
+        ) as mock_extract,
+        patch.object(
+            image_translator,
+            "render_translated_image",
+            return_value=Image.new("RGB", (20, 20), "white"),
+        ) as mock_render,
     ):
         target_language = "es"
-        result_path = image_translator.translate_image(TEST_IMAGE_PATH, target_language)
-
-        assert str(result_path) == str(tmp_path / "translated_image.png")
-
-        # Verify that extract_text_from_image was called with correct arguments
-        image_translator.extract_text_from_image.assert_called_once_with(
-            TEST_IMAGE_PATH
+        translated_image = image_translator.translate_image(
+            TEST_IMAGE_PATH, target_language
         )
 
-        # Verify that plot_annotated_image was called with correct arguments
-        mock_plot_annotated_image.assert_called_once_with(
+        assert isinstance(translated_image, Image.Image)
+
+        mock_extract.assert_called_once_with(TEST_IMAGE_PATH)
+        mock_render.assert_called_once_with(
             TEST_IMAGE_PATH,
             mock_line_bounding_boxes,
             ["Translated: LIFE IS LIKE", "Translated: RIDING A BICYCLE"],
             target_language,
+            verbose=False,
+            fast_mode=False,
         )
 
 
@@ -216,9 +210,9 @@ def test_translate_batch_with_various_inputs():
         assert translated == f"Translated: {original}"
 
 
-def test_plot_annotated_image_with_multiple_boxes(image_translator, tmp_path):
+def test_render_translated_image_with_multiple_boxes(image_translator):
     """
-    Test plot_annotated_image method with multiple bounding boxes.
+    Test render_translated_image method with multiple bounding boxes.
     """
     image_path = TEST_IMAGE_PATH
     bounding_boxes = [
@@ -236,13 +230,11 @@ def test_plot_annotated_image_with_multiple_boxes(image_translator, tmp_path):
     translated_texts = ["Translation 1", "Translation 2"]
     target_language = "ko"
 
-    result_path = image_translator.plot_annotated_image(
+    translated_image = image_translator.render_translated_image(
         image_path, bounding_boxes, translated_texts, target_language
     )
 
-    assert isinstance(result_path, Path)
-    assert result_path.parent == tmp_path
-    assert str(result_path).endswith("translated_image.png")
+    assert isinstance(translated_image, Image.Image)
 
 
 @pytest.mark.parametrize("target_language", ["ko", "en", "ja", "zh"])
@@ -252,17 +244,15 @@ def test_translate_image_with_different_languages(
     """
     Test translate_image method with different target languages.
     """
-    result_path = image_translator.translate_image(TEST_IMAGE_PATH, target_language)
+    result = image_translator.translate_image(TEST_IMAGE_PATH, target_language)
 
-    assert isinstance(result_path, Path)
-    assert str(result_path).endswith("translated_image.png")
+    assert isinstance(result, Image.Image)
 
 
 def test_extract_text_with_low_confidence(image_translator):
     """
-    Test extract_text_from_image method's handling of low confidence text.
+    Test extract_line_bounding_boxes method's handling of low confidence text.
     """
-    mock_client = image_translator.get_image_analysis_client()
 
     # Override the mock implementation for this specific test
     def mock_extract_text(*args, **kwargs):
@@ -274,9 +264,9 @@ def test_extract_text_with_low_confidence(image_translator):
             }
         ]
 
-    image_translator.extract_text_from_image = mock_extract_text
+    image_translator.extract_line_bounding_boxes = mock_extract_text
 
-    result = image_translator.extract_text_from_image(TEST_IMAGE_PATH)
+    result = image_translator.extract_line_bounding_boxes(TEST_IMAGE_PATH)
     assert len(result) == 1
     assert result[0]["confidence"] < 0.5
     assert result[0]["text"] == "Low confidence text"

--- a/tests/co_op_translator/test_api.py
+++ b/tests/co_op_translator/test_api.py
@@ -1,6 +1,7 @@
 from unittest.mock import MagicMock
 
 import pytest
+from PIL import Image
 
 from co_op_translator.api import translation as api
 from co_op_translator.glossary import get_glossary_terms, set_glossary_terms
@@ -400,6 +401,36 @@ async def test_translate_markdown_content_uses_content_only_translator(monkeypat
             },
         )
     ]
+
+
+def test_translate_image_content_uses_content_only_translator(monkeypatch):
+    class FakeImageTranslator:
+        def __init__(self):
+            self.calls = []
+
+        def translate_image(self, image_path, language_code, fast_mode=False):
+            self.calls.append((image_path, language_code, fast_mode))
+            return Image.new("RGB", (10, 10), "blue")
+
+    fake = FakeImageTranslator()
+    create = MagicMock(return_value=fake)
+    monkeypatch.setattr(api.ImageTranslator, "create", create)
+
+    result = api.translate_image_content(
+        "docs/hero.png",
+        "ko",
+        {
+            "root_dir": "docs",
+            "fast_mode": True,
+        },
+    )
+
+    assert isinstance(result, Image.Image)
+    assert result.size == (10, 10)
+    assert fake.calls == [("docs/hero.png", "ko", True)]
+    create.assert_called_once_with(
+        root_dir="docs",
+    )
 
 
 def test_rewrite_markdown_paths_uses_target_path(tmp_path):


### PR DESCRIPTION
## Purpose

Separate image translation from project-specific output-path handling and metadata persistence while keeping `ImageTranslator.translate_image()` as the intuitive API that returns a translated, processed image.

## Description

This PR refactors the image translation pipeline into clearer responsibilities:

- Changes `ImageTranslator.translate_image()` to perform image text extraction, text translation, and in-memory rendering, then return a `PIL.Image.Image`.
- Keeps output path calculation, optimized image saving, up-to-date checks, fallback copy behavior, and image metadata writes in `ProjectFileTranslationMixin.translate_image()`.
- Changes `ImageTranslator.render_translated_image()` into an in-memory rendering helper instead of a file-writing method.
- Adds `api.translate_image_content()` and `ImageTranslationOptions` for programmatic image translation without project-level saving or metadata writes.
- Updates image, project orchestration, and public API tests for the separated pipeline.

## Related Issue

N/A

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

- [x] Yes
- [ ] No

Note: CLI/project translation remains covered, but this intentionally changes the low-level `ImageTranslator.translate_image()` contract from returning an output path to returning a `PIL.Image.Image`.

## Type of change

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (e.g., formatting, local variables)
- [ ] Refactoring (no functional or API changes)
- [ ] Documentation content changes
- [x] Other... Please describe: Core image pipeline/API boundary refactor

## Checklist

Before submitting your pull request, please confirm the following:

- [x] **I have thoroughly tested my changes**: I confirm that I have run the code and manually tested all affected areas.
- [x] **All existing tests pass**: I have run all tests and confirmed that nothing is broken.
- [x] **I have added new tests** (if applicable): I have written tests that cover the new functionality introduced by my code changes.
- [x] **I have followed the Co-op Translators coding conventions**: My code adheres to the style guide and coding conventions outlined in the repository.
- [ ] **I have documented my changes** (if applicable): I have updated the documentation to reflect the changes where necessary.

## Additional context

Validation performed:

- `python -m ruff check` for changed source and tests.
- `python -m pytest tests\co_op_translator\test_api.py tests\co_op_translator\core\vision\test_image_translator.py tests\co_op_translator\core\project\test_translation_manager.py` -> 38 passed.
- `python -m pytest tests\co_op_translator -m "not api_key_required"` -> 269 passed.
- Local smoke using `test_repo/image.png` copied into a temporary project with a fake image translator verified project-level image persistence and image metadata generation without calling live Vision/LLM services.