### PR TITLE
Docs: Add why Co-op Translator section

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,19 @@ Example of how translated content is organized:
 
 ![Example](./imgs/translation-ex.png)
 
+## Why Co-op Translator?
+
+Translating one file is easy. Keeping an entire documentation repository
+translated, linked, and up to date is the hard part.
+
+| Problem | How Co-op Translator helps |
+| --- | --- |
+| Long docs are not one prompt | Large Markdown files are split into chunks, so a long README does not depend on one fragile model response. If a chunk fails, Co-op Translator can retry and re-chunk only the failed part. |
+| Incomplete translations should not be marked current | A truncated translation should never be sealed as up to date. Co-op Translator checks translation integrity before saving and can detect structurally incomplete existing translations. |
+| Links should match the translated repo structure | Manual translations often leave relative links pointing back to the source tree. Co-op Translator rewrites Markdown, notebook, image, and README links to match the `translations/<lang>/...` structure. |
+| Translation should work across an entire repo | Co-op Translator handles README files, docs, notebooks, and image text as part of one repository workflow, instead of translating files one by one. |
+| Maintaining translations matters more than creating them once | Source hashes and translation metadata let Co-op Translator find outdated files, skip unchanged files, and keep translated content synchronized as the source repo evolves. |
+
 ## How translation state is managed
 
 Co-op Translator manages translated content as **versioned software artifacts**,  


### PR DESCRIPTION
## Purpose

Explain why Co-op Translator is useful beyond one-off file translation by highlighting repository-scale translation maintenance scenarios.

## Description

This PR adds a new "Why Co-op Translator?" section to the README. The section frames common documentation translation problems and maps them to Co-op Translator capabilities, including chunked long-document handling, incomplete translation protection, translated repo link rewriting, repository-wide translation workflows, and source-hash based maintenance.

## Related Issue

N/A

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

- [ ] Yes
- [x] No

## Type of change

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (e.g., formatting, local variables)
- [ ] Refactoring (no functional or API changes)
- [x] Documentation content changes
- [ ] Other... Please describe:

## Checklist

Before submitting your pull request, please confirm the following:

- [x] **I have thoroughly tested my changes**: I confirm that I have run the code and manually tested all affected areas.
- [ ] **All existing tests pass**: I have run all tests and confirmed that nothing is broken.
- [x] **I have added new tests** (if applicable): I have written tests that cover the new functionality introduced by my code changes.
- [x] **I have followed the Co-op Translators coding conventions**: My code adheres to the style guide and coding conventions outlined in the repository.
- [x] **I have documented my changes** (if applicable): I have updated the documentation to reflect the changes where necessary.

## Additional context

Validation: `git diff --check` passed. Full test suite was not run because this is a README-only documentation change.