### PR TITLE
Core: Connect README-only translation mode

### DIFF
--- a/src/co_op_translator/api/translation.py
+++ b/src/co_op_translator/api/translation.py
@@ -23,7 +23,9 @@ from co_op_translator.core.llm.jupyter_notebook_translator import (
 from co_op_translator.core.llm.markdown_translator import MarkdownTranslator
 from co_op_translator.core.project.language_migrator import LanguageFolderMigrator
 from co_op_translator.core.project.project_translator import ProjectTranslator
+from co_op_translator.core.project.readme_translator import ReadmeTranslator
 from co_op_translator.core.project.translation.request import (
+    TranslationMode,
     build_translation_request,
     resolve_translation_types,
 )
@@ -37,6 +39,7 @@ from co_op_translator.utils.common.file_utils import (
 )
 from co_op_translator.utils.common.logging_utils import setup_logging
 from co_op_translator.utils.common.metadata_utils import (
+    calculate_string_hash,
     normalize_language_codes_in_lang_metadata,
 )
 from co_op_translator.utils.common.token_estimation import estimate_translation_tokens
@@ -270,9 +273,14 @@ def run_translation(
     groups: Iterable[tuple[str, str | None]] | None = None,
     repo_url: str | None = None,
     glossaries: Iterable[str] | None = None,
+    readme_only: bool = False,
     dry_run: bool = False,
 ) -> None:
-    """Programmatic translation entrypoint mirroring the translate CLI options."""
+    """Programmatic translation entrypoint mirroring the translate CLI options.
+
+    Set ``readme_only`` to translate only the root README while keeping
+    document links pointed at the source tree.
+    """
 
     def _split_lang_placeholder(path: str) -> tuple[str, str | None]:
         placeholder = "<lang>"
@@ -301,6 +309,7 @@ def run_translation(
         image_dir: str | None,
         lang_subdir: str | None,
         repo_url: str | None,
+        readme_only: bool,
         dry_run: bool,
     ) -> None:
         Config.check_configuration()
@@ -310,6 +319,7 @@ def run_translation(
                 markdown=markdown,
                 images=images,
                 notebook=notebook,
+                readme_only=readme_only,
             )
         )
 
@@ -364,16 +374,23 @@ def run_translation(
             markdown=markdown,
             images=images,
             notebook=notebook,
+            readme_only=readme_only,
         )
         language_codes = request.language_codes
         lang_list = request.language_list_values()
         translation_types = request.translation_types_list()
 
         if update:
