### PR TITLE
Build: Enforce lint and formatting checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,10 +40,16 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install Poetry
-        run: python -m pip install --upgrade pip poetry
+        run: python -m pip install --upgrade pip poetry black==26.3.1 ruff==0.15.12
 
       - name: Install dependencies
         run: poetry install --with dev --no-interaction
+
+      - name: Run lint
+        run: ruff check src tests
+
+      - name: Check formatting
+        run: black --check src tests
 
       - name: Run tests
         run: poetry run pytest -m "not api_key_required"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,6 +126,8 @@ This manual testing helps ensure that your changes work well in real-world scena
 
 We use [Black](https://github.com/psf/black) as our Python code formatter to maintain consistent code style across the project. Black is an uncompromising code formatter that automatically reformats Python code to conform to the Black code style.
 
+For package re-export modules such as `__init__.py`, prefer explicit imports and an explicit `__all__` list instead of wildcard imports.
+
 #### Configuration
 
 The Black configuration is specified in our `pyproject.toml`:

--- a/src/co_op_translator/cli/evaluate.py
+++ b/src/co_op_translator/cli/evaluate.py
@@ -6,7 +6,6 @@ import asyncio
 import logging
 import click
 from pathlib import Path
-import os
 
 from co_op_translator.core.project.project_evaluator import ProjectEvaluator
 from co_op_translator.config.base_config import Config
@@ -226,12 +225,12 @@ def evaluate_command(
 
                     # Show issues as reference information if available
                     if issues:
-                        click.echo(f"  Issues found:")
+                        click.echo("  Issues found:")
                         for issue in issues:
                             click.echo(f"    - {issue}")
                     else:
                         click.echo(
-                            f"  No specific issues identified, but confidence score is low"
+                            "  No specific issues identified, but confidence score is low"
                         )
                 except Exception as e:
                     logger.error(f"Error reading issues from {file_path}: {e}")

--- a/src/co_op_translator/config/llm_config/azure_openai.py
+++ b/src/co_op_translator/config/llm_config/azure_openai.py
@@ -1,4 +1,3 @@
-import os
 from dotenv import load_dotenv
 
 from co_op_translator.utils.common.env_set_utils import get_active_env_set, get_env_sets

--- a/src/co_op_translator/config/vision_config/azure_computer_vision.py
+++ b/src/co_op_translator/config/vision_config/azure_computer_vision.py
@@ -1,5 +1,3 @@
-import os
-
 from co_op_translator.utils.common.env_set_utils import get_active_env_set, get_env_sets
 
 

--- a/src/co_op_translator/core/__init__.py
+++ b/src/co_op_translator/core/__init__.py
@@ -1,5 +1,5 @@
-from co_op_translator.core.llm import *
-from co_op_translator.core.vision import *
-from co_op_translator.core.project import *
+from co_op_translator.core.llm import *  # noqa: F403
+from co_op_translator.core.vision import *  # noqa: F403
+from co_op_translator.core.project import *  # noqa: F403
 
 __all__ = []

--- a/src/co_op_translator/core/__init__.py
+++ b/src/co_op_translator/core/__init__.py
@@ -1,5 +1,19 @@
-from co_op_translator.core.llm import *  # noqa: F403
-from co_op_translator.core.vision import *  # noqa: F403
-from co_op_translator.core.project import *  # noqa: F403
+from co_op_translator.core.llm import (
+    AzureMarkdownTranslator,
+    AzureTextTranslator,
+    JupyterNotebookTranslator,
+    OpenAIMarkdownTranslator,
+    OpenAITextTranslator,
+)
+from co_op_translator.core.project import ProjectTranslator
+from co_op_translator.core.vision import AzureImageTranslator
 
-__all__ = []
+__all__ = [
+    "AzureMarkdownTranslator",
+    "AzureTextTranslator",
+    "AzureImageTranslator",
+    "JupyterNotebookTranslator",
+    "OpenAIMarkdownTranslator",
+    "OpenAITextTranslator",
+    "ProjectTranslator",
+]

--- a/src/co_op_translator/review/checks/structure.py
+++ b/src/co_op_translator/review/checks/structure.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 from co_op_translator.review.models import ReviewIssue, ReviewSeverity
 from co_op_translator.review.targets import ReviewTarget
 

--- a/src/co_op_translator/utils/common/env_set_utils.py
+++ b/src/co_op_translator/utils/common/env_set_utils.py
@@ -3,7 +3,6 @@ import logging
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, List, Optional, Sequence, TypeVar
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/src/co_op_translator/utils/common/lang_utils.py
+++ b/src/co_op_translator/utils/common/lang_utils.py
@@ -3,8 +3,7 @@ from __future__ import annotations
 import importlib.resources
 import logging
 import re
-from pathlib import Path
-from typing import Iterable, List, Tuple
+from typing import Iterable, List
 
 import yaml
 

--- a/src/co_op_translator/utils/common/logging_utils.py
+++ b/src/co_op_translator/utils/common/logging_utils.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from datetime import datetime, timezone
+from datetime import datetime
 import os
 import sys
 

--- a/src/co_op_translator/utils/common/metadata_utils.py
+++ b/src/co_op_translator/utils/common/metadata_utils.py
@@ -5,6 +5,7 @@ This module contains utility functions for handling file metadata and hashing op
 import hashlib
 import json
 import logging
+import threading
 from datetime import datetime
 from pathlib import Path
 from typing import Dict, Any, Optional
@@ -345,9 +346,6 @@ def _find_lang_dir_for_translated_file(translated_path: Path) -> Optional[Path]:
 
 # Metadata file name (placed in each language folder)
 IMAGE_METADATA_FILENAME = ".co-op-translator.json"
-
-# Lock for thread-safe metadata file access (per-language locks)
-import threading
 
 _metadata_locks: dict[str, threading.Lock] = {}
 _locks_lock = threading.Lock()

--- a/src/co_op_translator/utils/common/token_estimation.py
+++ b/src/co_op_translator/utils/common/token_estimation.py
@@ -120,7 +120,9 @@ def estimate_tokens_for_images(translation_manager: Any, update: bool) -> int:
                 translation_manager.root_dir,
             )
             translated_image_path = (
-                Path(translation_manager.image_dir) / language_code / translated_filename
+                Path(translation_manager.image_dir)
+                / language_code
+                / translated_filename
             )
             if not update and translated_image_path.exists():
                 continue

--- a/src/co_op_translator/utils/vision/image_utils.py
+++ b/src/co_op_translator/utils/vision/image_utils.py
@@ -17,7 +17,6 @@ from co_op_translator.config.constants import (
     RGBA_IMAGE_EXTENSIONS,
 )
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/tests/co_op_translator/core/llm/test_markdown_evaluator.py
+++ b/tests/co_op_translator/core/llm/test_markdown_evaluator.py
@@ -11,7 +11,6 @@ from co_op_translator.core.llm.providers.openai.markdown_evaluator import (
 )
 from co_op_translator.utils.markdown.evaluation import generate_evaluation_prompt
 
-
 # Sample test data for markdown evaluation
 SAMPLE_MD_CONTENT = """
 # Sample Document

--- a/tests/co_op_translator/core/project/test_directory_manager.py
+++ b/tests/co_op_translator/core/project/test_directory_manager.py
@@ -9,7 +9,6 @@ def setup_test_dirs(tmp_path):
     """Set up test directory structure"""
     # Create test directories
     root_dir = tmp_path / "test_project"
-    translations_dir = root_dir / "translations"
     root_dir.mkdir()
 
     # Create some test files
@@ -65,24 +64,20 @@ class TestDirectoryManager:
 
         # Create test files
         test_file = ko_dir / "test.md"
-        test_file.write_text(
-            """<!--
+        test_file.write_text("""<!--
 {
     "source_file": "test.md"
 }
 -->
-# Test Translation"""
-        )
+# Test Translation""")
 
         orphaned_file = ko_dir / "orphaned.md"
-        orphaned_file.write_text(
-            """<!--
+        orphaned_file.write_text("""<!--
 {
     "source_file": "nonexistent.md"
 }
 -->
-# Orphaned Translation"""
-        )
+# Orphaned Translation""")
 
         # Create original file only for test.md
         (root_dir / "test.md").write_text("# Original Test")

--- a/tests/co_op_translator/core/project/test_project_translator.py
+++ b/tests/co_op_translator/core/project/test_project_translator.py
@@ -69,7 +69,6 @@ async def project_translator(temp_project_dir):
 async def test_check_and_retry_translations(project_translator, temp_project_dir):
     """Test checking and retrying translations."""
     # Setup
-    md_file = temp_project_dir / "docs" / "test.md"
     translated_file = temp_project_dir / "translations" / "ko" / "docs" / "test.md"
     translated_file.parent.mkdir(parents=True)
     translated_file.write_text(

--- a/tests/co_op_translator/utils/common/test_file_utils.py
+++ b/tests/co_op_translator/utils/common/test_file_utils.py
@@ -81,7 +81,6 @@ def test_get_unique_id(temp_dir):
 
 def test_cross_platform_path_hash_consistency(temp_dir, monkeypatch):
     """Test that path hashing is consistent across different OS path separators."""
-    import os
 
     # Setup test directory structure
     test_dir = temp_dir / "test_dir"

--- a/tests/co_op_translator/utils/common/test_lang_utils.py
+++ b/tests/co_op_translator/utils/common/test_lang_utils.py
@@ -1,5 +1,3 @@
-import pytest
-
 from co_op_translator.utils.common.lang_utils import (
     normalize_language_code,
     normalize_language_codes,

--- a/tests/co_op_translator/utils/common/test_metadata_utils.py
+++ b/tests/co_op_translator/utils/common/test_metadata_utils.py
@@ -18,7 +18,6 @@ from co_op_translator.utils.common.metadata_utils import (
     read_image_metadata,
     is_image_up_to_date,
     remove_image_metadata,
-    IMAGE_METADATA_FILENAME,
     _get_metadata_file_path,
 )
 
@@ -295,7 +294,7 @@ def test_is_notebook_up_to_date(tmp_path):
     translated_file.write_text(json.dumps(translated_content), encoding="utf-8")
 
     # Should be up to date
-    assert is_notebook_up_to_date(original_file, translated_file) == True
+    assert is_notebook_up_to_date(original_file, translated_file)
 
     # Create translated notebook with incorrect hash
     outdated_translated_file = tmp_path / "outdated.ipynb"
@@ -313,7 +312,7 @@ def test_is_notebook_up_to_date(tmp_path):
     outdated_translated_file.write_text(json.dumps(outdated_content), encoding="utf-8")
 
     # Should be outdated
-    assert is_notebook_up_to_date(original_file, outdated_translated_file) == False
+    assert not is_notebook_up_to_date(original_file, outdated_translated_file)
 
     # Test with translated notebook without metadata
     no_metadata_file = tmp_path / "no_metadata.ipynb"
@@ -321,12 +320,12 @@ def test_is_notebook_up_to_date(tmp_path):
     no_metadata_file.write_text(json.dumps(no_metadata_content), encoding="utf-8")
 
     # Should be outdated (no metadata means outdated)
-    assert is_notebook_up_to_date(original_file, no_metadata_file) == False
+    assert not is_notebook_up_to_date(original_file, no_metadata_file)
 
     # Test with non-existent files
     non_existent = tmp_path / "non_existent.ipynb"
-    assert is_notebook_up_to_date(original_file, non_existent) == False
-    assert is_notebook_up_to_date(non_existent, translated_file) == False
+    assert not is_notebook_up_to_date(original_file, non_existent)
+    assert not is_notebook_up_to_date(non_existent, translated_file)
 
 
 # ============================================================================
@@ -543,7 +542,7 @@ def test_is_image_up_to_date(tmp_path):
     save_image_metadata(translated_path, original_path, "ko", tmp_path)
 
     # Should be up to date
-    assert is_image_up_to_date(original_path, translated_path) == True
+    assert is_image_up_to_date(original_path, translated_path)
 
 
 def test_is_image_up_to_date_outdated(tmp_path):
@@ -566,7 +565,7 @@ def test_is_image_up_to_date_outdated(tmp_path):
     img_modified.save(original_path)
 
     # Should be outdated now
-    assert is_image_up_to_date(original_path, translated_path) == False
+    assert not is_image_up_to_date(original_path, translated_path)
 
 
 def test_is_image_up_to_date_no_metadata(tmp_path):
@@ -584,7 +583,7 @@ def test_is_image_up_to_date_no_metadata(tmp_path):
     img.save(translated_path)  # No metadata saved
 
     # Should be outdated (no metadata)
-    assert is_image_up_to_date(original_path, translated_path) == False
+    assert not is_image_up_to_date(original_path, translated_path)
 
 
 def test_is_image_up_to_date_nonexistent_translated(tmp_path):
@@ -600,7 +599,7 @@ def test_is_image_up_to_date_nonexistent_translated(tmp_path):
     translated_path = lang_dir / "non_existent.png"
 
     # Should be outdated (file doesn't exist)
-    assert is_image_up_to_date(original_path, translated_path) == False
+    assert not is_image_up_to_date(original_path, translated_path)
 
 
 def test_cleanup_orphan_image_metadata(tmp_path):

--- a/tests/co_op_translator/utils/llm/test_text_utils.py
+++ b/tests/co_op_translator/utils/llm/test_text_utils.py
@@ -82,7 +82,9 @@ def test_gen_image_translation_prompt_special_chars():
 def test_gen_image_translation_prompt_includes_glossary_and_keeps_rules():
     try:
         set_glossary_terms(["Co-op Translator"])
-        prompt = gen_image_translation_prompt(["Co-op Translator Cloud"], "ko", "Korean")
+        prompt = gen_image_translation_prompt(
+            ["Co-op Translator Cloud"], "ko", "Korean"
+        )
         assert "GLOSSARY" in prompt
         assert "Co-op Translator" in prompt
         assert "EXACTLY 1 items" in prompt

--- a/tests/co_op_translator/utils/markdown/test_image_links.py
+++ b/tests/co_op_translator/utils/markdown/test_image_links.py
@@ -55,26 +55,22 @@ def complex_dir_structure(tmp_path):
 
     # Create markdown files
     with open(tmp_path / "docs/examples/nested.md", "w") as f:
-        f.write(
-            """# Nested Document
+        f.write("""# Nested Document
 This is a test with an image in the same directory: ![Local Image](images/test2.png)
 This is a test with an image from parent: ![Parent Image](../images/test1.png)
 This is a test with an image from root: ![Root Image](../hero.jpg)
-"""
-        )
+""")
 
     # Create markdown file with root-relative paths
     with open(tmp_path / "README.md", "w") as f:
-        f.write(
-            """# Root Document
+        f.write("""# Root Document
 ![Logo](/imgs/logo.png)
 
 ## Video Presentations
 Learn more here:
 
 [![Thumbnail](/imgs/open-ms-thumbnail.jpg)](https://example.com)
-"""
-        )
+""")
 
     return tmp_path
 

--- a/tests/co_op_translator/utils/vision/test_image_utils.py
+++ b/tests/co_op_translator/utils/vision/test_image_utils.py
@@ -39,12 +39,12 @@ def test_get_text_color():
     # Test dark background
     bg_color = (0, 0, 50)  # Dark blue
     text_color = get_text_color(bg_color)
-    assert text_color == (255, 255, 255), f"Expected white text for dark background"
+    assert text_color == (255, 255, 255), "Expected white text for dark background"
 
     # Test light background
     bg_color = (200, 200, 255)  # Light blue
     text_color = get_text_color(bg_color)
-    assert text_color == (0, 0, 0), f"Expected black text for light background"
+    assert text_color == (0, 0, 0), "Expected black text for light background"
 
 
 @patch("PIL.ImageFont.truetype")


### PR DESCRIPTION
## Purpose

Turn the repository's linting and formatting expectations into an enforced CI quality gate so contributors can see the real merge bar in automation instead of discovering it after review.

## Description

- Adds Ruff and Black checks to the CI workflow before the test job completes.
- Applies the existing Black configuration across `src/` and `tests/`.
- Replaces wildcard re-exports in `co_op_translator.core` with explicit imports and an explicit `__all__` list.
- Documents the same re-export rule in `CONTRIBUTING.md` so future package surfaces follow the same pattern.
- Fixes current Ruff violations so the new CI checks start green.

## Related Issue

N/A - follow-up to repository audit findings.

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

- [ ] Yes
- [x] No

## Type of change

- [ ] Bugfix
- [ ] Feature
- [x] Code style update (e.g., formatting, local variables)
- [ ] Refactoring (no functional or API changes)
- [x] Documentation content changes
- [x] Other... Please describe: CI quality gate updates.

## Checklist

Before submitting your pull request, please confirm the following:

- [x] **I have thoroughly tested my changes**: I confirm that I have run the code and manually tested all affected areas.
- [x] **All existing tests pass**: I have run all tests and confirmed that nothing is broken.
- [ ] **I have added new tests** (if applicable): I have written tests that cover the new functionality introduced by my code changes.
- [x] **I have followed the Co-op Translators coding conventions**: My code adheres to the style guide and coding conventions outlined in the repository.
- [x] **I have documented my changes** (if applicable): I have updated the documentation to reflect the changes where necessary.

## Additional context

Validation performed:
- `.\.venv\Scripts\python.exe -m ruff check src tests`
- `.\.venv\Scripts\python.exe -m black --check src tests`
- `.\.venv\Scripts\python.exe -m pytest -m "not api_key_required"`
- `git diff --check`