### PR TITLE
Core: Add README translator

### DIFF
--- a/src/co_op_translator/core/project/__init__.py
+++ b/src/co_op_translator/core/project/__init__.py
@@ -1,3 +1,7 @@
 from co_op_translator.core.project.project_translator import ProjectTranslator
+from co_op_translator.core.project.readme_translator import (
+    ReadmeTranslationResult,
+    ReadmeTranslator,
+)
 
-__all__ = ["ProjectTranslator"]
+__all__ = ["ProjectTranslator", "ReadmeTranslationResult", "ReadmeTranslator"]

--- a/src/co_op_translator/core/project/readme_translator.py
+++ b/src/co_op_translator/core/project/readme_translator.py
@@ -1,0 +1,299 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+from urllib.parse import urlparse
+
+from co_op_translator.config.constants import (
+    SUPPORTED_MARKDOWN_EXTENSIONS,
+    SUPPORTED_NOTEBOOK_EXTENSIONS,
+)
+from co_op_translator.core.llm.markdown_translator import MarkdownTranslator
+from co_op_translator.utils.common.file_utils import (
+    handle_empty_document,
+    read_input_file,
+)
+from co_op_translator.utils.common.lang_utils import normalize_language_codes
+from co_op_translator.utils.common.metadata_utils import (
+    calculate_file_hash,
+    read_text_metadata_for_source,
+    save_text_metadata_for_source,
+)
+from co_op_translator.utils.markdown.path_rewriter import (
+    MarkdownPathRewritePolicy,
+    rewrite_markdown_paths,
+)
+from co_op_translator.utils.markdown.processing import compare_line_breaks
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ReadmeTranslationResult:
+    """Result for one README translation target."""
+
+    language_code: str
+    source_path: Path
+    translated_path: Path
+    skipped: bool = False
+
+
+class ReadmeTranslator:
+    """Translate only the root README.md without running project-wide workflows."""
+
+    def __init__(
+        self,
+        language_codes: str | Iterable[str],
+        root_dir: str | Path = ".",
+        *,
+        translations_dir: str | Path | None = None,
+        image_dir: str | Path | None = None,
+        add_disclaimer: bool = True,
+        lang_subdir: str | Path | None = None,
+        markdown_translator=None,
+    ):
+        raw_language_codes = (
+            language_codes.split()
+            if isinstance(language_codes, str)
+            else list(language_codes)
+        )
+        self.language_codes = normalize_language_codes(raw_language_codes)
+        if not self.language_codes:
+            raise ValueError("No valid language codes provided")
+
+        self.root_dir = Path(root_dir).resolve()
+        self.translations_dir = self._resolve_under_root(
+            translations_dir,
+            "translations",
+        )
+        self.image_dir = self._resolve_under_root(image_dir, "translated_images")
+        self.add_disclaimer = add_disclaimer
+        self.lang_subdir = Path(lang_subdir) if lang_subdir else None
+        self.markdown_translator = markdown_translator or MarkdownTranslator.create()
+        self.source_path = (self.root_dir / "README.md").resolve()
+
+    def _resolve_under_root(
+        self,
+        path: str | Path | None,
+        default: str,
+    ) -> Path:
+        if path is None:
+            return self.root_dir / default
+
+        candidate = Path(path)
+        if candidate.is_absolute():
+            return candidate.resolve()
+        return (self.root_dir / candidate).resolve()
+
+    def _get_language_root(self, language_code: str) -> Path:
+        lang_dir = self.translations_dir / language_code
+        if self.lang_subdir:
+            lang_dir = lang_dir / self.lang_subdir
+        return lang_dir
+
+    def get_translated_path(self, language_code: str) -> Path:
+        return self._get_language_root(language_code) / "README.md"
+
+    def _is_current(self, language_code: str) -> bool:
+        translated_path = self.get_translated_path(language_code)
+        if not translated_path.exists():
+            return False
+
+        metadata = read_text_metadata_for_source(
+            self._get_language_root(language_code),
+            "README.md",
+        )
+        return metadata.get("original_hash") == calculate_file_hash(self.source_path)
+
+    async def _append_disclaimer(self, content: str, language_code: str) -> str:
+        if not self.add_disclaimer:
+            return content
+
+        disclaimer = await self.markdown_translator.generate_disclaimer(language_code)
+        if not disclaimer:
+            return content
+
+        start_marker = "<!-- CO-OP TRANSLATOR DISCLAIMER START -->"
+        end_marker = "<!-- CO-OP TRANSLATOR DISCLAIMER END -->"
+        disclaimer_block = f"{start_marker}\n{disclaimer}\n{end_marker}"
+        return content + "\n\n---\n\n" + disclaimer_block
+
+    def _rewrite_paths(
+        self,
+        content: str,
+        language_code: str,
+        translated_path: Path,
+    ) -> str:
+        content = self._rewrite_document_links_to_source(content, translated_path)
+        return rewrite_markdown_paths(
+            content,
+            source_path=self.source_path,
+            target_path=translated_path,
+            policy=MarkdownPathRewritePolicy(
+                language_code=language_code,
+                root_dir=self.root_dir,
+                translations_dir=self.translations_dir,
+                translated_images_dir=self.image_dir,
+                translation_types=["markdown", "notebook"],
+                lang_subdir=self.lang_subdir,
+            ),
+        )
+
+    def _rewrite_document_links_to_source(
+        self,
+        content: str,
+        translated_path: Path,
+    ) -> str:
+        target_dir = translated_path.parent
+        link_pattern = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
+
+        def replace_link(match: re.Match[str]) -> str:
+            label = match.group(1)
+            link = match.group(2)
+            parsed = urlparse(link)
+            path = parsed.path
+
+            if self._should_skip_document_link(link, parsed):
+                return match.group(0)
+
+            source_target = (
+                (self.root_dir / path.lstrip("/")).resolve()
+                if path.startswith("/")
+                else (self.source_path.parent / path).resolve()
+            )
+            relative_path = os.path.relpath(source_target, target_dir).replace(
+                os.path.sep,
+                "/",
+            )
+            rewritten_link = relative_path
+            if parsed.query:
+                rewritten_link += f"?{parsed.query}"
+            if parsed.fragment:
+                rewritten_link += f"#{parsed.fragment}"
+
+            return f"[{label}]({rewritten_link})"
+
+        return link_pattern.sub(replace_link, content)
+
+    def _should_skip_document_link(self, link: str, parsed) -> bool:
+        path = parsed.path
+        if path in ("", ".", "./") or link.startswith("#"):
+            return True
+        if parsed.scheme or "@" in link or link.endswith((".com", ".org", ".net")):
+            return True
+        if re.fullmatch(r"\.?/?translations/[A-Za-z-]+/README\.md", path):
+            return True
+
+        suffix = Path(path).suffix.lower()
+        return suffix not in (
+            *SUPPORTED_MARKDOWN_EXTENSIONS,
+            *SUPPORTED_NOTEBOOK_EXTENSIONS,
+        )
+
+    async def translate_readme(
+        self,
+        language_code: str,
+        *,
+        update: bool = False,
+    ) -> ReadmeTranslationResult:
+        if not self.source_path.exists():
+            raise FileNotFoundError(f"README.md not found under {self.root_dir}")
+
+        language_code = normalize_language_codes([language_code])[0]
+        translated_path = self.get_translated_path(language_code)
+
+        if not update and self._is_current(language_code):
+            return ReadmeTranslationResult(
+                language_code=language_code,
+                source_path=self.source_path,
+                translated_path=translated_path,
+                skipped=True,
+            )
+
+        document = read_input_file(self.source_path)
+        translated_path.parent.mkdir(parents=True, exist_ok=True)
+
+        if not document:
+            handle_empty_document(self.source_path, translated_path)
+            save_text_metadata_for_source(
+                self._get_language_root(language_code),
+                self.source_path,
+                language_code,
+                root_dir=self.root_dir,
+            )
+            return ReadmeTranslationResult(
+                language_code=language_code,
+                source_path=self.source_path,
+                translated_path=translated_path,
+            )
+
+        translated_content = await self.markdown_translator.translate_markdown(
+            document,
+            language_code,
+            source_path=self.source_path,
+        )
+        translated_content = self._rewrite_paths(
+            translated_content,
+            language_code,
+            translated_path,
+        )
+        if not translated_content:
+            raise RuntimeError(
+                "Markdown translation returned empty content for README.md"
+            )
+
+        if compare_line_breaks(document, translated_content):
+            logger.warning("README translation line-break check failed. Retrying.")
+            translated_content = await self.markdown_translator.translate_markdown(
+                document,
+                language_code,
+                source_path=self.source_path,
+            )
+            translated_content = self._rewrite_paths(
+                translated_content,
+                language_code,
+                translated_path,
+            )
+            if not translated_content:
+                raise RuntimeError(
+                    "Markdown translation retry returned empty content for README.md"
+                )
+            if compare_line_breaks(document, translated_content):
+                raise RuntimeError(
+                    "Markdown translation retry produced incomplete content for README.md"
+                )
+
+        translated_content = await self._append_disclaimer(
+            translated_content,
+            language_code,
+        )
+        translated_path.write_text(translated_content, encoding="utf-8")
+        save_text_metadata_for_source(
+            self._get_language_root(language_code),
+            self.source_path,
+            language_code,
+            root_dir=self.root_dir,
+        )
+        return ReadmeTranslationResult(
+            language_code=language_code,
+            source_path=self.source_path,
+            translated_path=translated_path,
+        )
+
+    async def translate_async(
+        self,
+        *,
+        update: bool = False,
+    ) -> list[ReadmeTranslationResult]:
+        results: list[ReadmeTranslationResult] = []
+        for language_code in self.language_codes:
+            results.append(await self.translate_readme(language_code, update=update))
+        return results
+
+    def translate(self, *, update: bool = False) -> list[ReadmeTranslationResult]:
+        return asyncio.run(self.translate_async(update=update))

