### PR TITLE
Core: Recover incomplete markdown chunk translations

### DIFF
--- a/src/co_op_translator/core/llm/markdown_translator.py
+++ b/src/co_op_translator/core/llm/markdown_translator.py
@@ -34,6 +34,14 @@ from co_op_translator.utils.common.metadata_utils import (
 logger = logging.getLogger(__name__)
 
 
+class TranslationIncompleteError(RuntimeError):
+    """Raised when a provider response does not complete the requested chunk."""
+
+
+class TranslationContentFilterError(RuntimeError):
+    """Raised when a provider stops a translation because of content filtering."""
+
+
 class MarkdownTranslator(ABC):
     """Define interface for markdown translation services.
 
@@ -41,6 +49,9 @@ class MarkdownTranslator(ABC):
     """
 
     TRANSLATION_TIMEOUT_SECONDS = 1000  # Translation timeout in seconds
+    DEFAULT_CHUNK_MAX_TOKENS = 2600
+    RECOVERY_CHUNK_MAX_TOKENS = (1300, 650)
+    CHUNK_RETRY_ATTEMPTS = 1
     _disclaimer_templates_cache: dict[str, str] | None = None
 
     def __init__(
@@ -138,14 +149,19 @@ class MarkdownTranslator(ABC):
         )
 
         # Step 2: Split the document into chunks
-        document_chunks = process_markdown(document_with_placeholders)
+        document_chunks = process_markdown(
+            document_with_placeholders, max_tokens=self.DEFAULT_CHUNK_MAX_TOKENS
+        )
 
-        # Step 3: Generate translation prompts and translate each chunk
-        prompts = [
-            generate_prompt_template(language_code, language_name, chunk, is_rtl)
-            for chunk in document_chunks
-        ]
-        results = await self._run_prompts_sequentially(prompts, md_file_path)
+        # Step 3: Translate each chunk and recover incomplete chunks without
+        # rerunning the whole file.
+        results = await self._translate_chunks_with_recovery(
+            document_chunks,
+            language_code,
+            language_name,
+            is_rtl,
+            md_file_path,
+        )
         translated_content = "\n".join(results)
 
         # Step 4: Normalize emphasis markers for CJK scripts to improve renderer compatibility
@@ -207,6 +223,198 @@ class MarkdownTranslator(ABC):
             )
 
         return translated_content
