### PR TITLE
Docs: Clarify agent-assisted MCP workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,9 @@ docker run --rm -it --env-file .env -v ${PWD}:/work ghcr.io/azure/co-op-translat
 - Keeps translations in sync with source changes
 - Works locally (CLI) or in CI (GitHub Actions)
 - Exposes Markdown, notebook, image, review, and project translation tools through MCP
-- Uses Azure OpenAI or OpenAI; optional Azure AI Vision for images
+- Uses Azure OpenAI or OpenAI for provider-backed translation
+- Lets MCP host agents translate Markdown and notebook chunks without Co-op Translator LLM credentials
+- Uses Azure AI Vision for image text extraction and translation
 - Reviews translation structure and freshness with deterministic checks
 - Preserves Markdown formatting and structure
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -40,6 +40,8 @@ Choose the translation mode your MCP client will use:
 | Provider-backed | Co-op Translator calls `translate_markdown_content`, `translate_notebook_content`, `translate_image_content`, or `run_translation`. | Markdown and notebook translation require Azure OpenAI or OpenAI. Image translation also requires Azure AI Vision. |
 | Agent-assisted | The MCP host agent translates chunks returned by `start_markdown_agent_translation` or `start_notebook_agent_translation`. | No Co-op Translator LLM provider credentials are required for Markdown or notebook chunks. Image translation is not covered by agent-assisted mode yet. |
 
+If you are starting with Markdown or notebook translation inside an agent such as Codex or Claude Code, start with agent-assisted mode. Use provider-backed mode when you want Co-op Translator itself to call your configured providers, when you are translating images, or when you are running repository-level translation like the CLI.
+
 Configure provider credentials only for provider-backed workflows:
 
 ```bash
@@ -155,6 +157,24 @@ The content tools do not perform project discovery, metadata updates, disclaimer
 ### Translate with the Host Agent Model
 
 Use agent-assisted tools when you want the MCP host agent, such as a coding assistant, to produce the translated text instead of configuring Azure OpenAI or OpenAI for Co-op Translator.
+
+In a chat-based MCP client, you normally do not need to write tool JSON yourself. Ask the agent to use the agent-assisted workflow:
+
+```text
+Translate this Markdown file to Korean with Co-op Translator MCP.
+Use agent-assisted mode: call start_markdown_agent_translation, translate the returned chunks with your own model, then call finish_markdown_agent_translation.
+Keep Markdown formatting, code blocks, and links intact.
+```
+
+For notebooks, use the same pattern:
+
+```text
+Translate this notebook to Korean with Co-op Translator MCP.
+Use start_notebook_agent_translation, translate the returned Markdown-cell chunks with your own model, then call finish_notebook_agent_translation.
+Preserve code cells, outputs, and notebook metadata.
+```
+
+If your MCP client supports server prompts, use `agent_assisted_markdown_translation_prompt` to have the client load the same workflow instructions.
 
 For Markdown:
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -109,11 +109,20 @@ In the normal local setup, the user does not manually keep a server running. The
 Example user requests an agent could handle:
 
 - "Translate this Markdown file to Korean and keep the links correct."
+- "Translate this Markdown file to Korean with the agent-assisted MCP workflow, using your own model for the translated chunks."
+- "Translate this notebook to Korean, preserve code cells, and use Co-op Translator MCP to reconstruct the notebook."
 - "Translate the text in this image to Japanese and save the result."
 - "Dry-run a repository translation to Spanish and tell me what would change."
 - "Review whether the Korean translation output is up to date."
 
-MCP Markdown tool call shape:
+For Markdown and notebooks, MCP can work in two modes:
+
+| Mode | Use when | Main tools |
+| --- | --- | --- |
+| Agent-assisted | The MCP host agent should translate chunks with its own model, without Co-op Translator LLM provider credentials. | `start_markdown_agent_translation`, `finish_markdown_agent_translation`, `start_notebook_agent_translation`, `finish_notebook_agent_translation` |
+| Provider-backed | Co-op Translator should call Azure OpenAI or OpenAI directly. | `translate_markdown_content`, `translate_notebook_content` |
+
+MCP provider-backed Markdown tool call shape:
 
 ```json
 {
@@ -159,6 +168,7 @@ Repository translation is dry-run by default through MCP:
 Good fits:
 
 - You want natural-language translation workflows inside an agent or editor.
+- You want Markdown or notebook translation where the host agent model translates prepared chunks.
 - You want the agent to translate selected content instead of an entire repository.
 - You want an approval step before repository-wide writes.
 - You want one interface that exposes Markdown, notebook, image, review, and path-rewriting tools.


### PR DESCRIPTION
## Purpose

Make the agent-assisted MCP translation flow easier for first-time users to follow after #439.

## Description

- Add a plain-language mode selection note for agent-assisted versus provider-backed MCP translation.
- Add copy-ready natural language prompts for Markdown and notebook agent-assisted workflows.
- Update the workflow chooser and README feature bullets so users understand MCP can use the host agent model for Markdown/notebook chunks.

## Related Issue

N/A

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Type of change

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (e.g., formatting, local variables)
- [ ] Refactoring (no functional or API changes)
- [x] Documentation content changes
- [ ] Other... Please describe:

## Checklist

Before submitting your pull request, please confirm the following:

- [x] **I have thoroughly tested my changes**: `python -m mkdocs build --strict`, `git diff --check`
- [ ] **All existing tests pass**: Not run; documentation-only change.
- [ ] **I have added new tests** (if applicable): Not applicable.
- [x] **I have followed the Co-op Translators coding conventions**: Documentation-only change.
- [x] **I have documented my changes** (if applicable): Updated README, MCP, and workflow docs.

## Additional context

Follow-up documentation polish for `Core: Add agent-assisted MCP translation (#439)`.