--- a/tests/co_op_translator/core/project/test_readme_translator.py
+++ b/tests/co_op_translator/core/project/test_readme_translator.py
@@ -1,0 +1,157 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from co_op_translator.core.project import ReadmeTranslator
+
+
+class FakeMarkdownTranslator:
+    def __init__(self):
+        self.calls = []
+        self.disclaimer_calls = []
+
+    async def translate_markdown(self, document, language_code, source_path=None):
+        self.calls.append((document, language_code, Path(source_path)))
+        return document
+
+    async def generate_disclaimer(self, language_code):
+        self.disclaimer_calls.append(language_code)
+        return f"Disclaimer for {language_code}"
+
+
+def _write_readme_project(root: Path) -> None:
+    (root / "docs").mkdir()
+    (root / "docs" / "guide.md").write_text("# Guide", encoding="utf-8")
+    (root / "docs" / "tutorial.ipynb").write_text("{}", encoding="utf-8")
+    (root / "assets").mkdir()
+    (root / "assets" / "manual.pdf").write_text("pdf", encoding="utf-8")
+    (root / "images").mkdir()
+    (root / "images" / "hero.png").write_text("image", encoding="utf-8")
+    (root / "README.md").write_text(
+        "\n".join(
+            [
+                "# Course",
+                "",
+                "[Guide](docs/guide.md#quick-start)",
+                "[Notebook](docs/tutorial.ipynb?view=1#cell)",
+                "[Manual](assets/manual.pdf)",
+                "![Hero](images/hero.png)",
+                "[Korean](./translations/ko/README.md)",
+                "[Anchor](#course)",
+                "[Web](https://example.com/docs.md)",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+@pytest.mark.asyncio
+async def test_readme_translator_writes_only_root_readme_with_source_links(tmp_path):
+    _write_readme_project(tmp_path)
+    markdown_translator = FakeMarkdownTranslator()
+    translator = ReadmeTranslator(
+        "ko",
+        root_dir=tmp_path,
+        add_disclaimer=False,
+        markdown_translator=markdown_translator,
+    )
+
+    results = await translator.translate_async()
+
+    translated_path = tmp_path / "translations" / "ko" / "README.md"
+    translated_text = translated_path.read_text(encoding="utf-8")
+
+    assert len(results) == 1
+    assert results[0].translated_path == translated_path
+    assert results[0].skipped is False
+    assert markdown_translator.calls == [
+        (
+            (tmp_path / "README.md").read_text(encoding="utf-8").strip(),
+            "ko",
+            (tmp_path / "README.md").resolve(),
+        )
+    ]
+    assert "[Guide](../../docs/guide.md#quick-start)" in translated_text
+    assert "[Notebook](../../docs/tutorial.ipynb?view=1#cell)" in translated_text
+    assert "[Manual](../../assets/manual.pdf)" in translated_text
+    assert "[Korean](./README.md)" in translated_text
+    assert "[Anchor](#course)" in translated_text
+    assert "[Web](https://example.com/docs.md)" in translated_text
+    assert not (tmp_path / "translations" / "ko" / "docs" / "guide.md").exists()
+
+
+@pytest.mark.asyncio
+async def test_readme_translator_saves_metadata_and_skips_current_readme(tmp_path):
+    _write_readme_project(tmp_path)
+    markdown_translator = FakeMarkdownTranslator()
+    translator = ReadmeTranslator(
+        ["ko"],
+        root_dir=tmp_path,
+        add_disclaimer=False,
+        markdown_translator=markdown_translator,
+    )
+
+    first = await translator.translate_async()
+    second = await translator.translate_async()
+
+    metadata_path = tmp_path / "translations" / "ko" / ".co-op-translator.json"
+    metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+
+    assert first[0].skipped is False
+    assert second[0].skipped is True
+    assert len(markdown_translator.calls) == 1
+    assert metadata["README.md"]["source_file"] == "README.md"
+    assert metadata["README.md"]["language_code"] == "ko"
+
+
+@pytest.mark.asyncio
+async def test_readme_translator_update_retranslates_current_readme(tmp_path):
+    _write_readme_project(tmp_path)
+    markdown_translator = FakeMarkdownTranslator()
+    translator = ReadmeTranslator(
+        "ko",
+        root_dir=tmp_path,
+        add_disclaimer=False,
+        markdown_translator=markdown_translator,
+    )
+
+    await translator.translate_async()
+    results = await translator.translate_async(update=True)
+
+    assert results[0].skipped is False
+    assert len(markdown_translator.calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_readme_translator_appends_disclaimer(tmp_path):
+    _write_readme_project(tmp_path)
+    markdown_translator = FakeMarkdownTranslator()
+    translator = ReadmeTranslator(
+        "ko",
+        root_dir=tmp_path,
+        add_disclaimer=True,
+        markdown_translator=markdown_translator,
+    )
+
+    await translator.translate_async()
+
+    translated_text = (tmp_path / "translations" / "ko" / "README.md").read_text(
+        encoding="utf-8"
+    )
+    assert "<!-- CO-OP TRANSLATOR DISCLAIMER START -->" in translated_text
+    assert "Disclaimer for ko" in translated_text
+    assert markdown_translator.disclaimer_calls == ["ko"]
+
+
+@pytest.mark.asyncio
+async def test_readme_translator_requires_root_readme(tmp_path):
+    translator = ReadmeTranslator(
+        "ko",
+        root_dir=tmp_path,
+        markdown_translator=FakeMarkdownTranslator(),
+    )
+
+    with pytest.raises(FileNotFoundError, match="README.md not found"):
+        await translator.translate_async()


### PR DESCRIPTION
## Purpose

Add a dedicated README translator so README-only behavior can be implemented without threading mode-specific conditionals through the project-wide translation workflow.

## Description

This PR adds `ReadmeTranslator`, a core translator that targets only the root `README.md` and writes localized README files to `translations/<language-code>/README.md`.

The translator reuses the existing Markdown translator, markdown path rewriting, and centralized text metadata helpers. README links to source Markdown and notebook documents are rewritten back to the source tree from the translated README location, while assets, image links, and README language selector links continue to use the existing path rewrite utilities.

`ProjectTranslator` and the project-wide cleanup, sync, discovery, status, and maintenance workflow are intentionally unchanged.

## Related Issue

N/A

## Does this introduce a breaking change?

Will this change require users to update commands, configuration, environment variables, generated translation output, or public Python/MCP APIs?
If you're not sure, test the affected CLI, API, documentation, or GitHub Actions workflow before marking this as "No."

- [ ] Yes
- [x] No

## Type of change

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (e.g., formatting, local variables)
- [ ] Refactoring (no functional or API changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Checklist

Before submitting your pull request, please confirm the following:

- [x] **I have thoroughly tested my changes**: I confirm that I have run the code and manually tested all affected areas.
- [x] **All existing tests pass**: I have run all tests and confirmed that nothing is broken.
- [x] **I have added new tests** (if applicable): I have written tests that cover the new functionality introduced by my code changes.
- [x] **I have followed the Co-op Translator coding conventions**: My code adheres to the style guide and coding conventions outlined in the repository.
- [ ] **I have documented my changes** (if applicable): Not applicable yet; this core translator is not wired to the public CLI/API/MCP surface in this PR.

## Additional context
