### PR TITLE
Core: Separate notebook translation pipeline

### DIFF
--- a/src/co_op_translator/api/__init__.py
+++ b/src/co_op_translator/api/__init__.py
@@ -3,10 +3,13 @@
 from co_op_translator.api.translation import (
     ImageTranslationOptions,
     MarkdownTranslationOptions,
+    NotebookTranslationOptions,
     run_translation,
     rewrite_markdown_paths,
+    rewrite_notebook_paths,
     translate_image_content,
     translate_markdown_content,
+    translate_notebook_content,
     translate_project,
 )
 from co_op_translator.api.review import run_review
@@ -14,10 +17,13 @@ from co_op_translator.api.review import run_review
 __all__ = [
     "MarkdownTranslationOptions",
     "ImageTranslationOptions",
+    "NotebookTranslationOptions",
     "rewrite_markdown_paths",
+    "rewrite_notebook_paths",
     "run_review",
     "run_translation",
     "translate_image_content",
     "translate_markdown_content",
+    "translate_notebook_content",
     "translate_project",
 ]

--- a/src/co_op_translator/api/translation.py
+++ b/src/co_op_translator/api/translation.py
@@ -13,6 +13,9 @@ from PIL import Image
 from co_op_translator.config.base_config import Config
 from co_op_translator.config.llm_config.config import LLMConfig
 from co_op_translator.config.vision_config.config import VisionConfig
+from co_op_translator.core.llm.jupyter_notebook_translator import (
+    JupyterNotebookTranslator,
+)
 from co_op_translator.core.llm.markdown_translator import MarkdownTranslator
 from co_op_translator.core.project.language_migrator import LanguageFolderMigrator
 from co_op_translator.core.project.project_translator import ProjectTranslator
@@ -35,6 +38,9 @@ from co_op_translator.utils.markdown.path_rewriter import (
     MarkdownPathRewritePolicy,
     rewrite_markdown_paths as rewrite_markdown_paths_for_project,
 )
