### PR TITLE
Fix markdown structure preservation retries

### DIFF
--- a/src/co_op_translator/core/llm/markdown_translator.py
+++ b/src/co_op_translator/core/llm/markdown_translator.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
 import asyncio
+from dataclasses import dataclass
 import logging
 import re
 from importlib import resources
@@ -34,6 +35,18 @@ from co_op_translator.utils.common.metadata_utils import (
 logger = logging.getLogger(__name__)
 
 
+@dataclass(frozen=True)
+class ChunkAnchors:
+    """Control markers used to validate and rebuild one translated chunk."""
+
+    text: str
+    start_marker: str
+    end_marker: str
+    line_markers: list[str]
+    line_endings: list[str]
+    blank_lines: list[bool]
+
+
 class TranslationIncompleteError(RuntimeError):
     """Raised when a provider response does not complete the requested chunk."""
 
@@ -52,6 +65,7 @@ class MarkdownTranslator(ABC):
     DEFAULT_CHUNK_MAX_TOKENS = 2600
     RECOVERY_CHUNK_MAX_TOKENS = (1300, 650)
     CHUNK_RETRY_ATTEMPTS = 1
+    LINE_MARKER_RE = re.compile(r"@@LINE_(\d{4})@@")
     _disclaimer_templates_cache: dict[str, str] | None = None
 
     def __init__(
@@ -338,11 +352,17 @@ class MarkdownTranslator(ABC):
         index: int,
         total: int,
     ) -> str:
-        prompt = generate_prompt_template(language_code, language_name, chunk, is_rtl)
+        anchored_chunk = self._add_chunk_anchors(chunk, chunk_label)
+        prompt = generate_prompt_template(
+            language_code, language_name, anchored_chunk.text, is_rtl
+        )
         try:
-            return await asyncio.wait_for(
+            translated = await asyncio.wait_for(
                 self._run_prompt(prompt, index, total),
                 timeout=self.TRANSLATION_TIMEOUT_SECONDS,
+            )
+            return self._strip_chunk_anchors(
+                translated, anchored_chunk, md_file_path, chunk_label
             )
         except asyncio.TimeoutError as exc:
             logger.warning(
@@ -364,6 +384,107 @@ class MarkdownTranslator(ABC):
             raise RuntimeError(
                 f"Markdown translation failed for chunk {chunk_label} of '{md_file_path.name}': {e}"
             ) from e
+
+    def _add_chunk_anchors(self, chunk: str, chunk_label: str) -> ChunkAnchors:
+        """Wrap a markdown chunk with completion and per-line anchor markers."""
+        safe_label = self._safe_chunk_label(chunk_label)
+        start_marker = f"@@COOP_CHUNK_START:{safe_label}@@"
+        end_marker = f"@@COOP_CHUNK_END:{safe_label}@@"
+
+        line_markers: list[str] = []
+        line_endings: list[str] = []
+        blank_lines: list[bool] = []
+        anchored_parts = [start_marker, "\n"]
+
+        for line_index, source_line in enumerate(chunk.splitlines(keepends=True), 1):
+            line_content, line_ending = self._split_line_ending(source_line)
+            line_marker = f"@@LINE_{line_index:04d}@@"
+            line_markers.append(line_marker)
+            line_endings.append(line_ending)
+            blank_lines.append(line_content == "")
+
+            separator = " " if line_content else ""
+            anchored_parts.append(f"{line_marker}{separator}{line_content}")
+            anchored_parts.append(line_ending or "\n")
+
+        anchored_parts.append(end_marker)
+        return ChunkAnchors(
+            text="".join(anchored_parts),
+            start_marker=start_marker,
+            end_marker=end_marker,
+            line_markers=line_markers,
+            line_endings=line_endings,
+            blank_lines=blank_lines,
+        )
+
+    def _strip_chunk_anchors(
+        self,
+        translated: str,
+        anchors: ChunkAnchors,
+        md_file_path: Path,
+        chunk_label: str,
+    ) -> str:
+        """Validate completion/line anchors and remove them from a translation."""
+        start_pos = translated.find(anchors.start_marker)
+        end_pos = translated.find(anchors.end_marker)
+        if start_pos == -1 or end_pos == -1 or end_pos < start_pos:
+            raise TranslationIncompleteError(
+                f"Markdown translation for chunk {chunk_label} of '{md_file_path.name}' "
+                "did not preserve required chunk envelope markers."
+            )
+
+        body = translated[start_pos + len(anchors.start_marker) : end_pos]
+        marker_matches = list(self.LINE_MARKER_RE.finditer(body))
+        actual_markers = [match.group(0) for match in marker_matches]
+        if actual_markers != anchors.line_markers:
+            raise TranslationIncompleteError(
+                f"Markdown translation for chunk {chunk_label} of '{md_file_path.name}' "
+                "did not preserve required line anchor markers in order."
+            )
+
+        rebuilt_lines: list[str] = []
+        for line_index, match in enumerate(marker_matches):
+            segment_start = match.end()
+            segment_end = (
+                marker_matches[line_index + 1].start()
+                if line_index + 1 < len(marker_matches)
+                else len(body)
+            )
+            translated_line = body[segment_start:segment_end]
+            if anchors.blank_lines[line_index]:
+                rebuilt_lines.append(anchors.line_endings[line_index])
+                continue
+
+            cleaned_line = self._clean_anchored_line_segment(translated_line)
+            rebuilt_lines.append(cleaned_line + anchors.line_endings[line_index])
+
+        return "".join(rebuilt_lines)
+
+    @staticmethod
+    def _safe_chunk_label(chunk_label: str) -> str:
+        safe_label = re.sub(r"[^A-Za-z0-9_.-]", "_", chunk_label).strip("._-")
+        return safe_label or "chunk"
+
+    @staticmethod
+    def _split_line_ending(line: str) -> tuple[str, str]:
+        if line.endswith("\r\n"):
+            return line[:-2], "\r\n"
+        if line.endswith("\n"):
+            return line[:-1], "\n"
+        if line.endswith("\r"):
+            return line[:-1], "\r"
+        return line, ""
+
+    @staticmethod
+    def _clean_anchored_line_segment(segment: str) -> str:
+        had_line_break = "\n" in segment or "\r" in segment
+        cleaned = segment.strip("\r\n")
+        cleaned = re.sub(r"[ \t]*(?:\r\n|\r|\n)[ \t]*", " ", cleaned)
+        if cleaned.startswith(" "):
+            cleaned = cleaned[1:]
+        if not had_line_break and cleaned.endswith(" "):
+            cleaned = cleaned[:-1]
+        return cleaned
 
     def _split_failed_chunk(self, chunk: str, split_depth: int) -> list[str]:
         if split_depth >= len(self.RECOVERY_CHUNK_MAX_TOKENS):

--- a/src/co_op_translator/utils/llm/code_comment_translator.py
+++ b/src/co_op_translator/utils/llm/code_comment_translator.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 import logging
 import re
 from typing import Awaitable, Callable, Dict, List, Tuple
@@ -7,6 +8,16 @@ from co_op_translator.utils.markdown.constants import SPLIT_DELIMITER
 logger = logging.getLogger(__name__)
 
 RunPromptFunc = Callable[[str, int | str, int], Awaitable[str]]
+
+
+@dataclass(frozen=True)
+class MermaidSlot:
+    """A human-readable Mermaid span that can be translated in place."""
+
+    line_index: int
+    start: int
+    end: int
+    original: str
 
 
 async def translate_comments_in_code_blocks(
@@ -144,32 +155,233 @@ async def _translate_mermaid_block(
     """Translate human-readable text inside a Mermaid fenced code block.
 
     Preserves Mermaid syntax and structure (graph keywords, node IDs, arrows,
-    style/class definitions) while translating only labels and comments.
-    The entire fenced block is sent and expected back, so it can be restored
-    via the placeholder map without additional processing.
+    style/class definitions) while translating only labels and comments. The
+    block structure is never sent for rewriting; only extracted text slots are
+    translated and then injected back into the original lines.
     """
+    lines = code_block.splitlines(keepends=True)
+    slots = _extract_mermaid_slots(lines)
+    if not slots:
+        return code_block
+
+    translated_slots = await _translate_mermaid_slot_texts(
+        [slot.original for slot in slots],
+        language_code,
+        language_name,
+        is_rtl,
+        run_prompt,
+    )
+
+    if len(translated_slots) != len(slots):
+        return code_block
+
+    new_lines = list(lines)
+    slots_by_line: Dict[int, List[Tuple[int, MermaidSlot]]] = {}
+    for slot_index, slot in enumerate(slots):
+        slots_by_line.setdefault(slot.line_index, []).append((slot_index, slot))
+
+    for line_index, line_slots in slots_by_line.items():
+        line_content, line_ending = _split_line_ending(new_lines[line_index])
+        for slot_index, slot in sorted(
+            line_slots, key=lambda item: item[1].start, reverse=True
+        ):
+            translated_text = _sanitize_slot_translation(
+                translated_slots[slot_index], slot.original
+            )
+            line_content = (
+                line_content[: slot.start] + translated_text + line_content[slot.end :]
+            )
+        new_lines[line_index] = line_content + line_ending
+
+    return "".join(new_lines)
+
+
+def _extract_mermaid_slots(lines: List[str]) -> List[MermaidSlot]:
+    slots: List[MermaidSlot] = []
+    if len(lines) < 3:
+        return slots
+
+    for line_index in range(1, len(lines) - 1):
+        line_content, _ = _split_line_ending(lines[line_index])
+        for start, end in _extract_mermaid_line_spans(line_content):
+            text = line_content[start:end]
+            if _should_translate_mermaid_text(text):
+                slots.append(MermaidSlot(line_index, start, end, text))
+
+    return slots
+
+
+def _extract_mermaid_line_spans(line: str) -> List[Tuple[int, int]]:
+    stripped = line.strip()
+    if not stripped:
+        return []
+
+    if stripped.startswith(("%%{", "style ", "classDef ", "class ", "click ")):
+        return []
+    if stripped.startswith(("linkStyle ", "accTitle:", "accDescr:")):
+        return []
+    if stripped in {"end"}:
+        return []
+
+    spans: List[Tuple[int, int]] = []
+
+    if stripped.startswith("%%"):
+        comment_start = line.find("%%") + 2
+        while comment_start < len(line) and line[comment_start].isspace():
+            comment_start += 1
+        _append_mermaid_span(spans, comment_start, len(line))
+        return spans
+
+    participant_match = re.match(
+        r"^(\s*(?:participant|actor)\s+\S+\s+as\s+)(.+)$",
+        line,
+        flags=re.IGNORECASE,
+    )
+    if participant_match:
+        _append_mermaid_span(
+            spans,
+            participant_match.start(2),
+            participant_match.end(2),
+        )
+        return spans
+
+    note_match = re.match(
+        r"^(\s*note\s+(?:over|right of|left of)\s+[^:]+:\s*)(.+)$",
+        line,
+        flags=re.IGNORECASE,
+    )
+    if note_match:
+        _append_mermaid_span(spans, note_match.start(2), note_match.end(2))
+        return spans
+
+    control_match = re.match(
+        r"^(\s*(?:alt|else|opt|loop|par|and|critical|break)\s+)(.+)$",
+        line,
+        flags=re.IGNORECASE,
+    )
+    if control_match:
+        _append_mermaid_span(spans, control_match.start(2), control_match.end(2))
+        return spans
+
+    subgraph_match = re.match(r"^(\s*subgraph\s+)(.+)$", line, flags=re.IGNORECASE)
+    if subgraph_match and "[" not in subgraph_match.group(2):
+        _append_mermaid_span(spans, subgraph_match.start(2), subgraph_match.end(2))
+        return spans
+
+    if _looks_like_mermaid_message(line):
+        message_match = re.search(r":\s*(.+?)\s*;?\s*$", line)
+        if message_match:
+            _append_mermaid_span(spans, message_match.start(1), message_match.end(1))
+            return spans
+
+    for pattern in (
+        r"\|([^|\r\n]+)\|",
+        r"\[([^\]\r\n]+)\]",
+        r"\{([^}\r\n]+)\}",
+        r'"([^"\r\n]+)"',
+    ):
+        for match in re.finditer(pattern, line):
+            _append_mermaid_span(spans, match.start(1), match.end(1))
+
+    return spans
+
+
+def _append_mermaid_span(spans: List[Tuple[int, int]], start: int, end: int) -> None:
+    if start >= end:
+        return
+    for existing_start, existing_end in spans:
+        if start < existing_end and end > existing_start:
+            return
+    spans.append((start, end))
+
+
+def _looks_like_mermaid_message(line: str) -> bool:
+    return bool(re.search(r"(?:-{1,2}|=|x)?>>?|--\)|-\)|==", line))
+
+
+def _should_translate_mermaid_text(text: str) -> bool:
+    stripped = text.strip()
+    if not stripped:
+        return False
+    if stripped.startswith(("http://", "https://", "/", "./", "../")):
+        return False
+    if stripped.startswith("@@") and stripped.endswith("@@"):
+        return False
+    return True
+
+
+async def _translate_mermaid_slot_texts(
+    slot_texts: List[str],
+    language_code: str,
+    language_name: str,
+    is_rtl: bool,
+    run_prompt: RunPromptFunc,
+) -> List[str]:
     instruction = (
-        f"Translate the following Mermaid diagram code to {language_name} ({language_code}).\n"
-        "Preserve all Mermaid syntax and structure exactly, including keywords (graph, subgraph, end), "
-        "node IDs, arrows, style/class definitions, and URLs.\n"
-        'Only translate human-readable text, such as labels in square brackets [Like this], text inside quotes "Like this", '
-        "and comment text after %% markers.\n"
-        "Do not change node IDs, arrow syntax, style declarations, or URLs/paths.\n"
-        "Return only the translated Mermaid code block without any explanations or extra text.\n"
+        f"Translate the following Mermaid label/comment text to {language_name} ({language_code}).\n"
+        "Each line is in the form 'MERMAID_SLOT_n: <text>'.\n"
+        "Translate only the text after the colon into the target language.\n"
+        "Keep the 'MERMAID_SLOT_n:' prefix exactly the same and in English.\n"
+        "Return the same number of slots, with the same MERMAID_SLOT_n numbers.\n"
+        "Do not add, remove, or reorder slots.\n"
+        "Preserve URLs, file paths, inline HTML tags such as <br/>, and markdown/code tokens exactly.\n"
+        "Do not add any explanations or extra text.\n"
     )
 
     if is_rtl:
-        instruction += "Write the translated labels from right to left if appropriate for the language.\n"
+        instruction += "Write the translated labels and comments from right to left if appropriate for the language.\n"
     else:
-        instruction += "Write the translated labels from left to right.\n"
+        instruction += "Write the translated labels and comments from left to right.\n"
 
-    prompt = instruction + SPLIT_DELIMITER + code_block
+    user_lines = [
+        f"MERMAID_SLOT_{idx}: {text}" for idx, text in enumerate(slot_texts, start=1)
+    ]
+    prompt = instruction + SPLIT_DELIMITER + "\n".join(user_lines)
 
-    translated = await run_prompt(prompt, "mermaid", 1)
+    translated = await run_prompt(prompt, "mermaid_slots", 1)
     if not translated:
-        return code_block
+        return slot_texts
 
-    return _normalize_mermaid_fence_boundaries(translated, code_block)
+    return _parse_numbered_slot_response(translated, "MERMAID_SLOT", slot_texts)
+
+
+def _parse_numbered_slot_response(
+    translated: str, prefix: str, originals: List[str]
+) -> List[str]:
+    marker_pattern = re.compile(rf"\b{re.escape(prefix)}_(\d+):\s*")
+    matches = list(marker_pattern.finditer(translated))
+    if not matches:
+        return originals
+
+    mapping: Dict[int, str] = {}
+    for match_index, match in enumerate(matches):
+        slot_index = int(match.group(1))
+        text_start = match.end()
+        text_end = (
+            matches[match_index + 1].start()
+            if match_index + 1 < len(matches)
+            else len(translated)
+        )
+        mapping[slot_index] = translated[text_start:text_end].strip()
+
+    return [mapping.get(idx, original) for idx, original in enumerate(originals, 1)]
+
+
+def _sanitize_slot_translation(translated: str, fallback: str) -> str:
+    sanitized = re.sub(r"[ \t]*(?:\r\n|\r|\n)[ \t]*", " ", translated).strip()
+    if not sanitized or "MERMAID_SLOT_" in sanitized:
+        return fallback
+    return sanitized
+
+
+def _split_line_ending(line: str) -> Tuple[str, str]:
+    if line.endswith("\r\n"):
+        return line[:-2], "\r\n"
+    if line.endswith("\n"):
+        return line[:-1], "\n"
+    if line.endswith("\r"):
+        return line[:-1], "\r"
+    return line, ""
 
 
 def _normalize_mermaid_fence_boundaries(

--- a/src/co_op_translator/utils/markdown/prompts.py
+++ b/src/co_op_translator/utils/markdown/prompts.py
@@ -50,6 +50,8 @@ def generate_prompt_template(
             f"Translate the following text to {language_name} ({language_code}). "
             "STRICT RULE: Do NOT add, remove, or modify any markdown characters. "
             "Do NOT introduce HTML tags. Translate ONLY text content. "
+            "If tokens such as @@COOP_CHUNK_START:...@@, @@COOP_CHUNK_END:...@@, "
+            "@@LINE_0001@@, @@CODE_BLOCK_x@@, or @@INLINE_CODE_x@@ appear, keep them exactly. "
             "Return ONLY the translation."
         )
 
@@ -79,6 +81,7 @@ STRICT RULES (NO EXCEPTIONS):
      * Markdown syntax
      * Variable names, function names, class names
      * Placeholders like @@INLINE_CODE_x@@ and @@CODE_BLOCK_x@@
+     * Control markers like @@COOP_CHUNK_START:...@@, @@COOP_CHUNK_END:...@@, and @@LINE_0001@@
      * Tags such as [!NOTE], [!TIP], [!WARNING], [!IMPORTANT], [!CAUTION]
 
 3. HTML HANDLING RULES
@@ -103,6 +106,12 @@ STRICT RULES (NO EXCEPTIONS):
    - Do NOT remove blank lines.
    - Do NOT merge or split paragraphs.
    - Preserve whitespace, indentation, and list structure exactly.
+
+6. CONTROL MARKERS
+   - Markers matching @@COOP_CHUNK_START:...@@ and @@COOP_CHUNK_END:...@@ are required envelope markers.
+   - Markers matching @@LINE_0001@@ are required line anchors.
+   - Keep every marker exactly as written, exactly once, in the same order.
+   - Keep the translated content for each original line attached to its matching @@LINE_0001@@ marker.
 """
 
     # Direction rule (minimal + unambiguous)

--- a/tests/co_op_translator/core/llm/test_markdown_translator.py
+++ b/tests/co_op_translator/core/llm/test_markdown_translator.py
@@ -96,6 +96,36 @@ def real_markdown_translator(tmp_path):
     return ConcreteMarkdownTranslator(root_dir=tmp_path)
 
 
+def _translate_marked_prompt_body(prompt: str, replacements: dict[str, str]) -> str:
+    """Return the marked user body with requested text replacements applied."""
+    _, body = prompt.split(SPLIT_DELIMITER, 1)
+    for source, target in replacements.items():
+        body = body.replace(source, target)
+    return body
+
+
+def _translate_numbered_prompt_slots(
+    prompt: str,
+    prefix: str,
+    transform,
+) -> str:
+    _, user_part = prompt.split(SPLIT_DELIMITER, 1)
+    marker_pattern = re.compile(rf"\b{re.escape(prefix)}_(\d+):\s*")
+    matches = list(marker_pattern.finditer(user_part))
+    out_lines = []
+    for match_index, match in enumerate(matches):
+        slot_number = match.group(1)
+        text_start = match.end()
+        text_end = (
+            matches[match_index + 1].start()
+            if match_index + 1 < len(matches)
+            else len(user_part)
+        )
+        text = user_part[text_start:text_end].strip()
+        out_lines.append(f"{prefix}_{slot_number}: {transform(text)}")
+    return "\n".join(out_lines)
+
+
 @pytest.mark.asyncio
 async def test_generate_disclaimer_uses_packaged_language_template(
     real_markdown_translator,
@@ -210,10 +240,9 @@ async def test_translate_markdown_partial_mock(real_markdown_translator, tmp_pat
                 out_lines.append(f"{prefix}: [es]{text}[/es]")
             return "\n".join(out_lines)
         if "Sample Markdown" in prompt:
-            # Keep any code block placeholders in the translation
-            placeholder_match = re.search(r"@@CODE_BLOCK_\d+@@", prompt)
-            code_placeholder = placeholder_match.group(0) if placeholder_match else ""
-            return f"# Ejemplo de Markdown\n\n{code_placeholder}"
+            return _translate_marked_prompt_body(
+                prompt, {"# Sample Markdown": "# Ejemplo de Markdown"}
+            )
         if "Disclaimer" in prompt.lower():
             return "Aviso Legal: Este es un documento traducido."
         return prompt  # Return the original prompt for any other content
@@ -301,9 +330,9 @@ async def test_translate_markdown_translates_code_comments(
                 out_lines.append(f"{prefix}: [es]{text}[/es]")
             return "\n".join(out_lines)
         if "Sample Markdown" in prompt:
-            placeholder_match = re.search(r"@@CODE_BLOCK_\d+@@", prompt)
-            code_placeholder = placeholder_match.group(0) if placeholder_match else ""
-            return f"# Ejemplo de Markdown\n\n{code_placeholder}"
+            return _translate_marked_prompt_body(
+                prompt, {"# Sample Markdown": "# Ejemplo de Markdown"}
+            )
         if "Disclaimer" in prompt.lower():
             return "Aviso Legal: Este es un documento traducido."
         return prompt
@@ -339,21 +368,14 @@ async def test_translate_markdown_translates_mermaid_block(
 
     async def fake_prompt(prompt, index, total):
         # Mermaid-specific translation
-        if "Mermaid diagram code" in prompt:
-            _, code_block = prompt.split(SPLIT_DELIMITER, 1)
-            # Simulate translation by wrapping labels in [es]...[/es]
-            # We keep the overall Mermaid syntax intact.
-            translated = (
-                code_block.replace("Start", "[es]Start[/es]")
-                .replace("Decision", "[es]Decision[/es]")
-                .replace("Do it", "[es]Do it[/es]")
-                .replace("Stop", "[es]Stop[/es]")
+        if "MERMAID_SLOT_n" in prompt:
+            return _translate_numbered_prompt_slots(
+                prompt, "MERMAID_SLOT", lambda text: f"[es]{text}[/es]"
             )
-            return translated
         if "Sample Markdown" in prompt:
-            placeholder_match = re.search(r"@@CODE_BLOCK_\d+@@", prompt)
-            code_placeholder = placeholder_match.group(0) if placeholder_match else ""
-            return f"# Ejemplo de Markdown\n\n{code_placeholder}"
+            return _translate_marked_prompt_body(
+                prompt, {"# Sample Markdown": "# Ejemplo de Markdown"}
+            )
         if "Disclaimer" in prompt.lower():
             return "Aviso Legal: Este es un documento traducido."
         return prompt
@@ -388,13 +410,17 @@ async def test_translate_markdown_keeps_mermaid_closing_fence_separate_from_text
     test_file.write_text(TEST_MD_WITH_MERMAID_AND_PARAGRAPH)
 
     async def fake_prompt(prompt, index, total):
-        if "Mermaid diagram code" in prompt:
-            _, code_block = prompt.split(SPLIT_DELIMITER, 1)
-            return code_block.replace("Knowledge", "知識").replace("\n```\n", "```")
+        if "MERMAID_SLOT_n" in prompt:
+            return _translate_numbered_prompt_slots(
+                prompt, "MERMAID_SLOT", lambda text: text.replace("Knowledge", "知識")
+            )
         if "Sample Markdown" in prompt:
-            _, body = prompt.split(SPLIT_DELIMITER, 1)
-            return body.replace("# Sample Markdown", "# サンプル Markdown").replace(
-                "Universal connector text.", "ユニバーサルコネクターにより"
+            return _translate_marked_prompt_body(
+                prompt,
+                {
+                    "# Sample Markdown": "# サンプル Markdown",
+                    "Universal connector text.": "ユニバーサルコネクターにより",
+                },
             )
         if "Disclaimer" in prompt.lower():
             return "Aviso Legal: Este es un documento traducido."
@@ -480,16 +506,14 @@ async def test_translate_markdown_keeps_internal_links_inside_code_blocks_unchan
             return "Aviso Legal: Este es un documento traducido."
 
         if "# Sample" in prompt:
-            placeholder_match = re.search(r"@@CODE_BLOCK_\d+@@", prompt)
-            code_placeholder = placeholder_match.group(0) if placeholder_match else ""
-            return """# 샘플
-
-- [섹션 1](#section-one)
-
-## 섹션 1
-
-{code_placeholder}
-""".format(code_placeholder=code_placeholder)
+            return _translate_marked_prompt_body(
+                prompt,
+                {
+                    "# Sample": "# 샘플",
+                    "- [Section One](#section-one)": "- [섹션 1](#section-one)",
+                    "## Section One": "## 섹션 1",
+                },
+            )
 
         return prompt
 
@@ -509,6 +533,64 @@ async def test_translate_markdown_keeps_internal_links_inside_code_blocks_unchan
 
 
 @pytest.mark.asyncio
+async def test_translate_markdown_rebuilds_lines_from_collapsed_anchor_output(
+    real_markdown_translator,
+):
+    """Line anchors allow recovery when a provider merges markdown lines."""
+
+    document = "# Title\n\nFirst paragraph.  \nSecond paragraph.\n"
+
+    async def fake_prompt(prompt, index, total):
+        if "# Title" in prompt:
+            body = _translate_marked_prompt_body(
+                prompt,
+                {
+                    "# Title": "# Titulo",
+                    "First paragraph.": "Primer parrafo.",
+                    "Second paragraph.": "Segundo parrafo.",
+                },
+            )
+            return " ".join(body.splitlines())
+        return prompt
+
+    with patch.object(
+        real_markdown_translator, "_run_prompt", new_callable=AsyncMock
+    ) as mock_run_prompt:
+        mock_run_prompt.side_effect = fake_prompt
+
+        result = await real_markdown_translator.translate_markdown(document, "es")
+
+    assert result == "# Titulo\n\nPrimer parrafo.  \nSegundo parrafo.\n"
+    assert "@@COOP_CHUNK_START" not in result
+    assert "@@LINE_" not in result
+
+
+@pytest.mark.asyncio
+async def test_translate_markdown_missing_chunk_end_marker_is_incomplete(
+    real_markdown_translator,
+):
+    """Missing envelope markers should be treated as incomplete responses."""
+
+    calls = 0
+
+    async def fake_prompt(prompt, index, total):
+        nonlocal calls
+        calls += 1
+        _, body = prompt.split(SPLIT_DELIMITER, 1)
+        return re.sub(r"@@COOP_CHUNK_END:[^@]+@@", "", body)
+
+    with patch.object(
+        real_markdown_translator, "_run_prompt", new_callable=AsyncMock
+    ) as mock_run_prompt:
+        mock_run_prompt.side_effect = fake_prompt
+
+        with pytest.raises(TranslationIncompleteError):
+            await real_markdown_translator.translate_markdown("# Title\n", "es")
+
+    assert calls == 2
+
+
+@pytest.mark.asyncio
 async def test_translate_markdown_retries_incomplete_chunk_once(
     real_markdown_translator,
     tmp_path,
@@ -523,7 +605,10 @@ async def test_translate_markdown_retries_incomplete_chunk_once(
             calls += 1
             if calls == 1:
                 raise TranslationIncompleteError("length")
-            return "# Reintentar\n\nTexto estable.\n"
+            return _translate_marked_prompt_body(
+                prompt,
+                {"# Retry me": "# Reintentar", "Stable text.": "Texto estable."},
+            )
         return prompt
 
     with patch.object(
@@ -567,13 +652,18 @@ async def test_translate_markdown_splits_incomplete_chunk_after_retry(
 
     async def fake_prompt(prompt, index, total):
         nonlocal original_failures
-        if "First part.\n\nSecond part." in prompt:
+        if "First part." in prompt and "Second part." in prompt:
             original_failures += 1
             raise TranslationIncompleteError("length")
         if "First part." in prompt:
-            return "# Dividido\n\nPrimera parte.\n"
+            return _translate_marked_prompt_body(
+                prompt,
+                {"# Needs split": "# Dividido", "First part.": "Primera parte."},
+            )
         if "Second part." in prompt:
-            return "Segunda parte.\n"
+            return _translate_marked_prompt_body(
+                prompt, {"Second part.": "Segunda parte."}
+            )
         return prompt
 
     with patch.object(
@@ -654,5 +744,5 @@ async def test_translate_markdown_full_integration(real_markdown_translator, tmp
         'print("Hello, world!")' in result
     ), "Even in a full integration scenario, the code block should remain."
     assert (
-        "[Default Translation]" in result
-    ), "Expected the default translation text in the output."
+        "@@LINE_" not in result
+    ), "Expected chunk line anchors to be stripped from the output."

--- a/tests/co_op_translator/utils/llm/test_code_comment_translator.py
+++ b/tests/co_op_translator/utils/llm/test_code_comment_translator.py
@@ -7,6 +7,24 @@ from co_op_translator.utils.llm.code_comment_translator import (
 from co_op_translator.utils.markdown.constants import SPLIT_DELIMITER
 
 
+def _translate_numbered_prompt_slots(prompt: str, prefix: str, transform) -> str:
+    _, user_part = prompt.split(SPLIT_DELIMITER, 1)
+    marker_pattern = re.compile(rf"\b{re.escape(prefix)}_(\d+):\s*")
+    matches = list(marker_pattern.finditer(user_part))
+    out_lines = []
+    for match_index, match in enumerate(matches):
+        slot_number = match.group(1)
+        text_start = match.end()
+        text_end = (
+            matches[match_index + 1].start()
+            if match_index + 1 < len(matches)
+            else len(user_part)
+        )
+        text = user_part[text_start:text_end].strip()
+        out_lines.append(f"{prefix}_{slot_number}: {transform(text)}")
+    return "\n".join(out_lines)
+
+
 @pytest.mark.asyncio
 async def test_translate_comments_in_code_blocks_python_comments():
     """Translate only # comments inside a fenced python code block."""
@@ -71,15 +89,10 @@ async def test_translate_comments_in_code_blocks_mermaid_block():
 
     async def fake_run_prompt(prompt, index, total):
         # Mermaid-specific translation
-        if "Mermaid diagram code" in prompt:
-            _, code_block = prompt.split(SPLIT_DELIMITER, 1)
-            translated = (
-                code_block.replace("Start", "[es]Start[/es]")
-                .replace("Decision", "[es]Decision[/es]")
-                .replace("Do it", "[es]Do it[/es]")
-                .replace("Stop", "[es]Stop[/es]")
+        if "MERMAID_SLOT_n" in prompt:
+            return _translate_numbered_prompt_slots(
+                prompt, "MERMAID_SLOT", lambda text: f"[es]{text}[/es]"
             )
-            return translated
         return prompt
 
     result_map = await translate_comments_in_code_blocks(
@@ -118,9 +131,10 @@ async def test_translate_comments_in_code_blocks_mermaid_restores_fence_newlines
     }
 
     async def fake_run_prompt(prompt, index, total):
-        if "Mermaid diagram code" in prompt:
-            _, code_block = prompt.split(SPLIT_DELIMITER, 1)
-            return code_block.replace("Knowledge", "知識").replace("\n```\n", "```")
+        if "MERMAID_SLOT_n" in prompt:
+            return _translate_numbered_prompt_slots(
+                prompt, "MERMAID_SLOT", lambda text: text.replace("Knowledge", "知識")
+            )
         return prompt
 
     result_map = await translate_comments_in_code_blocks(
@@ -135,6 +149,46 @@ async def test_translate_comments_in_code_blocks_mermaid_restores_fence_newlines
 
     assert "end\n```\n" in translated_block
     assert "end```" not in translated_block
+
+
+@pytest.mark.asyncio
+async def test_translate_comments_in_code_blocks_mermaid_collapsed_slot_response():
+    """Collapsed Mermaid slot responses must not collapse the diagram block."""
+
+    original_block = (
+        "```mermaid\n"
+        "sequenceDiagram\n"
+        "    participant WebApp as Web App<br/>(ContentSafetyController)\n"
+        "    WebApp->>MCP: Send text for moderation\n"
+        "    MCP-->>WebApp: Return decision\n"
+        "```\n"
+    )
+    placeholder_map = {"@@CODE_BLOCK_0@@": original_block}
+
+    async def fake_run_prompt(prompt, index, total):
+        if "MERMAID_SLOT_n" in prompt:
+            translated = _translate_numbered_prompt_slots(
+                prompt, "MERMAID_SLOT", lambda text: f"[ko]{text}[/ko]"
+            )
+            return " ".join(translated.splitlines())
+        return prompt
+
+    result_map = await translate_comments_in_code_blocks(
+        placeholder_map,
+        language_code="ko",
+        language_name="Korean",
+        is_rtl=False,
+        run_prompt=fake_run_prompt,
+    )
+
+    translated_block = result_map["@@CODE_BLOCK_0@@"]
+
+    assert translated_block.count("\n") == original_block.count("\n")
+    assert "sequenceDiagram\n" in translated_block
+    assert "```mermaid\n" in translated_block
+    assert "```\n" in translated_block
+    assert "[ko]Send text for moderation[/ko]" in translated_block
+    assert "[ko]Return decision[/ko]" in translated_block
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Purpose

Improve markdown translation reliability when an LLM response completes normally but still drops or merges markdown line structure. This addresses failures where file-level retry repeats the same translation path and reproduces the same line-loss problem.

## Description

- Add chunk envelope markers and per-line anchors around markdown chunks before translation.
- Validate the returned envelope and line anchor order, then strip/rebuild output from the anchors so collapsed line output can recover original structure.
- Treat missing envelope or line markers as `TranslationIncompleteError`, allowing existing chunk recovery to retry/split instead of accepting structurally incomplete output.
- Update markdown prompts to preserve the new control markers exactly.
- Change Mermaid fenced block handling to translate extracted label/comment slots and inject them back into the original Mermaid block, preserving diagram lines and fences.
- Add regression tests for collapsed anchor output, missing chunk end markers, and collapsed Mermaid slot responses.

## Related Issue

N/A

## Does this introduce a breaking change?

Will this change require users to update commands, configuration, environment variables, generated translation output, or public Python/MCP APIs?
If you're not sure, test the affected CLI, API, documentation, or GitHub Actions workflow before marking this as "No."

- [ ] Yes
- [x] No

## Type of change

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (e.g., formatting, local variables)
- [ ] Refactoring (no functional or API changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Checklist

Before submitting your pull request, please confirm the following:

- [x] **I have thoroughly tested my changes**: I confirm that I have run the code and manually tested all affected areas.
- [ ] **All existing tests pass**: I have run all tests and confirmed that nothing is broken.
- [x] **I have added new tests** (if applicable): I have written tests that cover the new functionality introduced by my code changes.
- [x] **I have followed the Co-op Translator coding conventions**: My code adheres to the style guide and coding conventions outlined in the repository.
- [ ] **I have documented my changes** (if applicable): I have updated the documentation to reflect the changes where necessary.

## Additional context

Validation run locally:

- `python -m pytest tests/co_op_translator/core/llm/test_markdown_translator.py tests/co_op_translator/utils/llm/test_code_comment_translator.py` -> 25 passed
- `python -m ruff check src/co_op_translator/core/llm/markdown_translator.py src/co_op_translator/utils/llm/code_comment_translator.py src/co_op_translator/utils/markdown/prompts.py tests/co_op_translator/core/llm/test_markdown_translator.py tests/co_op_translator/utils/llm/test_code_comment_translator.py` -> passed
- `python -m black --check src/co_op_translator/core/llm/markdown_translator.py src/co_op_translator/utils/llm/code_comment_translator.py src/co_op_translator/utils/markdown/prompts.py tests/co_op_translator/core/llm/test_markdown_translator.py tests/co_op_translator/utils/llm/test_code_comment_translator.py` -> passed
- `git diff --check` -> passed

Full `python -m pytest` was also attempted. It reached `306 passed` but had `3 failed, 2 errors` in project translator tests because the local environment initializes Azure OpenAI without `chat_deployment_name`; those failures appear unrelated to this markdown/Mermaid change.
