### PR TITLE
Build: Modernize publishing workflows

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -54,4 +54,5 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64,linux/arm64
-          provenance: false
+          provenance: mode=max
+          sbom: true

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,12 +1,4 @@
-# This workflow will upload a Python Package using Twine when a release is created
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python#publishing-to-package-registries
-
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-
-name: Upload Python Package
+name: Publish Python package
 
 on:
   release:
@@ -14,26 +6,28 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
-  deploy:
-
+  publish:
     runs-on: ubuntu-latest
+    environment:
+      name: pypi
 
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python
-      uses: actions/setup-python@v3
-      with:
-        python-version: '3.x'
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install build
-    - name: Build package
-      run: python -m build
-    - name: Publish package
-      uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
-      with:
-        user: __token__
-        password: ${{ secrets.PYPI_API_TOKEN }}
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install build tool
+        run: python -m pip install --upgrade pip build
+
+      - name: Build package
+        run: python -m build
+
+      - name: Publish package to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -320,9 +320,12 @@ This section describes the simplest way for maintainers to publish a new release
 
 #### 2. Create a GitHub Release
 
+Before the first trusted publish from this repository, configure PyPI Trusted Publishing for the project so the GitHub Actions workflow can exchange the GitHub OIDC identity for a PyPI upload. This replaces repository-scoped API tokens in the publish workflow.
+
 1. Go to the GitHub repository page and open **Releases** → **Draft a new release**.
 2. Create a new tag (for example, `v0.13.0`) from the `main` branch.
 3. Set the release title to the same version (for example, `v0.13.0`).
 4. Click **Generate release notes** to auto-populate the changelog.
 5. Optionally edit the text (for example, to highlight newly supported languages or important changes).
 6. Publish the release.
+7. Confirm the PyPI publish workflow succeeds and the new package appears on the project page.


### PR DESCRIPTION
## Purpose

Modernize the release workflows so package and container publishes rely on stronger provenance and less manual secret handling.

## Description

- Switches the PyPI publish workflow from repository API tokens to PyPI Trusted Publishing with GitHub OIDC.
- Updates the release instructions to call out the one-time PyPI trusted publisher setup and post-release verification.
- Enables Docker image provenance and SBOM generation for GHCR publishes.

## Related Issue

N/A - follow-up to repository audit findings.

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

- [ ] Yes
- [x] No

## Type of change

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (e.g., formatting, local variables)
- [ ] Refactoring (no functional or API changes)
- [x] Documentation content changes
- [x] Other... Please describe: publishing workflow hardening.

## Checklist

Before submitting your pull request, please confirm the following:

- [x] **I have thoroughly tested my changes**: I confirm that I have run the code and manually tested all affected areas.
- [ ] **All existing tests pass**: I have run all tests and confirmed that nothing is broken.
- [x] **I have added new tests** (if applicable): I have written tests that cover the new functionality introduced by my code changes.
- [x] **I have followed the Co-op Translators coding conventions**: My code adheres to the style guide and coding conventions outlined in the repository.
- [x] **I have documented my changes** (if applicable): I have updated the documentation to reflect the changes where necessary.

## Additional context

Validation performed:
- YAML parse check for `.github/workflows/python-publish.yml` and `.github/workflows/docker-publish.yml`
- `git diff --check`

Follow-up:
- PyPI project settings still need the repository configured as a trusted publisher before the first release publish can succeed.