+from co_op_translator.utils.markdown.notebook_path_rewriter import (
+    rewrite_notebook_paths as rewrite_notebook_paths_for_project,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -52,6 +58,13 @@ class ImageTranslationOptions:
 
     root_dir: str | Path = "."
     fast_mode: bool = False
+
+
+@dataclass(frozen=True)
+class NotebookTranslationOptions:
+    """Options for content-only notebook translation."""
+
+    source_path: str | Path | None = None
 
 
 def _coerce_markdown_translation_options(
@@ -74,6 +87,16 @@ def _coerce_image_translation_options(
     return ImageTranslationOptions(**dict(options))
 
 
+def _coerce_notebook_translation_options(
+    options: NotebookTranslationOptions | Mapping[str, object] | None,
+) -> NotebookTranslationOptions:
+    if options is None:
+        return NotebookTranslationOptions()
+    if isinstance(options, NotebookTranslationOptions):
+        return options
+    return NotebookTranslationOptions(**dict(options))
+
+
 async def translate_markdown_content(
     document: str,
     language_code: str,
@@ -85,6 +108,22 @@ async def translate_markdown_content(
     translator = MarkdownTranslator.create()
     return await translator.translate_markdown(
         document,
+        language_code,
+        source_path=resolved_options.source_path,
+    )
+
+
+async def translate_notebook_content(
+    notebook: str | dict[str, object],
+    language_code: str,
+    options: NotebookTranslationOptions | Mapping[str, object] | None = None,
+) -> str:
+    """Translate notebook markdown cells without project path rewriting or file I/O."""
+
+    resolved_options = _coerce_notebook_translation_options(options)
+    translator = JupyterNotebookTranslator.create()
+    return await translator.translate_notebook(
+        notebook,
         language_code,
         source_path=resolved_options.source_path,
     )
@@ -105,6 +144,22 @@ def translate_image_content(
         image_path,
         language_code,
         fast_mode=resolved_options.fast_mode,
+    )
+
+
+def rewrite_notebook_paths(
+    content: str,
+    source_path: str | Path,
+    target_path: str | Path,
+    policy: MarkdownPathRewritePolicy | Mapping[str, object],
+) -> str:
+    """Rewrite markdown-cell paths for a translated project notebook target."""
+
+    return rewrite_notebook_paths_for_project(
+        content,
+        source_path=source_path,
+        target_path=target_path,
+        policy=policy,
     )
 
 

--- a/src/co_op_translator/core/llm/jupyter_notebook_translator.py
+++ b/src/co_op_translator/core/llm/jupyter_notebook_translator.py
@@ -7,12 +7,15 @@ extracting markdown cells, translating them, and preserving code cells unchanged
 
 import json
 import logging
+from copy import deepcopy
 from pathlib import Path
+from typing import Any
 
 from co_op_translator.core.llm.markdown_translator import MarkdownTranslator
-from co_op_translator.utils.markdown.path_rewriter import (
-    MarkdownPathRewritePolicy,
-    rewrite_markdown_paths,
+from co_op_translator.utils.markdown.notebook_cells import (
+    get_cell_source_text,
+    iter_markdown_cells,
+    set_cell_source_text,
 )
 
 logger = logging.getLogger(__name__)
@@ -35,198 +38,76 @@ class JupyterNotebookTranslator:
         """Initialize the notebook translator.
 
         Args:
-            root_dir: Root directory of the project for path calculations
+            root_dir: Optional project root retained for compatibility
         """
         self.root_dir = root_dir
         self.translations_dir = translations_dir
         self.image_dir = image_dir
         self.lang_subdir = Path(lang_subdir) if lang_subdir else None
-        self.markdown_translator = MarkdownTranslator.create(
-            root_dir,
-            translations_dir=translations_dir,
-            image_dir=image_dir,
-            lang_subdir=self.lang_subdir,
-        )
+        self.markdown_translator = MarkdownTranslator.create()
 
-    def _get_notebook_target_path(
-        self,
-        notebook_path: Path,
-        language_code: str,
-        target_path: str | Path | None = None,
-    ) -> Path | None:
-        if target_path is not None:
-            return Path(target_path).resolve()
-        if self.root_dir is None:
-            return None
-
-        root_dir = Path(self.root_dir).resolve()
-        try:
-            relative_path = notebook_path.resolve().relative_to(root_dir)
-        except ValueError:
-            return None
-
-        translations_dir = (
-            Path(self.translations_dir)
-            if self.translations_dir is not None
-            else root_dir / "translations"
-        )
-        language_root = translations_dir / language_code
-        if self.lang_subdir:
-            language_root = language_root / self.lang_subdir
-        return (language_root / relative_path).resolve()
-
-    def _rewrite_markdown_cell_paths(
-        self,
-        content: str,
-        notebook_path: Path,
-        target_notebook_path: Path | None,
-        language_code: str,
-        translation_types: list[str],
-    ) -> str:
-        if target_notebook_path is None or self.root_dir is None:
-            return content
-
-        return rewrite_markdown_paths(
-            content,
-            source_path=notebook_path,
-            target_path=target_notebook_path,
-            policy=MarkdownPathRewritePolicy(
-                language_code=language_code,
-                root_dir=self.root_dir,
-                translations_dir=self.translations_dir,
-                translated_images_dir=self.image_dir,
-                translation_types=translation_types,
-                lang_subdir=self.lang_subdir,
-            ),
-        )
+    def _load_notebook(self, notebook: str | dict[str, Any]) -> dict[str, Any]:
+        if isinstance(notebook, dict):
+            return deepcopy(notebook)
+        return json.loads(notebook)
 
     async def translate_notebook(
         self,
-        notebook_path: str | Path,
+        notebook: str | dict[str, Any],
         language_code: str,
-        use_translated_images: bool = True,
-        add_disclaimer: bool = True,
-        target_path: str | Path | None = None,
+        source_path: str | Path | None = None,
     ) -> str:
-        """Translate a Jupyter Notebook file to the target language.
+        """Translate markdown cells in a Jupyter Notebook payload.
 
-        Extracts markdown cells from the notebook, translates them using
-        the existing markdown translator, and reconstructs the notebook
-        with translated content.
+        This method performs no file I/O, no project path rewriting, no
+        disclaimer insertion, and no metadata writes. Project-level callers
+        compose those steps around this content-only translation.
 
         Args:
-            notebook_path: Path to the .ipynb file
+            notebook: Notebook JSON string or parsed notebook dictionary
             language_code: Target language code
-            use_translated_images: Whether to use translated images (False = skip image translation)
-            add_disclaimer: Add disclaimer cell at the end of notebook if True
-            target_path: Optional translated notebook path used as the relative-link base
+            source_path: Optional source path used only for translation context/logging
 
         Returns:
             str: The translated notebook content as JSON string
         """
-        notebook_path = Path(notebook_path)
-        target_notebook_path = self._get_notebook_target_path(
-            notebook_path, language_code, target_path=target_path
-        )
-
-        # Read the notebook file
-        with open(notebook_path, "r", encoding="utf-8") as f:
-            notebook = json.load(f)
+        notebook_name = Path(source_path).name if source_path else "notebook"
+        translated_notebook = self._load_notebook(notebook)
 
         # Track which cells were translated for logging
         translated_cells = 0
         total_markdown_cells = 0
 
         # Process each cell
-        for cell in notebook.get("cells", []):
-            if cell.get("cell_type") == "markdown":
-                total_markdown_cells += 1
+        for cell in iter_markdown_cells(translated_notebook):
+            total_markdown_cells += 1
 
-                # Extract the source content
-                source = cell.get("source", [])
-                if not source:
-                    continue
+            markdown_content = get_cell_source_text(cell)
+            if not markdown_content.strip():
+                continue
 
-                # Convert source to string (it might be a list of lines)
-                if isinstance(source, list):
-                    markdown_content = "".join(source)
-                else:
-                    markdown_content = str(source)
+            try:
+                translated_content = await self.markdown_translator.translate_markdown(
+                    markdown_content,
+                    language_code,
+                    source_path=source_path,
+                )
+                set_cell_source_text(cell, translated_content)
+                translated_cells += 1
 
-                # Skip empty cells
-                if not markdown_content.strip():
-                    continue
-
-                try:
-                    # Translate the markdown content
-                    # Don't add metadata and disclaimer to individual cells
-                    # For notebook translation, always enable notebook link processing
-                    notebook_translation_types = ["markdown", "notebook"]
-                    if use_translated_images:
-                        notebook_translation_types.append("images")
-
-                    translated_content = (
-                        await self.markdown_translator.translate_markdown(
-                            markdown_content,
-                            language_code,
-                            source_path=notebook_path,
-                        )
-                    )
-                    translated_content = self._rewrite_markdown_cell_paths(
-                        translated_content,
-                        notebook_path,
-                        target_notebook_path,
-                        language_code,
-                        notebook_translation_types,
-                    )
-
-                    # Convert back to the original format (list or string)
-                    if isinstance(source, list):
-                        # Split by lines but preserve the original line ending behavior
-                        translated_lines = translated_content.splitlines(keepends=True)
-                        # Ensure lines end with \n if they don't already
-                        translated_lines = [
-                            line if line.endswith("\n") else line + "\n"
-                            for line in translated_lines
-                        ]
-                        cell["source"] = translated_lines
-                    else:
-                        cell["source"] = translated_content
-
-                    translated_cells += 1
-
-                except Exception as e:
-                    logger.warning(
-                        f"Failed to translate cell in {notebook_path}: {e}. "
-                        f"Keeping original content."
-                    )
+            except Exception as e:
+                logger.warning(
+                    f"Failed to translate cell in {notebook_name}: {e}. "
+                    f"Keeping original content."
+                )
 
         logger.info(
             f"Translated {translated_cells}/{total_markdown_cells} markdown cells "
-            f"in {notebook_path.name}"
+            f"in {notebook_name}"
         )
 
-        # Add disclaimer cell at the end if requested
-        if add_disclaimer:
-            disclaimer_text = await self.markdown_translator.generate_disclaimer(
-                language_code
-            )
-            if disclaimer_text:
-                start_marker = "<!-- CO-OP TRANSLATOR DISCLAIMER START -->"
-                end_marker = "<!-- CO-OP TRANSLATOR DISCLAIMER END -->"
-                disclaimer_block = (
-                    f"---\n\n{start_marker}\n{disclaimer_text}\n{end_marker}"
-                )
-                disclaimer_cell = {
-                    "cell_type": "markdown",
-                    "metadata": {},
-                    "source": [disclaimer_block + "\n"],
-                }
-                notebook["cells"].append(disclaimer_cell)
-                logger.debug(f"Added disclaimer cell to {notebook_path.name}")
-
         # Return the modified notebook as JSON string
-        return json.dumps(notebook, ensure_ascii=False, indent=1)
+        return json.dumps(translated_notebook, ensure_ascii=False, indent=1)
 
     @classmethod
     def create(

--- a/src/co_op_translator/core/project/translation/project_file_translation.py
+++ b/src/co_op_translator/core/project/translation/project_file_translation.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import logging
 import os
 from pathlib import Path
@@ -26,6 +27,9 @@ from co_op_translator.utils.markdown.processing import compare_line_breaks
 from co_op_translator.utils.markdown.path_rewriter import (
     MarkdownPathRewritePolicy,
     rewrite_markdown_paths,
+)
+from co_op_translator.utils.markdown.notebook_path_rewriter import (
+    rewrite_notebook_paths,
 )
 from co_op_translator.utils.vision.image_utils import save_optimized_image
 
@@ -68,6 +72,56 @@ class ProjectFileTranslationMixin:
                 lang_subdir=self.lang_subdir,
             ),
         )
+
+    def _rewrite_notebook_paths_for_target(
+        self,
+        content: str,
+        file_path: Path,
+        translated_path: Path,
+        language_code: str,
+    ) -> str:
+        notebook_translation_types = ["markdown", "notebook"]
+        if "images" in self.translation_types:
+            notebook_translation_types.append("images")
+
+        return rewrite_notebook_paths(
+            content,
+            source_path=file_path,
+            target_path=translated_path,
+            policy=MarkdownPathRewritePolicy(
+                language_code=language_code,
+                root_dir=self.root_dir,
+                translations_dir=self.translations_dir,
+                translated_images_dir=self.image_dir,
+                translation_types=notebook_translation_types,
+                lang_subdir=self.lang_subdir,
+            ),
+        )
+
+    async def _append_notebook_disclaimer(
+        self, content: str, language_code: str
+    ) -> str:
+        if not self.add_disclaimer:
+            return content
+
+        disclaimer_text = await self.markdown_translator.generate_disclaimer(
+            language_code
+        )
+        if not disclaimer_text:
+            return content
+
+        notebook = json.loads(content)
+        start_marker = "<!-- CO-OP TRANSLATOR DISCLAIMER START -->"
+        end_marker = "<!-- CO-OP TRANSLATOR DISCLAIMER END -->"
+        disclaimer_block = f"---\n\n{start_marker}\n{disclaimer_text}\n{end_marker}"
+        notebook.setdefault("cells", []).append(
+            {
+                "cell_type": "markdown",
+                "metadata": {},
+                "source": [disclaimer_block + "\n"],
+            }
+        )
+        return json.dumps(notebook, ensure_ascii=False, indent=1)
 
     def _get_translated_image_path(self, image_path: Path, language_code: str) -> Path:
         translated_filename = generate_translated_filename(
@@ -281,16 +335,22 @@ class ProjectFileTranslationMixin:
                 handle_empty_document(file_path, output_file)
                 return str(output_file)
 
-            # Perform translation
-            use_translated_images = "images" in self.translation_types
             relative_path = file_path.relative_to(self.root_dir)
             translated_path = self._get_language_root(language_code) / relative_path
             translated_content = await self.notebook_translator.translate_notebook(
-                file_path,
+                document,
                 language_code,
-                use_translated_images=use_translated_images,
-                add_disclaimer=self.add_disclaimer,
-                target_path=translated_path,
+                source_path=file_path,
+            )
+            translated_content = self._rewrite_notebook_paths_for_target(
+                translated_content,
+                file_path,
+                translated_path,
+                language_code,
+            )
+            translated_content = await self._append_notebook_disclaimer(
+                translated_content,
+                language_code,
             )
             if not translated_content:
                 logger.error(

--- a/src/co_op_translator/utils/markdown/notebook_cells.py
+++ b/src/co_op_translator/utils/markdown/notebook_cells.py
@@ -1,0 +1,36 @@
+"""Helpers for reading and updating markdown cells in Jupyter notebooks."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any
+
+
+def iter_markdown_cells(notebook: dict[str, Any]) -> Iterator[dict[str, Any]]:
+    """Yield markdown cells from a parsed notebook payload."""
+
+    for cell in notebook.get("cells", []):
+        if cell.get("cell_type") == "markdown":
+            yield cell
+
+
+def get_cell_source_text(cell: dict[str, Any]) -> str:
+    """Return a notebook cell source as a single string."""
+
+    source = cell.get("source", [])
+    if isinstance(source, list):
+        return "".join(source)
+    return str(source)
+
+
+def set_cell_source_text(cell: dict[str, Any], content: str) -> None:
+    """Set a cell source while preserving the original source shape."""
+
+    source = cell.get("source", [])
+    if isinstance(source, list):
+        translated_lines = content.splitlines(keepends=True)
+        cell["source"] = [
+            line if line.endswith("\n") else line + "\n" for line in translated_lines
+        ]
+    else:
+        cell["source"] = content

--- a/src/co_op_translator/utils/markdown/notebook_path_rewriter.py
+++ b/src/co_op_translator/utils/markdown/notebook_path_rewriter.py
@@ -1,0 +1,52 @@
+"""Path rewriting for markdown cells inside Jupyter notebooks."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Mapping
+
+from co_op_translator.utils.markdown.notebook_cells import (
+    get_cell_source_text,
+    iter_markdown_cells,
+    set_cell_source_text,
+)
+from co_op_translator.utils.markdown.path_rewriter import (
+    MarkdownPathRewritePolicy,
+    rewrite_markdown_paths,
+)
+
+
+def _coerce_policy(
+    policy: MarkdownPathRewritePolicy | Mapping[str, Any],
+) -> MarkdownPathRewritePolicy:
+    if isinstance(policy, MarkdownPathRewritePolicy):
+        return policy
+    return MarkdownPathRewritePolicy(**dict(policy))
+
+
+def rewrite_notebook_paths(
+    content: str,
+    source_path: str | Path,
+    target_path: str | Path,
+    policy: MarkdownPathRewritePolicy | Mapping[str, Any],
+) -> str:
+    """Rewrite project paths in markdown cells for a translated notebook target."""
+
+    resolved_policy = _coerce_policy(policy)
+    notebook = json.loads(content)
+
+    for cell in iter_markdown_cells(notebook):
+        markdown_content = get_cell_source_text(cell)
+        if not markdown_content.strip():
+            continue
+
+        rewritten_content = rewrite_markdown_paths(
+            markdown_content,
+            source_path=source_path,
+            target_path=target_path,
+            policy=resolved_policy,
+        )
+        set_cell_source_text(cell, rewritten_content)
+
+    return json.dumps(notebook, ensure_ascii=False, indent=1)

--- a/tests/co_op_translator/core/llm/test_jupyter_notebook_translator.py
+++ b/tests/co_op_translator/core/llm/test_jupyter_notebook_translator.py
@@ -9,6 +9,10 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from co_op_translator.core.llm.jupyter_notebook_translator import (
     JupyterNotebookTranslator,
 )
+from co_op_translator.utils.markdown.notebook_path_rewriter import (
+    rewrite_notebook_paths,
+)
+from co_op_translator.utils.markdown.path_rewriter import MarkdownPathRewritePolicy
 
 
 @pytest.fixture
@@ -93,8 +97,9 @@ class TestJupyterNotebookTranslator:
 
         # Create translator and translate
         translator = JupyterNotebookTranslator.create()
+        notebook_content = temp_notebook_file.read_text(encoding="utf-8")
         result = await translator.translate_notebook(
-            temp_notebook_file, "es", use_translated_images=False, add_disclaimer=False
+            notebook_content, "es", source_path=temp_notebook_file
         )
 
         # Verify result is valid JSON
@@ -139,7 +144,9 @@ class TestJupyterNotebookTranslator:
         # Create translator and translate
         translator = JupyterNotebookTranslator.create()
         result = await translator.translate_notebook(
-            notebook_file, "es", add_disclaimer=False
+            notebook_file.read_text(encoding="utf-8"),
+            "es",
+            source_path=notebook_file,
         )
 
         # Verify no translation calls were made for empty cells
@@ -183,7 +190,9 @@ class TestJupyterNotebookTranslator:
         # Create translator and translate
         translator = JupyterNotebookTranslator.create()
         result = await translator.translate_notebook(
-            notebook_file, "es", add_disclaimer=False
+            notebook_file.read_text(encoding="utf-8"),
+            "es",
+            source_path=notebook_file,
         )
 
         # Verify translation was called
@@ -242,11 +251,21 @@ class TestJupyterNotebookTranslator:
             image_dir=image_dir,
         )
         result = await translator.translate_notebook(
-            notebook_file,
+            notebook_file.read_text(encoding="utf-8"),
             "ko",
-            use_translated_images=True,
-            add_disclaimer=False,
+            source_path=notebook_file,
+        )
+        result = rewrite_notebook_paths(
+            result,
+            source_path=notebook_file,
             target_path=target_path,
+            policy=MarkdownPathRewritePolicy(
+                language_code="ko",
+                root_dir=root_dir,
+                translations_dir=translations_dir,
+                translated_images_dir=image_dir,
+                translation_types=["markdown", "notebook", "images"],
+            ),
         )
 
         translated_notebook = json.loads(result)
@@ -275,7 +294,9 @@ class TestJupyterNotebookTranslator:
         # Create translator with root directory and translate without disclaimer for simplicity
         translator = JupyterNotebookTranslator.create(tmp_path)
         result = await translator.translate_notebook(
-            temp_notebook_file, "ko", add_disclaimer=False
+            temp_notebook_file.read_text(encoding="utf-8"),
+            "ko",
+            source_path=temp_notebook_file,
         )
 
         # Verify result includes notebook metadata but not coopTranslator section
@@ -298,7 +319,11 @@ class TestJupyterNotebookTranslator:
 
         # Create translator and translate
         translator = JupyterNotebookTranslator.create()
-        result = await translator.translate_notebook(temp_notebook_file, "ko")
+        result = await translator.translate_notebook(
+            temp_notebook_file.read_text(encoding="utf-8"),
+            "ko",
+            source_path=temp_notebook_file,
+        )
 
         # Verify translation still completes (graceful error handling)
         translated_notebook = json.loads(result)
@@ -333,7 +358,9 @@ class TestJupyterNotebookTranslator:
         # Create translator and translate
         translator = JupyterNotebookTranslator.create()
         result = await translator.translate_notebook(
-            temp_notebook_file, "ko", add_disclaimer=False
+            temp_notebook_file.read_text(encoding="utf-8"),
+            "ko",
+            source_path=temp_notebook_file,
         )
 
         # Parse result
@@ -360,10 +387,10 @@ class TestJupyterNotebookTranslator:
 
     @patch("co_op_translator.core.llm.jupyter_notebook_translator.MarkdownTranslator")
     @pytest.mark.asyncio
-    async def test_translate_notebook_with_disclaimer(
+    async def test_translate_notebook_does_not_add_disclaimer_in_core(
         self, mock_markdown_translator_class, temp_notebook_file
     ):
-        """Test that notebook translation adds disclaimer cell when enabled."""
+        """Notebook core translation leaves disclaimer insertion to the project layer."""
         # Setup mock translator
         mock_translator = AsyncMock()
         mock_translator.translate_markdown = AsyncMock(
@@ -374,48 +401,12 @@ class TestJupyterNotebookTranslator:
         )
         mock_markdown_translator_class.create.return_value = mock_translator
 
-        # Create translator and translate with disclaimer
+        # Create translator and translate
         translator = JupyterNotebookTranslator.create()
         result = await translator.translate_notebook(
-            temp_notebook_file, "ko", add_disclaimer=True
-        )
-
-        # Parse result
-        translated_notebook = json.loads(result)
-
-        # Verify disclaimer cell was added at the end
-        cells = translated_notebook["cells"]
-        assert len(cells) == 4  # Original 3 + 1 disclaimer
-
-        disclaimer_cell = cells[-1]  # Last cell should be disclaimer
-        assert disclaimer_cell["cell_type"] == "markdown"
-        disclaimer_content = "".join(disclaimer_cell["source"])
-        assert "Disclaimer" in disclaimer_content
-        assert "---" in disclaimer_content  # Separator line
-
-        # Verify generate_disclaimer was called
-        mock_translator.generate_disclaimer.assert_called_once_with("ko")
-
-    @patch("co_op_translator.core.llm.jupyter_notebook_translator.MarkdownTranslator")
-    @pytest.mark.asyncio
-    async def test_translate_notebook_without_disclaimer(
-        self, mock_markdown_translator_class, temp_notebook_file
-    ):
-        """Test that notebook translation skips disclaimer when disabled."""
-        # Setup mock translator
-        mock_translator = AsyncMock()
-        mock_translator.translate_markdown = AsyncMock(
-            return_value="# Translated Title\n\nTranslated content"
-        )
-        mock_translator.generate_disclaimer = AsyncMock(
-            return_value="**Disclaimer**: This document has been translated using an AI translation service."
-        )
-        mock_markdown_translator_class.create.return_value = mock_translator
-
-        # Create translator and translate without disclaimer
-        translator = JupyterNotebookTranslator.create()
-        result = await translator.translate_notebook(
-            temp_notebook_file, "ko", add_disclaimer=False
+            temp_notebook_file.read_text(encoding="utf-8"),
+            "ko",
+            source_path=temp_notebook_file,
         )
 
         # Parse result
@@ -423,39 +414,7 @@ class TestJupyterNotebookTranslator:
 
         # Verify no disclaimer cell was added
         cells = translated_notebook["cells"]
-        assert len(cells) == 3  # Original 3, no disclaimer
+        assert len(cells) == 3
 
         # Verify generate_disclaimer was not called
         mock_translator.generate_disclaimer.assert_not_called()
-
-    @patch("co_op_translator.core.llm.jupyter_notebook_translator.MarkdownTranslator")
-    @pytest.mark.asyncio
-    async def test_translate_notebook_disclaimer_generation_fails(
-        self, mock_markdown_translator_class, temp_notebook_file
-    ):
-        """Test that notebook translation handles disclaimer generation failure gracefully."""
-        # Setup mock translator with failing disclaimer generation
-        mock_translator = AsyncMock()
-        mock_translator.translate_markdown = AsyncMock(
-            return_value="# Translated Title\n\nTranslated content"
-        )
-        mock_translator.generate_disclaimer = AsyncMock(
-            return_value=""  # Empty disclaimer (failure case)
-        )
-        mock_markdown_translator_class.create.return_value = mock_translator
-
-        # Create translator and translate
-        translator = JupyterNotebookTranslator.create()
-        result = await translator.translate_notebook(
-            temp_notebook_file, "ko", add_disclaimer=True
-        )
-
-        # Parse result
-        translated_notebook = json.loads(result)
-
-        # Verify no disclaimer cell was added when generation fails
-        cells = translated_notebook["cells"]
-        assert len(cells) == 3  # Original 3, no disclaimer due to failure
-
-        # Verify generate_disclaimer was called but failed
-        mock_translator.generate_disclaimer.assert_called_once_with("ko")

--- a/tests/co_op_translator/core/project/test_translation_manager.py
+++ b/tests/co_op_translator/core/project/test_translation_manager.py
@@ -48,22 +48,18 @@ class FakeNotebookTranslator:
 
     async def translate_notebook(
         self,
-        file_path,
+        document,
         language_code,
-        use_translated_images=True,
-        add_disclaimer=True,
-        target_path=None,
+        source_path=None,
     ):
         self.calls.append(
             (
-                Path(file_path),
+                document,
                 language_code,
-                use_translated_images,
-                add_disclaimer,
-                Path(target_path) if target_path is not None else None,
+                Path(source_path) if source_path is not None else None,
             )
         )
-        notebook = json.loads(Path(file_path).read_text(encoding="utf-8"))
+        notebook = json.loads(document)
         notebook.setdefault("metadata", {})["translated_to"] = language_code
         return json.dumps(notebook)
 
@@ -466,6 +462,68 @@ async def test_translate_notebook_writes_translation_and_metadata(
     assert (
         temp_project_dir / "translations" / "ko" / ".co-op-translator.json"
     ).exists()
+
+
+@pytest.mark.asyncio
+async def test_translate_notebook_rewrites_paths_and_appends_disclaimer(
+    temp_project_dir,
+):
+    docs_dir = temp_project_dir / "docs"
+    images_dir = docs_dir / "images"
+    images_dir.mkdir(parents=True, exist_ok=True)
+    image_file = images_dir / "hero.png"
+    image_file.write_text("image", encoding="utf-8")
+    notebook_file = docs_dir / "tutorial.ipynb"
+    notebook_file.write_text(
+        json.dumps(
+            {
+                "cells": [
+                    {
+                        "cell_type": "markdown",
+                        "metadata": {},
+                        "source": ["# Tutorial\n", "![Hero](images/hero.png)\n"],
+                    }
+                ],
+                "metadata": {},
+                "nbformat": 4,
+                "nbformat_minor": 5,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    markdown_translator = FakeMarkdownTranslator()
+    notebook_translator = FakeNotebookTranslator()
+    translation_manager = TranslationManager(
+        root_dir=temp_project_dir,
+        translations_dir=temp_project_dir / "translations",
+        image_dir=temp_project_dir / "translated_images",
+        language_codes=["ko"],
+        excluded_dirs=["translations", "translated_images", "logs"],
+        supported_image_extensions=[".png"],
+        supported_notebook_extensions=[".ipynb"],
+        markdown_translator=markdown_translator,
+        image_translator=FakeImageTranslator(),
+        notebook_translator=notebook_translator,
+        translation_types=["notebook", "images"],
+        add_disclaimer=True,
+    )
+
+    result = await translation_manager.translate_notebook(notebook_file, "ko")
+
+    translated_path = (
+        temp_project_dir / "translations" / "ko" / "docs" / "tutorial.ipynb"
+    )
+    assert Path(result) == translated_path
+    translated_notebook = json.loads(translated_path.read_text(encoding="utf-8"))
+    cell_source = "".join(translated_notebook["cells"][0]["source"])
+    disclaimer_source = "".join(translated_notebook["cells"][-1]["source"])
+
+    assert "images/hero.png" not in cell_source
+    assert "../../../translated_images/ko/hero." in cell_source
+    assert "Disclaimer for ko" in disclaimer_source
+    assert markdown_translator.disclaimer_calls == ["ko"]
+    assert notebook_translator.calls[0][2] == notebook_file.resolve()
 
 
 @pytest.mark.asyncio

--- a/tests/co_op_translator/test_api.py
+++ b/tests/co_op_translator/test_api.py
@@ -1,3 +1,4 @@
+import json
 from unittest.mock import MagicMock
 
 import pytest
@@ -403,6 +404,53 @@ async def test_translate_markdown_content_uses_content_only_translator(monkeypat
     ]
 
 
+@pytest.mark.asyncio
+async def test_translate_notebook_content_uses_content_only_translator(monkeypatch):
+    class FakeNotebookTranslator:
+        def __init__(self):
+            self.calls = []
+
+        async def translate_notebook(self, notebook, language_code, **kwargs):
+            self.calls.append((notebook, language_code, kwargs))
+            payload = json.loads(notebook)
+            payload["metadata"]["translated_to"] = language_code
+            return json.dumps(payload)
+
+    notebook = json.dumps(
+        {
+            "cells": [
+                {"cell_type": "markdown", "metadata": {}, "source": ["# Hello\n"]}
+            ],
+            "metadata": {},
+            "nbformat": 4,
+            "nbformat_minor": 5,
+        }
+    )
+    fake = FakeNotebookTranslator()
+    monkeypatch.setattr(
+        api.JupyterNotebookTranslator, "create", MagicMock(return_value=fake)
+    )
+
+    result = await api.translate_notebook_content(
+        notebook,
+        "ko",
+        {
+            "source_path": "docs/tutorial.ipynb",
+        },
+    )
+
+    assert json.loads(result)["metadata"]["translated_to"] == "ko"
+    assert fake.calls == [
+        (
+            notebook,
+            "ko",
+            {
+                "source_path": "docs/tutorial.ipynb",
+            },
+        )
+    ]
+
+
 def test_translate_image_content_uses_content_only_translator(monkeypatch):
     class FakeImageTranslator:
         def __init__(self):
@@ -469,3 +517,47 @@ image: images/hero.png
     assert "translated_images/ko/hero." in rewritten
     assert "images/hero.png" not in rewritten
     assert "../../../translated_images/ko/" in rewritten
+
+
+def test_rewrite_notebook_paths_uses_target_path(tmp_path):
+    root_dir = tmp_path
+    source_path = root_dir / "docs" / "tutorial.ipynb"
+    target_path = root_dir / "out" / "ko" / "docs" / "tutorial.ipynb"
+    image_path = root_dir / "docs" / "images" / "hero.png"
+
+    source_path.parent.mkdir(parents=True)
+    image_path.parent.mkdir(parents=True)
+    image_path.write_text("image", encoding="utf-8")
+
+    content = json.dumps(
+        {
+            "cells": [
+                {
+                    "cell_type": "markdown",
+                    "metadata": {},
+                    "source": ["# Tutorial\n", "![Hero](images/hero.png)\n"],
+                }
+            ],
+            "metadata": {},
+            "nbformat": 4,
+            "nbformat_minor": 5,
+        }
+    )
+
+    rewritten = api.rewrite_notebook_paths(
+        content,
+        source_path=source_path,
+        target_path=target_path,
+        policy={
+            "language_code": "ko",
+            "root_dir": root_dir,
+            "translations_dir": root_dir / "out",
+            "translated_images_dir": root_dir / "translated_images",
+            "translation_types": ["markdown", "notebook", "images"],
+        },
+    )
+
+    cell_source = "".join(json.loads(rewritten)["cells"][0]["source"])
+    assert "images/hero.png" not in cell_source
+    assert "../../../translated_images/ko/hero." in cell_source
+    assert cell_source.endswith(".webp)\n")


### PR DESCRIPTION
## Purpose

Separate notebook content translation from project-specific path rewriting, disclaimer insertion, file persistence, and metadata handling so notebook translation can be composed like the markdown and image APIs.

## Description

This PR refactors the notebook translation pipeline into clearer responsibilities:

- Changes `JupyterNotebookTranslator.translate_notebook()` to translate notebook markdown cells from a JSON string or parsed notebook payload without reading or writing files.
- Moves project-specific notebook concerns into `ProjectFileTranslationMixin.translate_notebook()`: source file reading, translated path calculation, notebook markdown-cell path rewriting, disclaimer cell insertion, file writing, and metadata persistence.
- Adds `utils.markdown.notebook_cells` helpers for preserving notebook cell source shape while updating markdown cell text.
- Adds `utils.markdown.notebook_path_rewriter.rewrite_notebook_paths()` for markdown-cell link/path rewriting in notebooks.
- Adds public APIs `translate_notebook_content()`, `NotebookTranslationOptions`, and `rewrite_notebook_paths()`.
- Updates notebook translator, project translation, and public API tests for the separated pipeline.

## Related Issue

N/A

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

- [x] Yes
- [ ] No

Note: CLI/project translation remains covered, but this intentionally changes the low-level `JupyterNotebookTranslator.translate_notebook()` contract from a file-path/project-aware method to a content-only notebook translation method.

## Type of change

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (e.g., formatting, local variables)
- [ ] Refactoring (no functional or API changes)
- [ ] Documentation content changes
- [x] Other... Please describe: Core notebook pipeline/API boundary refactor

## Checklist

Before submitting your pull request, please confirm the following:

- [x] **I have thoroughly tested my changes**: I confirm that I have run the code and manually tested all affected areas.
- [x] **All existing tests pass**: I have run all tests and confirmed that nothing is broken.
- [x] **I have added new tests** (if applicable): I have written tests that cover the new functionality introduced by my code changes.
- [x] **I have followed the Co-op Translators coding conventions**: My code adheres to the style guide and coding conventions outlined in the repository.
- [ ] **I have documented my changes** (if applicable): I have updated the documentation to reflect the changes where necessary.

## Additional context

