### PR TITLE
Core: Add README-only translation mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ co-op-review -l "ko"
 
 For first runs on large repositories, use `--dry-run` before writing translated files. See the [CLI Reference](./docs/cli.md) for content type flags, logs, review, and link migration.
 
+To localize only README entry pages while keeping detailed docs in the source language, run `translate -l "ko ja" --readme-only`.
+
 Container quick run with Bash/Zsh:
 
 ```bash

--- a/docs/api.md
+++ b/docs/api.md
@@ -198,6 +198,17 @@ run_translation(
 )
 ```
 
+Translate only the root README while keeping links to source documentation:
+
+```python
+from co_op_translator.api import run_translation
+
+run_translation(
+    language_codes="ko ja",
+    readme_only=True,
+)
+```
+
 Translate multiple content roots in one call:
 
 ```python
@@ -240,6 +251,8 @@ run_translation(
 ```
 
 If none of `markdown`, `notebook`, or `images` are set, the API translates all supported types: Markdown, notebooks, and images.
+
+Set `readme_only=True` to translate only `README.md` into `translations/<language-code>/README.md`. README links to other Markdown documents are rewritten back to the source tree, so detailed docs can remain English-only while the README is localized.
 
 ## Review Translated Output
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -60,6 +60,12 @@ Translate Markdown and images:
 translate -l "pt-BR" -md -img
 ```
 
+Translate only the root README and keep links to source docs:
+
+```bash
+translate -l "ko ja" --readme-only
+```
+
 Update existing translations by deleting and recreating them:
 
 ```bash
@@ -88,6 +94,7 @@ translate -l "ko" -s
 | `-img`, `--images` | No | Translate only image files. |
 | `-md`, `--markdown` | No | Translate only Markdown files. |
 | `-nb`, `--notebook` | No | Translate only Jupyter notebook files. |
+| `--readme-only` | No | Translate only root `README.md`. Links to other Markdown documents are rewritten back to the source files. |
 | `-d`, `--debug` | No | Enable debug logging in the console. |
 | `-s`, `--save-logs` | No | Save DEBUG-level logs under `<root-dir>/logs/`. |
 | `-x`, `--fix` | No | Retranslate low-confidence Markdown files based on previous evaluation results. |
@@ -100,6 +107,8 @@ translate -l "ko" -s
 | `--dry-run` | No | Preview language folder migration and translation estimates without writing files. |
 
 If no type flag is provided, `translate` processes Markdown, notebooks, and images. Image translation requires Azure AI Vision configuration.
+
+`--readme-only` is a Markdown-only mode for localized README entry pages. It writes `translations/<language-code>/README.md`, skips other Markdown files, and leaves links to docs such as `docs/cli.md` pointing back to the source documentation.
 
 ## evaluate
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -207,6 +207,17 @@ Repository translation defaults to `dry_run=true` so an agent can inspect scope 
 }
 ```
 
+To translate only localized README entry pages and keep README links pointing to source docs, set `readme_only=true`:
+
+```json
+{
+  "language_codes": "ko ja",
+  "root_dir": ".",
+  "readme_only": true,
+  "dry_run": true
+}
+```
+
 To allow writes, the caller must set both `dry_run=false` and `confirm_write=true`:
 
 ```json

--- a/src/co_op_translator/api/translation.py
+++ b/src/co_op_translator/api/translation.py
@@ -269,6 +269,7 @@ def run_translation(
     groups: Iterable[tuple[str, str | None]] | None = None,
     repo_url: str | None = None,
     glossaries: Iterable[str] | None = None,
+    readme_only: bool = False,
     dry_run: bool = False,
 ) -> None:
     """Programmatic translation entrypoint mirroring the translate CLI options."""
@@ -300,17 +301,29 @@ def run_translation(
         image_dir: str | None,
         lang_subdir: str | None,
         repo_url: str | None,
+        readme_only: bool,
         dry_run: bool,
     ) -> None:
         Config.check_configuration()
 
         translation_types: list[str] = []
-        if markdown:
+        if readme_only:
+            if images or notebook:
+                raise RuntimeError(
+                    "readme_only can only be used with markdown translation."
+                )
+            translation_types = ["markdown"]
+        elif markdown:
             translation_types.append("markdown")
-        if images:
-            translation_types.append("images")
-        if notebook:
-            translation_types.append("notebook")
+            if images:
+                translation_types.append("images")
+            if notebook:
+                translation_types.append("notebook")
+        else:
+            if images:
+                translation_types.append("images")
+            if notebook:
+                translation_types.append("notebook")
         if not translation_types:
             translation_types = ["markdown", "notebook", "images"]
 