+
+    async def _translate_chunks_with_recovery(
+        self,
+        chunks: list[str],
+        language_code: str,
+        language_name: str,
+        is_rtl: bool,
+        md_file_path: Path,
+    ) -> list[str]:
+        results = []
+        total = len(chunks)
+        for index, chunk in enumerate(chunks, start=1):
+            results.append(
+                await self._translate_chunk_with_recovery(
+                    chunk,
+                    language_code,
+                    language_name,
+                    is_rtl,
+                    md_file_path,
+                    chunk_label=str(index),
+                    index=index,
+                    total=total,
+                    split_depth=0,
+                )
+            )
+        return results
+
+    async def _translate_chunk_with_recovery(
+        self,
+        chunk: str,
+        language_code: str,
+        language_name: str,
+        is_rtl: bool,
+        md_file_path: Path,
+        chunk_label: str,
+        index: int,
+        total: int,
+        split_depth: int,
+    ) -> str:
+        last_error: TranslationIncompleteError | None = None
+
+        for attempt in range(self.CHUNK_RETRY_ATTEMPTS + 1):
+            try:
+                return await self._translate_chunk_once(
+                    chunk,
+                    language_code,
+                    language_name,
+                    is_rtl,
+                    md_file_path,
+                    chunk_label,
+                    index,
+                    total,
+                )
+            except TranslationContentFilterError:
+                logger.error(
+                    "Translation blocked by content filter for chunk %s of file '%s'.",
+                    chunk_label,
+                    md_file_path.name,
+                    exc_info=True,
+                )
+                raise
+            except TranslationIncompleteError as e:
+                last_error = e
+                if attempt < self.CHUNK_RETRY_ATTEMPTS:
+                    logger.warning(
+                        "Incomplete translation for chunk %s of file '%s'; retrying same chunk.",
+                        chunk_label,
+                        md_file_path.name,
+                    )
+                    continue
+                break
+
+        subchunks = self._split_failed_chunk(chunk, split_depth)
+        if len(subchunks) <= 1:
+            raise TranslationIncompleteError(
+                f"Markdown translation remained incomplete for chunk {chunk_label} "
+                f"of '{md_file_path.name}', and the chunk could not be split further."
+            ) from last_error
+
+        logger.warning(
+            "Incomplete translation for chunk %s of file '%s'; retrying as %s smaller chunks.",
+            chunk_label,
+            md_file_path.name,
+            len(subchunks),
+        )
+
+        sub_results = []
+        for sub_index, subchunk in enumerate(subchunks, start=1):
+            sub_results.append(
+                await self._translate_chunk_with_recovery(
+                    subchunk,
+                    language_code,
+                    language_name,
+                    is_rtl,
+                    md_file_path,
+                    chunk_label=f"{chunk_label}.{sub_index}",
+                    index=sub_index,
+                    total=len(subchunks),
+                    split_depth=split_depth + 1,
+                )
+            )
+
+        return "\n".join(sub_results)
+
+    async def _translate_chunk_once(
+        self,
+        chunk: str,
+        language_code: str,
+        language_name: str,
+        is_rtl: bool,
+        md_file_path: Path,
+        chunk_label: str,
+        index: int,
+        total: int,
+    ) -> str:
+        prompt = generate_prompt_template(language_code, language_name, chunk, is_rtl)
+        try:
+            return await asyncio.wait_for(
+                self._run_prompt(prompt, index, total),
+                timeout=self.TRANSLATION_TIMEOUT_SECONDS,
+            )
+        except asyncio.TimeoutError as exc:
+            logger.warning(
+                f"Translation timeout for chunk {chunk_label} of file '{md_file_path.name}': "
+                f"Request exceeded {self.TRANSLATION_TIMEOUT_SECONDS} seconds. "
+                f"Check your network connection and API response time."
+            )
+            raise TranslationIncompleteError(
+                f"Markdown translation timed out for chunk {chunk_label} of '{md_file_path.name}'"
+            ) from exc
+        except (TranslationIncompleteError, TranslationContentFilterError):
+            raise
+        except Exception as e:
+            logger.error(
+                f"Translation failed for chunk {chunk_label} of file '{md_file_path.name}': {str(e)}. "
+                f"Check your API configuration and network connection.",
+                exc_info=True,
+            )
+            raise RuntimeError(
+                f"Markdown translation failed for chunk {chunk_label} of '{md_file_path.name}': {e}"
+            ) from e
+
+    def _split_failed_chunk(self, chunk: str, split_depth: int) -> list[str]:
+        if split_depth >= len(self.RECOVERY_CHUNK_MAX_TOKENS):
+            return []
+
+        max_tokens = self.RECOVERY_CHUNK_MAX_TOKENS[split_depth]
+        subchunks = process_markdown(chunk, max_tokens=max_tokens)
+        return [subchunk for subchunk in subchunks if subchunk]
+
+    def _raise_for_finish_reason(
+        self,
+        finish_reason,
+        index: int | str,
+        total: int,
+    ) -> None:
+        reason = self._normalize_finish_reason(finish_reason)
+        if reason is None or reason == "stop":
+            return
+
+        prompt_ref = f"{index}/{total}"
+        if reason in {"length", "max_tokens"}:
+            raise TranslationIncompleteError(
+                f"Provider stopped markdown translation at prompt {prompt_ref} "
+                f"because finish_reason was '{reason}'."
+            )
+
+        if reason in {"content_filter", "contentfilter"}:
+            raise TranslationContentFilterError(
+                f"Provider blocked markdown translation at prompt {prompt_ref} "
+                f"because finish_reason was '{reason}'."
+            )
+
+        raise TranslationIncompleteError(
+            f"Provider stopped markdown translation at prompt {prompt_ref} "
+            f"with unsupported finish_reason '{reason}'."
+        )
+
+    @staticmethod
+    def _normalize_finish_reason(finish_reason) -> str | None:
+        if finish_reason is None:
+            return None
+
+        value = getattr(finish_reason, "value", finish_reason)
+        if value is None:
+            return None
+
+        reason = str(value).strip().lower()
+        if not reason:
+            return None
+
+        return reason.rsplit(".", 1)[-1]
 
     async def _run_prompts_sequentially(self, prompts, md_file_path):
         """Execute translation prompts in sequence with timeout protection.

--- a/src/co_op_translator/core/llm/providers/azure/markdown_translator.py
+++ b/src/co_op_translator/core/llm/providers/azure/markdown_translator.py
@@ -94,7 +94,14 @@ class AzureMarkdownTranslator(MarkdownTranslator):
         result_contents = await service.get_chat_message_contents(
             chat_history=chat, settings=req_settings
         )
-        result = str(result_contents[0].content) if result_contents else ""
+        if not result_contents:
+            self._raise_for_finish_reason("length", index, total)
+
+        result_content = result_contents[0]
+        self._raise_for_finish_reason(
+            getattr(result_content, "finish_reason", None), index, total
+        )
+        result = str(result_content.content) if result_content.content else ""
         end_time = time.time()
         logger.info(
             f"Prompt {index}/{total} completed in {end_time - start_time} seconds"

--- a/src/co_op_translator/core/llm/providers/openai/markdown_translator.py
+++ b/src/co_op_translator/core/llm/providers/openai/markdown_translator.py
@@ -95,7 +95,14 @@ class OpenAIMarkdownTranslator(MarkdownTranslator):
         result_contents = await service.get_chat_message_contents(
             chat_history=chat, settings=req_settings
         )
-        result = str(result_contents[0].content) if result_contents else ""
+        if not result_contents:
+            self._raise_for_finish_reason("length", index, total)
+
+        result_content = result_contents[0]
+        self._raise_for_finish_reason(
+            getattr(result_content, "finish_reason", None), index, total
+        )
+        result = str(result_content.content) if result_content.content else ""
         end_time = time.time()
         logger.info(
             f"Prompt {index}/{total} completed in {end_time - start_time} seconds"

--- a/src/co_op_translator/core/project/translation/project_markdown_translation.py
+++ b/src/co_op_translator/core/project/translation/project_markdown_translation.py
@@ -109,6 +109,14 @@ class ProjectMarkdownTranslationMixin:
                     raise RuntimeError(
                         f"Markdown translation retry returned empty content for {file_path}"
                     )
+                if compare_line_breaks(document, translated_content):
+                    logger.error(
+                        "Retry translation failed for %s: line break counts still differ too much",
+                        file_path,
+                    )
+                    raise RuntimeError(
+                        f"Markdown translation retry produced incomplete content for {file_path}"
+                    )
 
             translated_content = await self._append_markdown_disclaimer(
                 translated_content, language_code

--- a/src/co_op_translator/core/project/translation/translation_status.py
+++ b/src/co_op_translator/core/project/translation/translation_status.py
@@ -17,6 +17,7 @@ from co_op_translator.utils.common.metadata_utils import (
     is_notebook_up_to_date,
     read_text_metadata_for_source,
 )
+from co_op_translator.utils.markdown.processing import compare_line_breaks
 
 logger = logging.getLogger(__name__)
 
@@ -250,7 +251,11 @@ class TranslationStatusMixin:
                 stored_hash = metadata.get("original_hash")
                 if stored_hash:
                     current_hash = calculate_file_hash(original_file)
-                    return stored_hash != current_hash
+                    if stored_hash != current_hash:
+                        return True
+                    return self._has_markdown_integrity_drift(
+                        original_file, translation_file
+                    )
 
             # Legacy fallback: read inline HTML comment metadata and migrate
             try:
@@ -267,10 +272,26 @@ class TranslationStatusMixin:
             if stored_hash:
                 # Read-only fallback: compare against inline stored hash.
                 current_hash = calculate_file_hash(original_file)
-                return stored_hash != current_hash
+                if stored_hash != current_hash:
+                    return True
+                return self._has_markdown_integrity_drift(
+                    original_file, translation_file
+                )
 
             # No metadata available; consider it outdated
             return True
 
         except Exception:
             return True
+
+    def _has_markdown_integrity_drift(
+        self, original_file: Path, translation_file: Path
+    ) -> bool:
+        """Detect saved translations that are current by hash but structurally incomplete."""
+        try:
+            original_content = original_file.read_text(encoding="utf-8")
+            translated_content = translation_file.read_text(encoding="utf-8")
+        except Exception:
+            return True
+
+        return compare_line_breaks(original_content, translated_content)

--- a/tests/co_op_translator/core/llm/test_markdown_translator.py
+++ b/tests/co_op_translator/core/llm/test_markdown_translator.py
@@ -2,7 +2,11 @@ import pytest
 from unittest.mock import AsyncMock, patch
 import re
 
-from co_op_translator.core.llm.markdown_translator import MarkdownTranslator
+from co_op_translator.core.llm.markdown_translator import (
+    MarkdownTranslator,
+    TranslationContentFilterError,
+    TranslationIncompleteError,
+)
 from co_op_translator.utils.common.lang_utils import get_supported_language_codes
 from co_op_translator.utils.markdown.constants import SPLIT_DELIMITER
 
@@ -116,6 +120,28 @@ def test_disclaimer_templates_cover_supported_languages(real_markdown_translator
 
     assert set(get_supported_language_codes()).issubset(set(templates))
     assert all(co_op_link in templates[code] for code in get_supported_language_codes())
+
+
+def test_finish_reason_stop_or_missing_is_allowed(real_markdown_translator):
+    real_markdown_translator._raise_for_finish_reason("stop", 1, 1)
+    real_markdown_translator._raise_for_finish_reason(None, 1, 1)
+
+
+def test_finish_reason_length_is_incomplete(real_markdown_translator):
+    with pytest.raises(TranslationIncompleteError):
+        real_markdown_translator._raise_for_finish_reason("length", 1, 1)
+
+
+def test_finish_reason_content_filter_is_separate_error(real_markdown_translator):
+    with pytest.raises(TranslationContentFilterError):
+        real_markdown_translator._raise_for_finish_reason("content_filter", 1, 1)
+
+
+def test_finish_reason_enum_values_are_normalized(real_markdown_translator):
+    class FinishReason:
+        value = "stop"
+
+    real_markdown_translator._raise_for_finish_reason(FinishReason(), 1, 1)
 
 
 @pytest.mark.asyncio
@@ -483,6 +509,130 @@ async def test_translate_markdown_keeps_internal_links_inside_code_blocks_unchan
 
 
 @pytest.mark.asyncio
+async def test_translate_markdown_retries_incomplete_chunk_once(
+    real_markdown_translator,
+    tmp_path,
+):
+    test_file = tmp_path / "retry_once.md"
+    test_file.write_text("# Retry me\n\nStable text.\n")
+    calls = 0
+
+    async def fake_prompt(prompt, index, total):
+        nonlocal calls
+        if "# Retry me" in prompt:
+            calls += 1
+            if calls == 1:
+                raise TranslationIncompleteError("length")
+            return "# Reintentar\n\nTexto estable.\n"
+        return prompt
+
+    with patch.object(
+        real_markdown_translator, "_run_prompt", new_callable=AsyncMock
+    ) as mock_run_prompt:
+        mock_run_prompt.side_effect = fake_prompt
+
+        result = await real_markdown_translator.translate_markdown(
+            "# Retry me\n\nStable text.\n",
+            "es",
+            source_path=test_file,
+        )
+
+    assert "# Reintentar" in result
+    assert "Texto estable." in result
+    assert calls == 2
+
+
+@pytest.mark.asyncio
+async def test_translate_markdown_splits_incomplete_chunk_after_retry(
+    real_markdown_translator,
+    monkeypatch,
+    tmp_path,
+):
+    test_file = tmp_path / "split_retry.md"
+    document = "# Needs split\n\nFirst part.\n\nSecond part.\n"
+    test_file.write_text(document)
+    split_max_tokens = []
+    original_failures = 0
+
+    def fake_process_markdown(content, max_tokens=2600, encoding="o200k_base"):
+        split_max_tokens.append(max_tokens)
+        if max_tokens == 2600:
+            return [content]
+        return ["# Needs split\n\nFirst part.\n", "Second part.\n"]
+
+    monkeypatch.setattr(
+        "co_op_translator.core.llm.markdown_translator.process_markdown",
+        fake_process_markdown,
+    )
+
+    async def fake_prompt(prompt, index, total):
+        nonlocal original_failures
+        if "First part.\n\nSecond part." in prompt:
+            original_failures += 1
+            raise TranslationIncompleteError("length")
+        if "First part." in prompt:
+            return "# Dividido\n\nPrimera parte.\n"
+        if "Second part." in prompt:
+            return "Segunda parte.\n"
+        return prompt
+
+    with patch.object(
+        real_markdown_translator, "_run_prompt", new_callable=AsyncMock
+    ) as mock_run_prompt:
+        mock_run_prompt.side_effect = fake_prompt
+
+        result = await real_markdown_translator.translate_markdown(
+            document,
+            "es",
+            source_path=test_file,
+        )
+
+    assert "# Dividido" in result
+    assert "Primera parte." in result
+    assert "Segunda parte." in result
+    assert original_failures == 2
+    assert split_max_tokens == [2600, 1300]
+
+
+@pytest.mark.asyncio
+async def test_translate_markdown_does_not_split_content_filter_errors(
+    real_markdown_translator,
+    monkeypatch,
+    tmp_path,
+):
+    test_file = tmp_path / "content_filter.md"
+    document = "# Blocked\n"
+    test_file.write_text(document)
+    split_max_tokens = []
+
+    def fake_process_markdown(content, max_tokens=2600, encoding="o200k_base"):
+        split_max_tokens.append(max_tokens)
+        return [content]
+
+    monkeypatch.setattr(
+        "co_op_translator.core.llm.markdown_translator.process_markdown",
+        fake_process_markdown,
+    )
+
+    async def fake_prompt(prompt, index, total):
+        raise TranslationContentFilterError("content_filter")
+
+    with patch.object(
+        real_markdown_translator, "_run_prompt", new_callable=AsyncMock
+    ) as mock_run_prompt:
+        mock_run_prompt.side_effect = fake_prompt
+
+        with pytest.raises(TranslationContentFilterError):
+            await real_markdown_translator.translate_markdown(
+                document,
+                "es",
+                source_path=test_file,
+            )
+
+    assert split_max_tokens == [2600]
+
+
+@pytest.mark.asyncio
 async def test_translate_markdown_full_integration(real_markdown_translator, tmp_path):
     """A full integration test that avoids mocking _run_prompt at all.
     This only works if the abstract _run_prompt has a default implementation
