### PR TITLE
Build: Fix labeler v6 configuration

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,25 +1,35 @@
 # Apply 'core' label for any changes in the core source files
 core:
-  - src/co_op_translator/core/**/*
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/co_op_translator/core/**/*
 
 # Apply 'language-support' label for changes related to font configurations or language support
 language-support:
-  - src/co_op_translator/fonts/**/*
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/co_op_translator/fonts/**/*
 
 # Apply 'tests' label for any changes in the test files
 tests:
-  - tests/**/*
+  - changed-files:
+      - any-glob-to-any-file:
+          - tests/**/*
 
-# Apply 'documentation' label for any changes in the documentation files, markdown files, or GitHub issue/PR templates
+# Apply 'documentation' label for changes in the documentation files, markdown files, or GitHub issue/PR templates
 documentation:
-  - docs/**/*
-  - '**/*.md'
-  - .github/ISSUE_TEMPLATE/**
-  - .github/PULL_REQUEST_TEMPLATE.md
+  - changed-files:
+      - any-glob-to-any-file:
+          - docs/**/*
+          - '**/*.md'
+          - .github/ISSUE_TEMPLATE/**
+          - .github/PULL_REQUEST_TEMPLATE.md
 
-# Apply 'build' label for any changes in the build configuration files, CI workflows, or Dockerfile
+# Apply 'build' label for changes in the build configuration files, CI workflows, or Dockerfile
 build:
-  - pyproject.toml
-  - requirements.txt
-  - Dockerfile
-  - .github/workflows/**
+  - changed-files:
+      - any-glob-to-any-file:
+          - pyproject.toml
+          - requirements.txt
+          - Dockerfile
+          - .github/workflows/**


### PR DESCRIPTION
## Purpose

Fix the pull request labeler workflow after the repository upgraded to `actions/labeler@v6`.

## Description

The labeler workflow currently fails with:

`found unexpected type for label 'core' (should be array of config options)`

The workflow was upgraded from `actions/labeler@v4` to `@v6`, but `.github/labeler.yml` still used the legacy `label: [glob]` configuration shape. This PR converts the existing label rules to the v5/v6 match-object schema using `changed-files` and `any-glob-to-any-file`, without changing the intended label mappings.

## Related Issue

N/A

## Does this introduce a breaking change?

Will this change require users to update commands, configuration, environment variables, generated translation output, or public Python/MCP APIs?
If you're not sure, test the affected CLI, API, documentation, or GitHub Actions workflow before marking this as "No."

- [ ] Yes
- [x] No

## Type of change

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (e.g., formatting, local variables)
- [ ] Refactoring (no functional or API changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Checklist

Before submitting your pull request, please confirm the following:

- [x] **I have thoroughly tested my changes**: I confirm that I have run the code and manually tested all affected areas.
- [ ] **All existing tests pass**: I have run all tests and confirmed that nothing is broken.
- [ ] **I have added new tests** (if applicable): I have written tests that cover the new functionality introduced by my code changes.
- [x] **I have followed the Co-op Translator coding conventions**: My code adheres to the style guide and coding conventions outlined in the repository.
- [ ] **I have documented my changes** (if applicable): I have updated the documentation to reflect the changes where necessary.

## Additional context

Validation run locally:

- Parsed `.github/labeler.yml` with Python/YAML and asserted each label maps to an array of match objects.
- `git diff --check upstream/main..HEAD` -> passed.

This change is limited to `.github/labeler.yml` and preserves the existing labels and glob patterns while updating only the configuration schema expected by `actions/labeler@v6`.