-            click.echo(
-                f"Warning: Update mode will delete all existing translations for '{language_codes}' "
-                f"and re-translate them."
-            )
+            if request.mode == TranslationMode.README:
+                click.echo(
+                    f"Warning: Update mode will delete existing translated README files for '{language_codes}' "
+                    f"and re-translate them."
+                )
+            else:
+                click.echo(
+                    f"Warning: Update mode will delete all existing translations for '{language_codes}' "
+                    f"and re-translate them."
+                )
 
         try:
             effective_translations_dir = (
@@ -469,6 +486,23 @@ def run_translation(
             except Exception as e:  # pragma: no cover
                 logger.warning(f"Failed to update README 'Other courses': {e}")
 
+        if dry_run:
+            click.echo("🧪 Dry run complete: no changes made.")
+            return
+
+        if request.mode == TranslationMode.README:
+            translator = ReadmeTranslator(
+                language_codes,
+                root_dir,
+                translations_dir=translations_dir,
+                image_dir=image_dir,
+                add_disclaimer=add_disclaimer,
+                lang_subdir=lang_subdir,
+            )
+            translator.translate(update=update)
+            logger.info(f"README translation completed for languages: {language_codes}")
+            return
+
         translator = ProjectTranslator(
             language_codes,
             root_dir,
@@ -478,10 +512,6 @@ def run_translation(
             image_dir=image_dir,
             lang_subdir=lang_subdir,
         )
-
-        if dry_run:
-            click.echo("🧪 Dry run complete: no changes made.")
-            return
 
         translator.translate_project(
             update=update,
@@ -561,6 +591,7 @@ def run_translation(
         image_dir: str | None,
         lang_subdir: str | None,
         repo_url: str | None,
+        readme_only: bool,
     ) -> dict[str, int]:
         request = build_translation_request(
             language_codes=language_codes,
@@ -568,8 +599,51 @@ def run_translation(
             markdown=markdown,
             images=images,
             notebook=notebook,
+            readme_only=readme_only,
         )
         translation_types = request.translation_types_list()
+
+        virtual_file_contents = compute_pretranslation_virtual_inputs(
+            request.root_path,
+            translation_types,
+            repo_url=repo_url,
+        )
+
+        if request.mode == TranslationMode.README:
+            translator = ReadmeTranslator(
+                request.language_codes,
+                root_dir,
+                translations_dir=translations_dir,
+                image_dir=image_dir,
+                add_disclaimer=add_disclaimer,
+                lang_subdir=lang_subdir,
+            )
+            readme_path = request.root_path / "README.md"
+            source_text = virtual_file_contents.get(readme_path.resolve())
+            source_hash = (
+                calculate_string_hash(source_text) if source_text is not None else None
+            )
+            total_tokens = translator.estimate_tokens(
+                update=update,
+                source_text=source_text,
+                source_hash=source_hash,
+            )
+            total_words = translator.estimate_words(
+                update=update,
+                source_text=source_text,
+                source_hash=source_hash,
+            )
+            return {
+                "markdown": total_tokens,
+                "notebook": 0,
+                "images": 0,
+                "outdated_markdown": 0,
+                "outdated_notebook": 0,
+                "outdated_images": 0,
+                "outdated": 0,
+                "total": total_tokens,
+                "words": total_words,
+            }
 
         translator = ProjectTranslator(
             request.language_codes,
@@ -579,11 +653,6 @@ def run_translation(
             translations_dir=translations_dir,
             image_dir=image_dir,
             lang_subdir=lang_subdir,
-        )
-        virtual_file_contents = compute_pretranslation_virtual_inputs(
-            request.root_path,
-            translation_types,
-            repo_url=repo_url,
         )
         est = estimate_translation_tokens(
             translator.translation_manager,
@@ -641,6 +710,7 @@ def run_translation(
                 markdown=markdown,
                 images=images,
                 notebook=notebook,
+                readme_only=readme_only,
             )
         )
 
@@ -676,6 +746,7 @@ def run_translation(
                 image_dir=image_dir,
                 lang_subdir=per_lang_subdir,
                 repo_url=repo_url,
+                readme_only=readme_only,
             )
             aggregated_estimate = _merge_estimates(aggregated_estimate, group_estimate)
 
@@ -700,6 +771,7 @@ def run_translation(
                     image_dir=image_dir,
                     lang_subdir=per_lang_subdir,
                     repo_url=repo_url,
+                    readme_only=readme_only,
                     dry_run=dry_run,
                 )
 

--- a/src/co_op_translator/cli/translate.py
+++ b/src/co_op_translator/cli/translate.py
@@ -8,6 +8,7 @@ import click
 from pathlib import Path
 
 from co_op_translator.core.project.project_translator import ProjectTranslator
+from co_op_translator.core.project.readme_translator import ReadmeTranslator
 from co_op_translator.config.base_config import Config
 from co_op_translator.config.vision_config.config import VisionConfig
 from co_op_translator.config.llm_config.config import LLMConfig
@@ -21,6 +22,7 @@ from co_op_translator.utils.common.metadata_utils import (
 )
 from co_op_translator.core.project.language_migrator import LanguageFolderMigrator
 from co_op_translator.core.project.translation.request import (
+    TranslationMode,
     build_translation_request,
     resolve_translation_types,
 )
@@ -50,6 +52,11 @@ logger = logging.getLogger(__name__)
 @click.option("--images", "-img", is_flag=True, help="Only translate image files.")
 @click.option("--markdown", "-md", is_flag=True, help="Only translate markdown files.")
 @click.option("--notebook", "-nb", is_flag=True, help="Only translate notebook files.")
+@click.option(
+    "--readme-only",
+    is_flag=True,
+    help="Translate only the root README.md and keep links to source documents.",
+)
 @click.option("--debug", "-d", is_flag=True, help="Enable debug mode.")
 @click.option(
     "--save-logs",
@@ -116,6 +123,7 @@ def translate_command(
     images,
     markdown,
     notebook,
+    readme_only,
     debug,
     save_logs,
     fix,
@@ -176,6 +184,7 @@ def translate_command(
                 markdown=markdown,
                 images=images,
                 notebook=notebook,
+                readme_only=readme_only,
             )
         )
 
@@ -252,10 +261,14 @@ def translate_command(
             markdown=markdown,
             images=images,
             notebook=notebook,
+            readme_only=readme_only,
         )
         language_codes = request.language_codes
         lang_list = request.language_list_values()
         translation_types = request.translation_types_list()
+
+        if readme_only and fix:
+            raise click.ClickException("--readme-only cannot be used with --fix.")
 
         # Detect and migrate alias-based language folders for the SELECTED languages
         # This runs before any translation work to avoid redundant re-translation.
@@ -321,9 +334,14 @@ def translate_command(
 
         # Show warning and prompt if update is selected
         if update:
-            click.echo(
-                f"Warning: The update command will delete all existing translations for '{language_codes}' and re-translate everything."
-            )
+            if request.mode == TranslationMode.README:
+                click.echo(
+                    f"Warning: The update command will delete existing translated README files for '{language_codes}' and re-translate them."
+                )
+            else:
+                click.echo(
+                    f"Warning: The update command will delete all existing translations for '{language_codes}' and re-translate everything."
+                )
             if not yes:
                 confirmation_update = click.prompt(
                     "Do you want to continue? Type 'yes' to proceed", type=str
@@ -337,17 +355,35 @@ def translate_command(
             else:
                 click.echo("Auto-confirming update operation...")
 
-        # Initialize ProjectTranslator with determined settings
-        translator = ProjectTranslator(
-            language_codes,
-            root_dir,
-            translation_types=translation_types,
-            add_disclaimer=add_disclaimer,
-        )
+        if request.mode == TranslationMode.README:
+            translator = ReadmeTranslator(
+                language_codes,
+                root_dir,
+                add_disclaimer=add_disclaimer,
+            )
+        else:
+            translator = ProjectTranslator(
+                language_codes,
+                root_dir,
+                translation_types=translation_types,
+                add_disclaimer=add_disclaimer,
+            )
 
         # Estimate tokens before running translation and print a concise summary
         try:
-            est = translator.translation_manager.estimate_tokens(update=update)
+            if request.mode == TranslationMode.README:
+                total_tokens = translator.estimate_tokens(update=update)
+                est = {
+                    "markdown": total_tokens,
+                    "notebook": 0,
+                    "images": 0,
+                    "outdated_markdown": 0,
+                    "outdated_notebook": 0,
+                    "outdated_images": 0,
+                    "total": total_tokens,
+                }
+            else:
+                est = translator.translation_manager.estimate_tokens(update=update)
             translation_parts = []
             if "markdown" in translation_types:
                 translation_parts.append(f"markdown: {est.get('markdown', 0):,}")
@@ -426,7 +462,6 @@ def translate_command(
             total_errors = 0
 
             for lang_code in lang_list:
-
                 logger.info(f"Processing language: {lang_code}")
 
                 try:
@@ -469,11 +504,14 @@ def translate_command(
             )
 
         else:
-            # Call translate_project with determined settings
-            translator.translate_project(
-                update=update,
-                fast_mode=fast,
-            )
+            if request.mode == TranslationMode.README:
+                translator.translate(update=update)
+            else:
+                # Call translate_project with determined settings
+                translator.translate_project(
+                    update=update,
+                    fast_mode=fast,
+                )
 
             logger.info(
                 f"Project translation completed for languages: {language_codes}"

--- a/src/co_op_translator/core/project/readme_translator.py
+++ b/src/co_op_translator/core/project/readme_translator.py
@@ -24,6 +24,7 @@ from co_op_translator.utils.common.metadata_utils import (
     read_text_metadata_for_source,
     save_text_metadata_for_source,
 )
+from co_op_translator.utils.common.token_estimation import count_tokens
 from co_op_translator.utils.markdown.path_rewriter import (
     MarkdownPathRewritePolicy,
     rewrite_markdown_paths,
@@ -99,7 +100,7 @@ class ReadmeTranslator:
     def get_translated_path(self, language_code: str) -> Path:
         return self._get_language_root(language_code) / "README.md"
 
-    def _is_current(self, language_code: str) -> bool:
+    def _is_current(self, language_code: str, source_hash: str | None = None) -> bool:
         translated_path = self.get_translated_path(language_code)
         if not translated_path.exists():
             return False
@@ -108,7 +109,65 @@ class ReadmeTranslator:
             self._get_language_root(language_code),
             "README.md",
         )
-        return metadata.get("original_hash") == calculate_file_hash(self.source_path)
+        return metadata.get("original_hash") == (
+            source_hash or calculate_file_hash(self.source_path)
+        )
+
+    def get_pending_language_codes(
+        self,
+        *,
+        update: bool = False,
+        source_hash: str | None = None,
+    ) -> list[str]:
+        if update:
+            return list(self.language_codes)
+        return [
+            language_code
+            for language_code in self.language_codes
+            if not self._is_current(language_code, source_hash=source_hash)
+        ]
+
+    def estimate_tokens(
+        self,
+        *,
+        update: bool = False,
+        source_text: str | None = None,
+        source_hash: str | None = None,
+    ) -> int:
+        if not self.source_path.exists():
+            return 0
+
+        text = (
+            source_text
+            if source_text is not None
+            else read_input_file(self.source_path)
+        )
+        pending_languages = self.get_pending_language_codes(
+            update=update,
+            source_hash=source_hash,
+        )
+        return count_tokens(text) * len(pending_languages)
+
+    def estimate_words(
+        self,
+        *,
+        update: bool = False,
+        source_text: str | None = None,
+        source_hash: str | None = None,
+    ) -> int:
+        if not self.source_path.exists():
+            return 0
+
+        text = (
+            source_text
+            if source_text is not None
+            else read_input_file(self.source_path)
+        )
+        pending_languages = self.get_pending_language_codes(
+            update=update,
+            source_hash=source_hash,
+        )
+        return len(re.findall(r"\S+", text)) * len(pending_languages)
 
     async def _append_disclaimer(self, content: str, language_code: str) -> str:
         if not self.add_disclaimer:

--- a/src/co_op_translator/core/project/translation/request.py
+++ b/src/co_op_translator/core/project/translation/request.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from enum import Enum
 from pathlib import Path
 from typing import Iterable
 
@@ -10,10 +11,16 @@ from co_op_translator.utils.common.lang_utils import normalize_language_codes
 DEFAULT_TRANSLATION_TYPES = ("markdown", "notebook", "images")
 
 
+class TranslationMode(str, Enum):
+    PROJECT = "project"
+    README = "readme"
+
+
 @dataclass(frozen=True)
 class TranslationRequest:
     """Normalized project translation options shared by CLI and API entrypoints."""
 
+    mode: TranslationMode
     language_codes: str
     language_list: tuple[str, ...]
     translation_types: tuple[str, ...]
@@ -33,8 +40,14 @@ def resolve_translation_types(
     markdown: bool = False,
     images: bool = False,
     notebook: bool = False,
+    readme_only: bool = False,
 ) -> tuple[str, ...]:
     """Return translation types using the existing CLI/API option semantics."""
+    if readme_only:
+        if images or notebook:
+            raise ValueError("readme_only can only be used with markdown translation.")
+        return ("markdown",)
+
     translation_types: list[str] = []
     if markdown:
         translation_types.append("markdown")
@@ -75,6 +88,7 @@ def build_translation_request(
     markdown: bool = False,
     images: bool = False,
     notebook: bool = False,
+    readme_only: bool = False,
 ) -> TranslationRequest:
     """Build normalized request data without performing I/O or provider checks."""
     language_list, all_languages_selected = normalize_requested_language_codes(
@@ -84,10 +98,12 @@ def build_translation_request(
         markdown=markdown,
         images=images,
         notebook=notebook,
+        readme_only=readme_only,
     )
     root_path = Path(root_dir).resolve()
 
     return TranslationRequest(
+        mode=TranslationMode.README if readme_only else TranslationMode.PROJECT,
         language_codes=" ".join(language_list),
         language_list=language_list,
         translation_types=translation_types,

--- a/src/co_op_translator/mcp/server.py
+++ b/src/co_op_translator/mcp/server.py
@@ -320,13 +320,15 @@ def run_translation(
     groups: list[dict[str, str | None]] | list[list[str | None]] | None = None,
     repo_url: str | None = None,
     glossaries: list[str] | None = None,
+    readme_only: bool = False,
     dry_run: bool = True,
     confirm_write: bool = False,
 ) -> dict[str, Any]:
     """Run repository translation through the public API.
 
     Non-dry-run calls can write, update, or delete many files. Set
-    confirm_write=true when dry_run=false.
+    confirm_write=true when dry_run=false. Set readme_only=true to translate
+    only the root README while leaving linked documents in the source tree.
     """
 
     if not dry_run and not confirm_write:
@@ -352,6 +354,7 @@ def run_translation(
             groups=_coerce_groups(groups),
             repo_url=repo_url,
             glossaries=glossaries,
+            readme_only=readme_only,
             dry_run=dry_run,
         )
 
@@ -381,6 +384,7 @@ def translate_project(
     groups: list[dict[str, str | None]] | list[list[str | None]] | None = None,
     repo_url: str | None = None,
     glossaries: list[str] | None = None,
+    readme_only: bool = False,
     dry_run: bool = True,
     confirm_write: bool = False,
 ) -> dict[str, Any]:
@@ -403,6 +407,7 @@ def translate_project(
         groups=groups,
         repo_url=repo_url,
         glossaries=glossaries,
+        readme_only=readme_only,
         dry_run=dry_run,
         confirm_write=confirm_write,
     )

--- a/tests/co_op_translator/core/project/test_readme_translator.py
+++ b/tests/co_op_translator/core/project/test_readme_translator.py
@@ -125,6 +125,27 @@ async def test_readme_translator_update_retranslates_current_readme(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_readme_translator_estimates_only_pending_readmes(tmp_path):
+    _write_readme_project(tmp_path)
+    markdown_translator = FakeMarkdownTranslator()
+    translator = ReadmeTranslator(
+        "ko ja",
+        root_dir=tmp_path,
+        add_disclaimer=False,
+        markdown_translator=markdown_translator,
+    )
+
+    initial_tokens = translator.estimate_tokens()
+    initial_words = translator.estimate_words()
+    await translator.translate_readme("ko")
+
+    assert initial_tokens > translator.estimate_tokens()
+    assert initial_words > translator.estimate_words()
+    assert translator.get_pending_language_codes() == ["ja"]
+    assert translator.get_pending_language_codes(update=True) == ["ko", "ja"]
+
+
+@pytest.mark.asyncio
 async def test_readme_translator_appends_disclaimer(tmp_path):
     _write_readme_project(tmp_path)
     markdown_translator = FakeMarkdownTranslator()

--- a/tests/co_op_translator/core/project/translation/test_request.py
+++ b/tests/co_op_translator/core/project/translation/test_request.py
@@ -17,6 +17,22 @@ def test_resolve_translation_types_preserves_existing_explicit_order():
     ) == ("markdown", "images", "notebook")
 
 
+def test_resolve_translation_types_readme_only_forces_markdown():
+    assert request.resolve_translation_types(readme_only=True) == ("markdown",)
+    assert request.resolve_translation_types(
+        markdown=True,
+        readme_only=True,
+    ) == ("markdown",)
+
+
+def test_resolve_translation_types_rejects_readme_only_with_images_or_notebooks():
+    with pytest.raises(ValueError, match="readme_only"):
+        request.resolve_translation_types(readme_only=True, images=True)
+
+    with pytest.raises(ValueError, match="readme_only"):
+        request.resolve_translation_types(readme_only=True, notebook=True)
+
+
 def test_build_translation_request_normalizes_language_codes(tmp_path):
     result = request.build_translation_request(
         language_codes="ko tw pt-br",
@@ -26,9 +42,21 @@ def test_build_translation_request_normalizes_language_codes(tmp_path):
 
     assert result.language_codes == "ko zh-TW pt-BR"
     assert result.language_list == ("ko", "zh-TW", "pt-BR")
+    assert result.mode == request.TranslationMode.PROJECT
     assert result.translation_types == ("markdown",)
     assert result.root_path == Path(tmp_path).resolve()
     assert result.all_languages_selected is False
+
+
+def test_build_translation_request_readme_only_sets_readme_mode(tmp_path):
+    result = request.build_translation_request(
+        language_codes="ko",
+        root_dir=str(tmp_path),
+        readme_only=True,
+    )
+
+    assert result.mode == request.TranslationMode.README
+    assert result.translation_types == ("markdown",)
 
 
 def test_build_translation_request_expands_all(monkeypatch, tmp_path):

--- a/tests/co_op_translator/test_api.py
+++ b/tests/co_op_translator/test_api.py
@@ -316,6 +316,87 @@ async def test_run_translation_dry_run_uses_virtual_readme_without_writing(tmp_p
 
 
 @pytest.mark.asyncio
+async def test_run_translation_readme_only_uses_readme_translator(
+    monkeypatch, tmp_path
+):
+    (tmp_path / "README.md").write_text("# Hello", encoding="utf-8")
+
+    monkeypatch.setattr(api.Config, "check_configuration", MagicMock(return_value=None))
+    monkeypatch.setattr(
+        api.LLMConfig, "validate_connectivity", MagicMock(return_value=None)
+    )
+    monkeypatch.setattr(api, "setup_logging", MagicMock(return_value=None))
+    monkeypatch.setattr(
+        api, "update_readme_languages_table", MagicMock(return_value=False)
+    )
+    monkeypatch.setattr(
+        api, "update_readme_other_courses", MagicMock(return_value=False)
+    )
+    project_translator = MagicMock()
+    monkeypatch.setattr(api, "ProjectTranslator", project_translator)
+
+    estimate_instance = MagicMock()
+    estimate_instance.estimate_tokens.return_value = 10
+    estimate_instance.estimate_words.return_value = 5
+    run_instance = MagicMock()
+    readme_translator = MagicMock(side_effect=[estimate_instance, run_instance])
+    monkeypatch.setattr(api, "ReadmeTranslator", readme_translator)
+
+    api.run_translation(
+        language_codes="ko",
+        root_dir=str(tmp_path),
+        readme_only=True,
+    )
+
+    assert project_translator.call_count == 0
+    assert readme_translator.call_count == 2
+    readme_translator.assert_any_call(
+        "ko",
+        str(tmp_path),
+        translations_dir=None,
+        image_dir=None,
+        add_disclaimer=False,
+        lang_subdir=None,
+    )
+    run_instance.translate.assert_called_once_with(update=False)
+
+
+@pytest.mark.asyncio
+async def test_run_translation_readme_only_dry_run_does_not_write(
+    monkeypatch, tmp_path
+):
+    (tmp_path / "README.md").write_text("# Hello", encoding="utf-8")
+
+    monkeypatch.setattr(api.Config, "check_configuration", MagicMock(return_value=None))
+    monkeypatch.setattr(
+        api.LLMConfig, "validate_connectivity", MagicMock(return_value=None)
+    )
+    monkeypatch.setattr(api, "setup_logging", MagicMock(return_value=None))
+    update_languages = MagicMock(return_value=True)
+    update_courses = MagicMock(return_value=True)
+    monkeypatch.setattr(api, "update_readme_languages_table", update_languages)
+    monkeypatch.setattr(api, "update_readme_other_courses", update_courses)
+
+    estimate_instance = MagicMock()
+    estimate_instance.estimate_tokens.return_value = 10
+    estimate_instance.estimate_words.return_value = 5
+    readme_translator = MagicMock(return_value=estimate_instance)
+    monkeypatch.setattr(api, "ReadmeTranslator", readme_translator)
+
+    api.run_translation(
+        language_codes="ko",
+        root_dir=str(tmp_path),
+        readme_only=True,
+        dry_run=True,
+    )
+
+    assert readme_translator.call_count == 1
+    estimate_instance.translate.assert_not_called()
+    update_languages.assert_not_called()
+    update_courses.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_run_translation_accepts_glossaries_and_restores_previous_terms(tmp_path):
     root_dir = tmp_path
 

--- a/tests/co_op_translator/test_mcp_server.py
+++ b/tests/co_op_translator/test_mcp_server.py
@@ -170,6 +170,7 @@ def test_mcp_run_translation_captures_public_api_output(monkeypatch):
         print("translation started")
         assert kwargs["groups"] == [("docs", "localized")]
         assert kwargs["dry_run"] is True
+        assert kwargs["readme_only"] is True
 
     monkeypatch.setattr(
         mcp_server.co_op_api,
@@ -180,6 +181,7 @@ def test_mcp_run_translation_captures_public_api_output(monkeypatch):
     result = mcp_server.run_translation(
         language_codes="ko",
         markdown=True,
+        readme_only=True,
         groups=[{"root_dir": "docs", "translations_dir": "localized"}],
     )
 


### PR DESCRIPTION
## Purpose

Expose README-only translation through the CLI, Python API, and MCP server after the option normalization and dedicated README translator foundations.

## Description

This PR adds a thin public `readme_only` / `--readme-only` mode that translates only the root `README.md` into each selected language folder.

The shared `TranslationRequest` now carries a project-vs-README mode so CLI/API/MCP option handling goes through the same normalization path. README mode dispatches to `ReadmeTranslator`, while the existing project-wide translation workflow remains the default path.

The README translator also exposes pending-language and estimate helpers so dry runs report README-only volume without invoking project-wide discovery. Translated README files keep Markdown and notebook document links pointed back to the source tree.

Documentation changes are intentionally deferred to a separate docs/globalization follow-up because changing source Markdown in this repository requires synchronized translated documentation updates.

## Related Issue

N/A

## Does this introduce a breaking change?

Will this change require users to update commands, configuration, environment variables, generated translation output, or public Python/MCP APIs?
If you're not sure, test the affected CLI, API, documentation, or GitHub Actions workflow before marking this as "No."

- [ ] Yes
- [x] No

## Type of change

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (e.g., formatting, local variables)
- [ ] Refactoring (no functional or API changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Checklist

Before submitting your pull request, please confirm the following:

- [x] **I have thoroughly tested my changes**: I confirm that I have run the code and manually tested all affected areas.
- [x] **All existing tests pass**: I have run all tests and confirmed that nothing is broken.
- [x] **I have added new tests** (if applicable): I have written tests that cover the new functionality introduced by my code changes.
- [x] **I have followed the Co-op Translator coding conventions**: My code adheres to the style guide and coding conventions outlined in the repository.
- [ ] **I have documented my changes** (if applicable): Deferred to a separate docs/globalization follow-up so source documentation and translated documentation can stay synchronized.

## Additional context