@@ -506,4 +656,3 @@ async def test_translate_markdown_full_integration(real_markdown_translator, tmp
     assert (
         "[Default Translation]" in result
     ), "Expected the default translation text in the output."
-

--- a/tests/co_op_translator/core/project/test_translation_manager.py
+++ b/tests/co_op_translator/core/project/test_translation_manager.py
@@ -42,6 +42,16 @@ class FakeNoTextImageTranslator(FakeImageTranslator):
             return original_image.copy()
 
 
+class FakeTruncatingMarkdownTranslator:
+    async def translate_markdown(
+        self, document, language_code, source_path=None, **kwargs
+    ):
+        return "# Truncated\n\nOnly the beginning survived.\n"
+
+    async def generate_disclaimer(self, language_code):
+        return ""
+
+
 class FakeNotebookTranslator:
     def __init__(self):
         self.calls = []
@@ -282,6 +292,67 @@ def test_get_outdated_translations_detects_stale_metadata(
     outdated_files = translation_manager.get_outdated_translations()
 
     assert outdated_files == [(source_file, translated_file)]
+
+
+def test_get_outdated_translations_detects_truncated_current_hash(
+    translation_manager, temp_project_dir
+):
+    source_file = temp_project_dir / "docs" / "test.md"
+    source_file.write_text(
+        "\n".join(f"Line {index}" for index in range(40)) + "\n",
+        encoding="utf-8",
+    )
+    translated_file = temp_project_dir / "translations" / "ko" / "docs" / "test.md"
+    translated_file.parent.mkdir(parents=True, exist_ok=True)
+    translated_file.write_text("# 번역\n\n중간에서 끝남\n", encoding="utf-8")
+    _write_lang_metadata(
+        temp_project_dir / "translations" / "ko",
+        {
+            "docs/test.md": {
+                "original_hash": calculate_file_hash(source_file),
+                "translation_date": "2026-01-01T00:00:00+00:00",
+                "source_file": "docs/test.md",
+                "language_code": "ko",
+            }
+        },
+    )
+    translation_manager.language_codes = ["ko"]
+
+    outdated_files = translation_manager.get_outdated_translations()
+
+    assert outdated_files == [(source_file, translated_file)]
+
+
+@pytest.mark.asyncio
+async def test_translate_markdown_does_not_save_incomplete_retry(temp_project_dir):
+    source_file = temp_project_dir / "docs" / "test.md"
+    source_file.write_text(
+        "\n".join(f"Line {index}" for index in range(40)) + "\n",
+        encoding="utf-8",
+    )
+    translation_manager = TranslationManager(
+        root_dir=temp_project_dir,
+        translations_dir=temp_project_dir / "translations",
+        image_dir=temp_project_dir / "translated_images",
+        language_codes=["ko"],
+        excluded_dirs=["translations", "translated_images", "logs"],
+        supported_image_extensions=[".png"],
+        supported_notebook_extensions=[".ipynb"],
+        markdown_translator=FakeTruncatingMarkdownTranslator(),
+        image_translator=FakeImageTranslator(),
+        notebook_translator=FakeNotebookTranslator(),
+        translation_types=["markdown"],
+        add_disclaimer=False,
+    )
+
+    with pytest.raises(RuntimeError, match="incomplete content"):
+        await translation_manager.translate_markdown(source_file, "ko")
+
+    translated_file = temp_project_dir / "translations" / "ko" / "docs" / "test.md"
+    assert not translated_file.exists()
+    assert not (
+        temp_project_dir / "translations" / "ko" / ".co-op-translator.json"
+    ).exists()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Purpose

Prevent truncated Markdown translations from being treated as successful, current translations. This addresses a data-loss class where provider output can stop early, get written to disk, and then be sealed with the latest source hash so future runs skip it.

## Description

- Inspect Markdown provider `finish_reason` values before accepting translated content.
- Treat `length`, empty provider responses, and unsupported finish reasons as incomplete translations.
- Treat `content_filter` as a distinct translation failure and do not retry it through smaller splits.
- Retry incomplete Markdown chunks once, then re-split only the failed chunk into smaller chunks before failing the file.
- Re-check line-break integrity after project-level retry before saving translated Markdown and metadata.
- Mark existing current-hash Markdown translations as outdated when the translated file is structurally too short.
- Add regression tests for finish-reason handling, failed-chunk recovery, content-filter behavior, truncated current-hash detection, and retry-save blocking.

## Related Issue

Fixes #415

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

- [ ] Yes
- [x] No

## Type of change

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (e.g., formatting, local variables)
- [ ] Refactoring (no functional or API changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Checklist

Before submitting your pull request, please confirm the following:

- [x] **I have thoroughly tested my changes**: I confirm that I have run the code and manually tested all affected areas.
- [x] **All existing tests pass**: I have run all tests and confirmed that nothing is broken.
- [x] **I have added new tests** (if applicable): I have written tests that cover the new functionality introduced by my code changes.
- [x] **I have followed the Co-op Translators coding conventions**: My code adheres to the style guide and coding conventions outlined in the repository.
- [x] **I have documented my changes** (if applicable): I have updated the documentation to reflect the changes where necessary.

## Additional context