@@ -497,14 +510,20 @@ def run_translation(
             except Exception as e:  # pragma: no cover
                 logger.warning(f"Failed to update README 'Other courses': {e}")
 
+        translator_kwargs = {
+            "translation_types": translation_types,
+            "add_disclaimer": add_disclaimer,
+            "translations_dir": translations_dir,
+            "image_dir": image_dir,
+            "lang_subdir": lang_subdir,
+        }
+        if readme_only:
+            translator_kwargs["readme_only"] = True
+
         translator = ProjectTranslator(
             language_codes,
             root_dir,
-            translation_types=translation_types,
-            add_disclaimer=add_disclaimer,
-            translations_dir=translations_dir,
-            image_dir=image_dir,
-            lang_subdir=lang_subdir,
+            **translator_kwargs,
         )
 
         if dry_run:
@@ -589,25 +608,43 @@ def run_translation(
         image_dir: str | None,
         lang_subdir: str | None,
         repo_url: str | None,
+        readme_only: bool,
     ) -> dict[str, int]:
         translation_types: list[str] = []
-        if markdown:
+        if readme_only:
+            if images or notebook:
+                raise RuntimeError(
+                    "readme_only can only be used with markdown translation."
+                )
+            translation_types = ["markdown"]
+        elif markdown:
             translation_types.append("markdown")
-        if images:
-            translation_types.append("images")
-        if notebook:
-            translation_types.append("notebook")
+            if images:
+                translation_types.append("images")
+            if notebook:
+                translation_types.append("notebook")
+        else:
+            if images:
+                translation_types.append("images")
+            if notebook:
+                translation_types.append("notebook")
         if not translation_types:
             translation_types = ["markdown", "notebook", "images"]
+
+        translator_kwargs = {
+            "translation_types": translation_types,
+            "add_disclaimer": add_disclaimer,
+            "translations_dir": translations_dir,
+            "image_dir": image_dir,
+            "lang_subdir": lang_subdir,
+        }
+        if readme_only:
+            translator_kwargs["readme_only"] = True
 
         translator = ProjectTranslator(
             language_codes,
             root_dir,
-            translation_types=translation_types,
-            add_disclaimer=add_disclaimer,
-            translations_dir=translations_dir,
-            image_dir=image_dir,
-            lang_subdir=lang_subdir,
+            **translator_kwargs,
         )
         virtual_file_contents = compute_pretranslation_virtual_inputs(
             Path(root_dir).resolve(),
@@ -666,12 +703,19 @@ def run_translation(
             "words": 0,
         }
         translation_types_for_summary: list[str] = []
-        if markdown:
+        if readme_only:
+            translation_types_for_summary = ["markdown"]
+        elif markdown:
             translation_types_for_summary.append("markdown")
-        if images:
-            translation_types_for_summary.append("images")
-        if notebook:
-            translation_types_for_summary.append("notebook")
+            if images:
+                translation_types_for_summary.append("images")
+            if notebook:
+                translation_types_for_summary.append("notebook")
+        else:
+            if images:
+                translation_types_for_summary.append("images")
+            if notebook:
+                translation_types_for_summary.append("notebook")
         if not translation_types_for_summary:
             translation_types_for_summary = ["markdown", "notebook", "images"]
 
@@ -707,6 +751,7 @@ def run_translation(
                 image_dir=image_dir,
                 lang_subdir=per_lang_subdir,
                 repo_url=repo_url,
+                readme_only=readme_only,
             )
             aggregated_estimate = _merge_estimates(aggregated_estimate, group_estimate)
 
@@ -731,6 +776,7 @@ def run_translation(
                     image_dir=image_dir,
                     lang_subdir=per_lang_subdir,
                     repo_url=repo_url,
+                    readme_only=readme_only,
                     dry_run=dry_run,
                 )
 

--- a/src/co_op_translator/api/translation.py
+++ b/src/co_op_translator/api/translation.py
@@ -411,10 +411,16 @@ def run_translation(
         lang_list = normalize_language_codes(lang_list) if lang_list else []
 
         if update:
-            click.echo(
-                f"Warning: Update mode will delete all existing translations for '{language_codes}' "
-                f"and re-translate them."
-            )
+            if readme_only:
+                click.echo(
+                    f"Warning: Update mode will delete existing translated README files for '{language_codes}' "
+                    f"and re-translate them."
+                )
+            else:
+                click.echo(
+                    f"Warning: Update mode will delete all existing translations for '{language_codes}' "
+                    f"and re-translate them."
+                )
 
         try:
             effective_translations_dir = (

--- a/src/co_op_translator/cli/translate.py
+++ b/src/co_op_translator/cli/translate.py
@@ -49,6 +49,11 @@ logger = logging.getLogger(__name__)
 @click.option("--images", "-img", is_flag=True, help="Only translate image files.")
 @click.option("--markdown", "-md", is_flag=True, help="Only translate markdown files.")
 @click.option("--notebook", "-nb", is_flag=True, help="Only translate notebook files.")
+@click.option(
+    "--readme-only",
+    is_flag=True,
+    help="Translate only the root README.md and keep links to other source documents.",
+)
 @click.option("--debug", "-d", is_flag=True, help="Enable debug mode.")
 @click.option(
     "--save-logs",
@@ -115,6 +120,7 @@ def translate_command(
     images,
     markdown,
     notebook,
+    readme_only,
     debug,
     save_logs,
     fix,
@@ -170,14 +176,26 @@ def translate_command(
         # Check that the required environment variables are set
         Config.check_configuration()
 
+        if readme_only and (images or notebook):
+            raise click.ClickException(
+                "--readme-only can only be combined with --markdown."
+            )
+
         # Build translation types list based on user selection
         translation_types = []
-        if markdown:
+        if readme_only:
+            translation_types = ["markdown"]
+        elif markdown:
             translation_types.append("markdown")
-        if images:
-            translation_types.append("images")
-        if notebook:
-            translation_types.append("notebook")
+            if images:
+                translation_types.append("images")
+            if notebook:
+                translation_types.append("notebook")
+        else:
+            if images:
+                translation_types.append("images")
+            if notebook:
+                translation_types.append("notebook")
 
         # Default: translate all supported file types if nothing specified
         if not translation_types:
@@ -351,6 +369,7 @@ def translate_command(
             root_dir,
             translation_types=translation_types,
             add_disclaimer=add_disclaimer,
+            readme_only=readme_only,
         )
 
         # Estimate tokens before running translation and print a concise summary

--- a/src/co_op_translator/cli/translate.py
+++ b/src/co_op_translator/cli/translate.py
@@ -347,9 +347,14 @@ def translate_command(
 
         # Show warning and prompt if update is selected
         if update:
-            click.echo(
-                f"Warning: The update command will delete all existing translations for '{language_codes}' and re-translate everything."
-            )
+            if readme_only:
+                click.echo(
+                    f"Warning: The update command will delete existing translated README files for '{language_codes}' and re-translate them."
+                )
+            else:
+                click.echo(
+                    f"Warning: The update command will delete all existing translations for '{language_codes}' and re-translate everything."
+                )
             if not yes:
                 confirmation_update = click.prompt(
                     "Do you want to continue? Type 'yes' to proceed", type=str

--- a/src/co_op_translator/core/project/project_translator.py
+++ b/src/co_op_translator/core/project/project_translator.py
@@ -44,6 +44,7 @@ class ProjectTranslator:
         translations_dir=None,
         image_dir=None,
         lang_subdir=None,
+        readme_only: bool = False,
     ):
         """Initialize project translation environment.
 
@@ -58,6 +59,7 @@ class ProjectTranslator:
         self.language_codes = normalize_language_codes(language_codes.split())
         self.root_dir = Path(root_dir).resolve()
         self.lang_subdir = Path(lang_subdir) if lang_subdir else None
+        self.readme_only = readme_only
         # Resolve translations_dir relative to root_dir when a relative path is provided.
         if translations_dir is not None:
             t_dir = Path(translations_dir)
@@ -81,6 +83,13 @@ class ProjectTranslator:
         # Default translation types if not specified (safe fallback for direct API usage)
         if translation_types is None:
             translation_types = ["markdown", "notebook", "images"]
+        if self.readme_only:
+            unsupported = [t for t in translation_types if t != "markdown"]
+            if unsupported:
+                raise ValueError(
+                    "--readme-only can only be used with markdown translation."
+                )
+            translation_types = ["markdown"]
         self.translation_types = translation_types
 
         # Build effective excluded dirs, always excluding the configured translation/image trees
@@ -174,6 +183,7 @@ class ProjectTranslator:
             self.translation_types,
             add_disclaimer=add_disclaimer,
             lang_subdir=self.lang_subdir,
+            readme_only=self.readme_only,
         )
 
     def translate_project(
@@ -306,6 +316,8 @@ class ProjectTranslator:
                 orig_file = (self.root_dir / orig_rel).resolve()
 
                 if orig_file.exists():
+                    if self.readme_only and orig_file != (self.root_dir / "README.md"):
+                        continue
                     files_to_retranslate.append((orig_file, confidence))
                 else:
                     error_msg = (

--- a/src/co_op_translator/core/project/translation/manager.py
+++ b/src/co_op_translator/core/project/translation/manager.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from co_op_translator.config.constants import SUPPORTED_MARKDOWN_EXTENSIONS
 from co_op_translator.core.llm.markdown_translator import MarkdownTranslator
 from co_op_translator.core.project.directory_manager import DirectoryManager
+from co_op_translator.utils.common.file_utils import filter_files
 
 from co_op_translator.core.project.translation.project_image_translation import (
     ProjectImageTranslationMixin,
@@ -58,6 +60,7 @@ class TranslationManager(
         translation_types: list[str] = None,
         add_disclaimer: bool = True,
         lang_subdir: Path | None = None,
+        readme_only: bool = False,
     ):
         """Initialize translation manager with required components and settings.
 
@@ -93,6 +96,7 @@ class TranslationManager(
         self.translation_types = translation_types
         self.add_disclaimer = add_disclaimer
         self.lang_subdir = Path(lang_subdir) if lang_subdir else None
+        self.readme_only = readme_only
         self.directory_manager = DirectoryManager(
             root_dir,
             translations_dir,
@@ -111,3 +115,30 @@ class TranslationManager(
         if self.lang_subdir:
             lang_dir = lang_dir / self.lang_subdir
         return lang_dir
+
+    def _readme_source_path(self) -> Path:
+        return (self.root_dir / "README.md").resolve()
+
+    def _is_source_in_scope(
+        self,
+        source_path: Path,
+        content_type: str = "markdown",
+    ) -> bool:
+        if not self.readme_only:
+            return True
+        if content_type != "markdown":
+            return False
+        try:
+            return Path(source_path).resolve() == self._readme_source_path()
+        except Exception:
+            return False
+
+    def _iter_markdown_source_files(self) -> list[Path]:
+        if self.readme_only:
+            readme_path = self._readme_source_path()
+            return [readme_path] if readme_path.exists() else []
+        return [
+            Path(path).resolve()
+            for path in filter_files(self.root_dir, self.excluded_dirs)
+            if Path(path).suffix.lower() in SUPPORTED_MARKDOWN_EXTENSIONS
+        ]

--- a/src/co_op_translator/core/project/translation/project_markdown_translation.py
+++ b/src/co_op_translator/core/project/translation/project_markdown_translation.py
@@ -11,6 +11,7 @@ from co_op_translator.utils.common.file_utils import (
     read_input_file,
 )
 from co_op_translator.utils.common.metadata_utils import save_text_metadata_for_source
+from co_op_translator.utils.common.metadata_utils import remove_text_metadata_for_source
 from co_op_translator.utils.markdown.path_rewriter import (
     MarkdownPathRewritePolicy,
     rewrite_markdown_paths,
@@ -54,6 +55,7 @@ class ProjectMarkdownTranslationMixin:
                 translated_images_dir=self.image_dir,
                 translation_types=self.translation_types,
                 lang_subdir=self.lang_subdir,
+                use_translated_markdown_links=not getattr(self, "readme_only", False),
             ),
         )
 
@@ -156,14 +158,32 @@ class ProjectMarkdownTranslationMixin:
 
         if update:
             for language_code in self.language_codes:
-                delete_translated_markdown_files_by_language_code(
-                    language_code, self.translations_dir, self.lang_subdir
-                )
-                logger.info(
-                    f"Deleted all translated markdown files for language: {language_code}"
-                )
+                if getattr(self, "readme_only", False):
+                    translated_readme_path = (
+                        self._get_language_root(language_code) / "README.md"
+                    )
+                    if translated_readme_path.exists():
+                        translated_readme_path.unlink()
+                        logger.info(
+                            "Deleted translated README for language: %s",
+                            language_code,
+                        )
+                    remove_text_metadata_for_source(
+                        self._get_language_root(language_code),
+                        "README.md",
+                    )
+                else:
+                    delete_translated_markdown_files_by_language_code(
+                        language_code, self.translations_dir, self.lang_subdir
+                    )
+                    logger.info(
+                        f"Deleted all translated markdown files for language: {language_code}"
+                    )
 
-        markdown_files = filter_files(self.root_dir, self.excluded_dirs)
+        if hasattr(self, "_iter_markdown_source_files"):
+            markdown_files = self._iter_markdown_source_files()
+        else:
+            markdown_files = filter_files(self.root_dir, self.excluded_dirs)
         tasks = []
         task_info = []
 

--- a/src/co_op_translator/core/project/translation/translation_discovery.py
+++ b/src/co_op_translator/core/project/translation/translation_discovery.py
@@ -19,7 +19,10 @@ class TranslationDiscoveryMixin:
 
     def _gather_pending_markdown(self, update: bool) -> List[Path]:
         pending: List[Path] = []
-        markdown_files = filter_files(self.root_dir, self.excluded_dirs)
+        if hasattr(self, "_iter_markdown_source_files"):
+            markdown_files = self._iter_markdown_source_files()
+        else:
+            markdown_files = filter_files(self.root_dir, self.excluded_dirs)
         for md_file_path in markdown_files:
             md_file_path = md_file_path.resolve()
             if md_file_path.suffix.lower() in SUPPORTED_MARKDOWN_EXTENSIONS:
@@ -35,6 +38,8 @@ class TranslationDiscoveryMixin:
 
     def _gather_pending_notebooks(self, update: bool) -> List[Path]:
         pending: List[Path] = []
+        if getattr(self, "readme_only", False):
+            return pending
         notebook_files: List[Path] = []
         for ext in self.supported_notebook_extensions:
             notebook_files.extend(filter_files(self.root_dir, self.excluded_dirs, ext))

--- a/src/co_op_translator/core/project/translation/translation_maintenance.py
+++ b/src/co_op_translator/core/project/translation/translation_maintenance.py
@@ -188,6 +188,13 @@ class TranslationMaintenanceMixin:
                     original_file = (self.root_dir / rel_to_lang).resolve()
                     if not original_file.exists():
                         continue
+                    if hasattr(
+                        self, "_is_source_in_scope"
+                    ) and not self._is_source_in_scope(
+                        original_file,
+                        content_type="markdown",
+                    ):
+                        continue
 
                     source_key: str | Path
                     try:

--- a/src/co_op_translator/core/project/translation/translation_status.py
+++ b/src/co_op_translator/core/project/translation/translation_status.py
@@ -73,7 +73,15 @@ class TranslationStatusMixin:
                         try:
                             rel = trans_file.relative_to(translation_dir)
                             original = self.root_dir / rel
-                            if original.exists():
+                            content_type = (
+                                "notebook"
+                                if trans_file.suffix.lower()
+                                in self.supported_notebook_extensions
+                                else "markdown"
+                            )
+                            if original.exists() and self._is_source_in_scope(
+                                original, content_type=content_type
+                            ):
                                 files.append((original, trans_file))
                         except Exception:
                             continue
@@ -129,6 +137,15 @@ class TranslationStatusMixin:
                 original_file = self.root_dir / relative_path
 
                 if not original_file.exists():
+                    continue
+                content_type = (
+                    "notebook"
+                    if trans_file.suffix.lower() in self.supported_notebook_extensions
+                    else "markdown"
+                )
+                if not self._is_source_in_scope(
+                    original_file, content_type=content_type
+                ):
                     continue
 
                 # Compare metadata

--- a/src/co_op_translator/core/project/translation/translation_workflow.py
+++ b/src/co_op_translator/core/project/translation/translation_workflow.py
@@ -53,12 +53,13 @@ class TranslationWorkflowMixin:
         all_errors = []
 
         try:
+            readme_only = getattr(self, "readme_only", False)
             rename_map: dict[str, str] = {}
             migrated_image_count = 0
             should_migrate_links = (
                 "markdown" in self.translation_types
                 or "notebook" in self.translation_types
-            )
+            ) and not readme_only
 
             if "images" in self.translation_types:
                 # Migrate legacy translated image filenames and update markdown/notebook links
@@ -120,52 +121,66 @@ class TranslationWorkflowMixin:
                     logger.warning(f"Image link canonicalization skipped: {e}")
 
             # Clean up files no longer needed in target directories
-            logger.info("Removing orphaned files...")
-            with tqdm(total=1, desc="🧹 Cleaning orphaned files") as cleanup_progress:
-                # Markdown/Notebook cleanup scoped to selected languages
-                removed_md_nb = self.directory_manager.cleanup_orphaned_translations(
-                    markdown="markdown" in self.translation_types,
-                    images=False,
-                    notebooks="notebook" in self.translation_types,
-                )
-
-                # Image cleanup should consider ALL supported languages to avoid removing other languages
-                removed_imgs = 0
-                if "images" in self.translation_types:
-                    cleanup_langs = Config.get_language_codes()
-                    img_dm = DirectoryManager(
-                        self.root_dir,
-                        self.translations_dir,
-                        cleanup_langs,
-                        self.excluded_dirs,
-                        image_dir=self.image_dir,
-                    )
-                    removed_imgs = img_dm.cleanup_orphaned_translations(
-                        markdown=False,
-                        images=True,
-                        notebooks=False,
+            if readme_only:
+                logger.info("Skipping orphan cleanup in README-only mode")
+            else:
+                logger.info("Removing orphaned files...")
+                with tqdm(
+                    total=1, desc="🧹 Cleaning orphaned files"
+                ) as cleanup_progress:
+                    # Markdown/Notebook cleanup scoped to selected languages
+                    removed_md_nb = (
+                        self.directory_manager.cleanup_orphaned_translations(
+                            markdown="markdown" in self.translation_types,
+                            images=False,
+                            notebooks="notebook" in self.translation_types,
+                        )
                     )
 
-                removed_total = (removed_md_nb or 0) + (removed_imgs or 0)
-                cleanup_progress.set_postfix_str(
-                    "None" if removed_total == 0 else f"Removed: {removed_total}"
-                )
-                cleanup_progress.update(1)
+                    # Image cleanup should consider ALL supported languages to avoid removing other languages
+                    removed_imgs = 0
+                    if "images" in self.translation_types:
+                        cleanup_langs = Config.get_language_codes()
+                        img_dm = DirectoryManager(
+                            self.root_dir,
+                            self.translations_dir,
+                            cleanup_langs,
+                            self.excluded_dirs,
+                            image_dir=self.image_dir,
+                        )
+                        removed_imgs = img_dm.cleanup_orphaned_translations(
+                            markdown=False,
+                            images=True,
+                            notebooks=False,
+                        )
+
+                    removed_total = (removed_md_nb or 0) + (removed_imgs or 0)
+                    cleanup_progress.set_postfix_str(
+                        "None" if removed_total == 0 else f"Removed: {removed_total}"
+                    )
+                    cleanup_progress.update(1)
 
             # Create and update directory structure to match source
-            logger.info("Synchronizing directory structure...")
-            with tqdm(total=1, desc="📁 Synchronizing directories") as sync_progress:
-                created, removed, _ = self.directory_manager.sync_directory_structure(
-                    markdown="markdown" in self.translation_types,
-                    images="images" in self.translation_types,
-                    notebooks="notebook" in self.translation_types,
-                )
-                sync_progress.set_postfix_str(
-                    "None"
-                    if (created == 0 and removed == 0)
-                    else f"Created: {created}, Removed: {removed}"
-                )
-                sync_progress.update(1)
+            if readme_only:
+                logger.info("Skipping directory sync in README-only mode")
+            else:
+                logger.info("Synchronizing directory structure...")
+                with tqdm(
+                    total=1, desc="📁 Synchronizing directories"
+                ) as sync_progress:
+                    created, removed, _ = (
+                        self.directory_manager.sync_directory_structure(
+                            markdown="markdown" in self.translation_types,
+                            images="images" in self.translation_types,
+                            notebooks="notebook" in self.translation_types,
+                        )
+                    )
+                    sync_progress.set_postfix_str(
+                        "None"
+                        if (created == 0 and removed == 0)
+                        else f"Created: {created}, Removed: {removed}"
+                    )
+                    sync_progress.update(1)
 
             # Find files needing translation due to source changes (markdown + notebooks)
             if (
@@ -340,11 +355,14 @@ class TranslationWorkflowMixin:
         files_to_translate = []
 
         # Collect all markdown files
-        markdown_files = [
-            file
-            for file in filter_files(self.root_dir, self.excluded_dirs)
-            if file.suffix.lower() in SUPPORTED_MARKDOWN_EXTENSIONS
-        ]
+        if hasattr(self, "_iter_markdown_source_files"):
+            markdown_files = self._iter_markdown_source_files()
+        else:
+            markdown_files = [
+                file
+                for file in filter_files(self.root_dir, self.excluded_dirs)
+                if file.suffix.lower() in SUPPORTED_MARKDOWN_EXTENSIONS
+            ]
         all_markdown_files = [
             (file, language_code)
             for file in markdown_files

--- a/src/co_op_translator/mcp/server.py
+++ b/src/co_op_translator/mcp/server.py
@@ -320,6 +320,7 @@ def run_translation(
     groups: list[dict[str, str | None]] | list[list[str | None]] | None = None,
     repo_url: str | None = None,
     glossaries: list[str] | None = None,
+    readme_only: bool = False,
     dry_run: bool = True,
     confirm_write: bool = False,
 ) -> dict[str, Any]:
@@ -352,6 +353,7 @@ def run_translation(
             groups=_coerce_groups(groups),
             repo_url=repo_url,
             glossaries=glossaries,
+            readme_only=readme_only,
             dry_run=dry_run,
         )
 
@@ -381,6 +383,7 @@ def translate_project(
     groups: list[dict[str, str | None]] | list[list[str | None]] | None = None,
     repo_url: str | None = None,
     glossaries: list[str] | None = None,
+    readme_only: bool = False,
     dry_run: bool = True,
     confirm_write: bool = False,
 ) -> dict[str, Any]:
@@ -403,6 +406,7 @@ def translate_project(
         groups=groups,
         repo_url=repo_url,
         glossaries=glossaries,
+        readme_only=readme_only,
         dry_run=dry_run,
         confirm_write=confirm_write,
     )

--- a/src/co_op_translator/utils/common/token_estimation.py
+++ b/src/co_op_translator/utils/common/token_estimation.py
@@ -154,7 +154,18 @@ def _collect_outdated_translations(
             try:
                 rel = trans_file.relative_to(translation_dir)
                 original = translation_manager.root_dir / rel
-                if original.exists():
+                content_type = (
+                    "notebook"
+                    if trans_file.suffix.lower()
+                    in translation_manager.supported_notebook_extensions
+                    else "markdown"
+                )
+                if original.exists() and (
+                    not hasattr(translation_manager, "_is_source_in_scope")
+                    or translation_manager._is_source_in_scope(
+                        original, content_type=content_type
+                    )
+                ):
                     files.append((original, trans_file))
             except Exception:
                 continue

--- a/src/co_op_translator/utils/common/word_estimation.py
+++ b/src/co_op_translator/utils/common/word_estimation.py
@@ -54,7 +54,18 @@ def _collect_outdated_sources_for_update(translation_manager: Any) -> list[Path]
             try:
                 rel = trans_file.relative_to(translation_dir)
                 original = translation_manager.root_dir / rel
-                if original.exists():
+                content_type = (
+                    "notebook"
+                    if trans_file.suffix.lower()
+                    in translation_manager.supported_notebook_extensions
+                    else "markdown"
+                )
+                if original.exists() and (
+                    not hasattr(translation_manager, "_is_source_in_scope")
+                    or translation_manager._is_source_in_scope(
+                        original, content_type=content_type
+                    )
+                ):
                     sources.append(original)
             except Exception:
                 continue

--- a/src/co_op_translator/utils/markdown/file_links.py
+++ b/src/co_op_translator/utils/markdown/file_links.py
@@ -23,6 +23,7 @@ def update_untranslated_file_links(
     translations_dir: Path,
     root_dir: Path,
     use_translated_notebook: bool = True,
+    use_translated_markdown: bool = True,
     target_path: Path | None = None,
 ) -> str:
     """Update links to untranslated files to point to original source files.
@@ -34,7 +35,7 @@ def update_untranslated_file_links(
     Skips:
     - Web URLs (http, https, mailto)
     - Image files (handled by update_image_links)
-    - Markdown files (always translated)
+    - Markdown files when use_translated_markdown=True
     - Notebook files (if use_translated_notebook=True, they are translated; if False, processed here)
 
     Args:
@@ -44,6 +45,7 @@ def update_untranslated_file_links(
         translations_dir (Path): Directory containing translations
         root_dir (Path): Root directory of the project
         use_translated_notebook (bool): Whether to use translated notebooks (False = process notebook links here)
+        use_translated_markdown (bool): Whether to use translated markdown links (False = process markdown links here)
 
     Returns:
         str: Updated markdown content with corrected untranslated file links
@@ -78,7 +80,7 @@ def update_untranslated_file_links(
             logger.info(f"Skipping image file {link}")
             continue
 
-        if file_ext in SUPPORTED_MARKDOWN_EXTENSIONS:
+        if file_ext in SUPPORTED_MARKDOWN_EXTENSIONS and use_translated_markdown:
             logger.info(f"Skipping markdown file {link}")
             continue
 
@@ -102,6 +104,10 @@ def update_untranslated_file_links(
             updated_link = os.path.relpath(
                 original_linked_file_path, translated_md_dir
             ).replace(os.path.sep, "/")
+            if parsed_url.query:
+                updated_link = f"{updated_link}?{parsed_url.query}"
+            if parsed_url.fragment:
+                updated_link = f"{updated_link}#{parsed_url.fragment}"
 
             old_file_markup = f"[{alt_text}]({link})"
             new_file_markup = f"[{alt_text}]({updated_link})"

--- a/src/co_op_translator/utils/markdown/links.py
+++ b/src/co_op_translator/utils/markdown/links.py
@@ -19,6 +19,7 @@ def update_links(
     translated_images_dir: Path | None = None,
     translation_types: list[str] = None,
     target_path: Path | None = None,
+    use_translated_markdown_links: bool | None = None,
 ) -> str:
     logger.info("Updating links in the markdown file")
 
@@ -30,6 +31,8 @@ def update_links(
         translations_dir = root_dir / "translations"
     if translated_images_dir is None:
         translated_images_dir = root_dir / "translated_images"
+    if use_translated_markdown_links is None:
+        use_translated_markdown_links = "markdown" in translation_types
 
     # Update image links
     markdown_string = update_image_links(
@@ -51,6 +54,7 @@ def update_links(
         translations_dir,
         root_dir,
         use_translated_notebook="notebook" in translation_types,
+        use_translated_markdown=use_translated_markdown_links,
         target_path=target_path,
     )
 

--- a/src/co_op_translator/utils/markdown/path_rewriter.py
+++ b/src/co_op_translator/utils/markdown/path_rewriter.py
@@ -21,6 +21,7 @@ class MarkdownPathRewritePolicy:
     translated_images_dir: str | Path | None = None
     translation_types: Sequence[str] | None = None
     lang_subdir: str | Path | None = None
+    use_translated_markdown_links: bool | None = None
 
 
 def _resolve_under_root(path: str | Path | None, root_dir: Path, default: str) -> Path:
@@ -101,6 +102,7 @@ def rewrite_markdown_paths(
         translated_images_dir=translated_images_dir,
         translation_types=translation_types,
         target_path=target,
+        use_translated_markdown_links=rewrite_policy.use_translated_markdown_links,
     )
 
 

--- a/tests/co_op_translator/core/project/test_translation_manager.py
+++ b/tests/co_op_translator/core/project/test_translation_manager.py
@@ -181,6 +181,104 @@ async def test_translate_markdown_appends_disclaimer_in_project_layer(
 
 
 @pytest.mark.asyncio
+async def test_readme_only_translates_root_readme_and_keeps_source_doc_links(
+    temp_project_dir,
+):
+    readme_path = temp_project_dir / "README.md"
+    readme_path.write_text(
+        "# Home\n\n[Workflow](docs/test.md#quick-start)\n",
+        encoding="utf-8",
+    )
+    existing_docs_translation = (
+        temp_project_dir / "translations" / "ko" / "docs" / "test.md"
+    )
+    existing_docs_translation.parent.mkdir(parents=True, exist_ok=True)
+    existing_docs_translation.write_text(
+        "# Existing docs translation\n", encoding="utf-8"
+    )
+
+    markdown_translator = FakeMarkdownTranslator()
+    translation_manager = TranslationManager(
+        root_dir=temp_project_dir,
+        translations_dir=temp_project_dir / "translations",
+        image_dir=temp_project_dir / "translated_images",
+        language_codes=["ko"],
+        excluded_dirs=["translations", "translated_images", "logs"],
+        supported_image_extensions=[".png"],
+        supported_notebook_extensions=[".ipynb"],
+        markdown_translator=markdown_translator,
+        image_translator=FakeImageTranslator(),
+        notebook_translator=FakeNotebookTranslator(),
+        translation_types=["markdown"],
+        add_disclaimer=False,
+        readme_only=True,
+    )
+
+    modified_count, errors = await translation_manager.translate_all_markdown_files(
+        update=True
+    )
+
+    translated_readme = temp_project_dir / "translations" / "ko" / "README.md"
+    assert modified_count == 1
+    assert errors == []
+    assert translated_readme.exists()
+    assert "../../docs/test.md#quick-start" in translated_readme.read_text(
+        encoding="utf-8"
+    )
+    assert existing_docs_translation.read_text(encoding="utf-8") == (
+        "# Existing docs translation\n"
+    )
+    assert markdown_translator.calls == [
+        (readme_path.read_text(encoding="utf-8").strip(), "ko", readme_path, {})
+    ]
+
+
+def test_readme_only_legacy_metadata_migration_ignores_non_readme(
+    temp_project_dir,
+):
+    (temp_project_dir / "README.md").write_text("# Home\n", encoding="utf-8")
+    translated_doc = temp_project_dir / "translations" / "ko" / "docs" / "test.md"
+    translated_doc.parent.mkdir(parents=True, exist_ok=True)
+    legacy_content = (
+        "<!--\n"
+        "CO_OP_TRANSLATOR_METADATA:\n"
+        "{\n"
+        '  "original_hash": "deadbeef",\n'
+        '  "translation_date": "2026-01-01T00:00:00+00:00",\n'
+        '  "source_file": "docs/test.md",\n'
+        '  "language_code": "ko"\n'
+        "}\n"
+        "-->\n"
+        "# Existing docs translation\n"
+    )
+    translated_doc.write_text(legacy_content, encoding="utf-8")
+
+    translation_manager = TranslationManager(
+        root_dir=temp_project_dir,
+        translations_dir=temp_project_dir / "translations",
+        image_dir=temp_project_dir / "translated_images",
+        language_codes=["ko"],
+        excluded_dirs=["translations", "translated_images", "logs"],
+        supported_image_extensions=[".png"],
+        supported_notebook_extensions=[".ipynb"],
+        markdown_translator=FakeMarkdownTranslator(),
+        image_translator=FakeImageTranslator(),
+        notebook_translator=FakeNotebookTranslator(),
+        translation_types=["markdown"],
+        add_disclaimer=False,
+        readme_only=True,
+    )
+
+    migrated = translation_manager._migrate_legacy_inline_text_metadata()
+
+    assert migrated == 0
+    assert translated_doc.read_text(encoding="utf-8") == legacy_content
+    assert not (
+        temp_project_dir / "translations" / "ko" / ".co-op-translator.json"
+    ).exists()
+
+
+@pytest.mark.asyncio
 async def test_translate_image_uses_configured_image_translator(
     translation_manager, temp_project_dir
 ):

--- a/tests/co_op_translator/test_api.py
+++ b/tests/co_op_translator/test_api.py
@@ -79,6 +79,40 @@ async def test_run_translation_with_disclaimer_flag(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_run_translation_accepts_readme_only(tmp_path):
+    root_dir = tmp_path
+    (root_dir / "README.md").write_text("# Home", encoding="utf-8")
+
+    api.Config.check_configuration = MagicMock(return_value=None)
+    api.LLMConfig.validate_connectivity = MagicMock(return_value=None)
+    api.setup_logging = MagicMock(return_value=None)
+
+    project_translator_instance = MagicMock()
+    project_translator_class = MagicMock(return_value=project_translator_instance)
+    api.ProjectTranslator = project_translator_class
+
+    api.run_translation(
+        language_codes="ko",
+        root_dir=str(root_dir),
+        readme_only=True,
+    )
+
+    project_translator_class.assert_any_call(
+        "ko",
+        str(root_dir),
+        translation_types=["markdown"],
+        add_disclaimer=False,
+        translations_dir=None,
+        image_dir=None,
+        lang_subdir=None,
+        readme_only=True,
+    )
+    project_translator_instance.translate_project.assert_called_once_with(
+        update=False,
+    )
+
+
+@pytest.mark.asyncio
 async def test_run_translation_with_multiple_root_dirs(tmp_path):
     root1 = tmp_path / "content1"
     root2 = tmp_path / "content2"

--- a/tests/co_op_translator/test_mcp_server.py
+++ b/tests/co_op_translator/test_mcp_server.py
@@ -170,6 +170,7 @@ def test_mcp_run_translation_captures_public_api_output(monkeypatch):
         print("translation started")
         assert kwargs["groups"] == [("docs", "localized")]
         assert kwargs["dry_run"] is True
+        assert kwargs["readme_only"] is True
 
     monkeypatch.setattr(
         mcp_server.co_op_api,
@@ -179,7 +180,7 @@ def test_mcp_run_translation_captures_public_api_output(monkeypatch):
 
     result = mcp_server.run_translation(
         language_codes="ko",
-        markdown=True,
+        readme_only=True,
         groups=[{"root_dir": "docs", "translations_dir": "localized"}],
     )
 

--- a/tests/co_op_translator/utils/markdown/test_links.py
+++ b/tests/co_op_translator/utils/markdown/test_links.py
@@ -15,3 +15,22 @@ def test_update_links(temp_dir, sample_markdown):
 
     assert "ko" in result
     assert "translations/ko" in result or "translated_images" in result
+
+
+def test_update_links_can_keep_markdown_links_pointing_to_source(tmp_path):
+    (tmp_path / "docs").mkdir()
+    source_readme = tmp_path / "README.md"
+    source_readme.write_text("# Home", encoding="utf-8")
+    (tmp_path / "docs" / "guide.md").write_text("# Guide", encoding="utf-8")
+
+    result = update_links(
+        source_readme,
+        "[Guide](docs/guide.md#install)",
+        "ko",
+        tmp_path,
+        translation_types=["markdown"],
+        target_path=tmp_path / "translations" / "ko" / "README.md",
+        use_translated_markdown_links=False,
+    )
+
+    assert result == "[Guide](../../docs/guide.md#install)"


### PR DESCRIPTION
## Purpose

Add a README-only translation mode so projects can localize README entry pages while keeping detailed documentation canonical in the source tree.

## Description

This PR adds `--readme-only` to the CLI and `readme_only=True` to the Python API and MCP `run_translation` / `translate_project` tools. When enabled, translation discovery, outdated checks, metadata migration, update behavior, token and word estimates, cleanup, and directory sync are scoped to the root `README.md`.

README Markdown links are rewritten to point back to source documents instead of translated docs. The existing README language table behavior is preserved: the selector is still generated from `src/co_op_translator/templates/languages_table.md` between the README marker comments, and is not derived from the selected `-l` value.

## Related Issue

N/A

## Does this introduce a breaking change?

Will this change require users to update commands, configuration, environment variables, generated translation output, or public Python/MCP APIs?
If you're not sure, test the affected CLI, API, documentation, or GitHub Actions workflow before marking this as "No."

- [ ] Yes
- [x] No

## Type of change

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (e.g., formatting, local variables)
- [ ] Refactoring (no functional or API changes)
- [x] Documentation content changes
- [ ] Other... Please describe:

## Checklist

Before submitting your pull request, please confirm the following:

- [x] **I have thoroughly tested my changes**: I confirm that I have run the code and manually tested all affected areas.
- [x] **All existing tests pass**: I have run all tests and confirmed that nothing is broken.
- [x] **I have added new tests** (if applicable): I have written tests that cover the new functionality introduced by my code changes.
- [x] **I have followed the Co-op Translator coding conventions**: My code adheres to the style guide and coding conventions outlined in the repository.
- [x] **I have documented my changes** (if applicable): I have updated the documentation to reflect the changes where necessary.
