### PR TITLE
Core: Preserve markdown translations on failure

### DIFF
--- a/src/co_op_translator/core/project/translation/project_markdown_translation.py
+++ b/src/co_op_translator/core/project/translation/project_markdown_translation.py
@@ -1,16 +1,24 @@
 from __future__ import annotations
 
 import logging
+import tempfile
 from pathlib import Path
 
 from co_op_translator.config.constants import SUPPORTED_MARKDOWN_EXTENSIONS
+from co_op_translator.core.llm.markdown_translator import (
+    TranslationContentFilterError,
+    TranslationIncompleteError,
+)
 from co_op_translator.utils.common.file_utils import (
-    delete_translated_markdown_files_by_language_code,
     filter_files,
     handle_empty_document,
     read_input_file,
 )
-from co_op_translator.utils.common.metadata_utils import save_text_metadata_for_source
+from co_op_translator.utils.common.metadata_utils import (
+    save_text_failure_metadata_for_source,
+    save_text_metadata_for_source,
+    should_retry_text_failure_for_source,
+)
 from co_op_translator.utils.markdown.path_rewriter import (
     MarkdownPathRewritePolicy,
     rewrite_markdown_paths,
@@ -55,6 +63,50 @@ class ProjectMarkdownTranslationMixin:
                 translation_types=self.translation_types,
                 lang_subdir=self.lang_subdir,
             ),
+        )
+
+    def _write_markdown_translation(
+        self, translated_path: Path, translated_content: str
+    ) -> None:
+        translated_path.parent.mkdir(parents=True, exist_ok=True)
+        temp_path = None
+        try:
+            with tempfile.NamedTemporaryFile(
+                "w",
+                encoding="utf-8",
+                dir=translated_path.parent,
+                prefix=f".{translated_path.name}.",
+                suffix=".tmp",
+                delete=False,
+            ) as temp_file:
+                temp_file.write(translated_content)
+                temp_path = Path(temp_file.name)
+
+            temp_path.replace(translated_path)
+        finally:
+            if temp_path and temp_path.exists():
+                try:
+                    temp_path.unlink()
+                except Exception:
+                    logger.debug("Failed to remove temporary file: %s", temp_path)
+
+    def _should_record_markdown_failure(self, error: Exception) -> bool:
+        if isinstance(
+            error, (TranslationIncompleteError, TranslationContentFilterError)
+        ):
+            return True
+
+        if not isinstance(error, RuntimeError):
+            return False
+
+        error_message = str(error)
+        return any(
+            message in error_message
+            for message in (
+                "Markdown translation returned empty content",
+                "Markdown translation retry returned empty content",
+                "Markdown translation retry produced incomplete content",
+            )
         )
 
     async def translate_markdown(self, file_path: Path, language_code: str) -> str:
@@ -122,11 +174,8 @@ class ProjectMarkdownTranslationMixin:
                 translated_content, language_code
             )
 
-            translated_path.parent.mkdir(parents=True, exist_ok=True)
-
             try:
-                with open(translated_path, "w", encoding="utf-8") as f:
-                    f.write(translated_content)
+                self._write_markdown_translation(translated_path, translated_content)
                 logger.info(
                     f"Translated {file_path} to {language_code} and saved to {translated_path}"
                 )
@@ -144,7 +193,30 @@ class ProjectMarkdownTranslationMixin:
 
         except Exception as e:
             logger.error(f"Failed to translate {file_path}: {e}")
-            raise
+            if not self._should_record_markdown_failure(e):
+                return ""
+
+            try:
+                lang_dir = self._get_language_root(language_code)
+                save_text_failure_metadata_for_source(
+                    lang_dir,
+                    file_path,
+                    language_code,
+                    root_dir=self.root_dir,
+                    error=e,
+                )
+                logger.warning(
+                    "Recorded failed markdown translation for %s in %s",
+                    file_path,
+                    lang_dir / ".co-op-translator.json",
+                )
+            except Exception as metadata_error:
+                logger.warning(
+                    "Failed to record markdown translation failure for %s: %s",
+                    file_path,
+                    metadata_error,
+                )
+            return ""
 
     async def translate_all_markdown_files(
         self, update: bool = False
@@ -153,15 +225,6 @@ class ProjectMarkdownTranslationMixin:
 
         modified_count = 0
         errors = []
-
-        if update:
-            for language_code in self.language_codes:
-                delete_translated_markdown_files_by_language_code(
-                    language_code, self.translations_dir, self.lang_subdir
-                )
-                logger.info(
-                    f"Deleted all translated markdown files for language: {language_code}"
-                )
 
         markdown_files = filter_files(self.root_dir, self.excluded_dirs)
         tasks = []
@@ -178,6 +241,18 @@ class ProjectMarkdownTranslationMixin:
                 translated_md_path = (
                     self._get_language_root(language_code) / relative_path
                 )
+
+                if not update and not should_retry_text_failure_for_source(
+                    self._get_language_root(language_code),
+                    md_file_path,
+                    language_code,
+                ):
+                    logger.info(
+                        "Skipping previously failed markdown file until source or "
+                        "translator changes: %s",
+                        md_file_path,
+                    )
+                    continue
 
                 if not update and translated_md_path.exists():
                     logger.info(

--- a/src/co_op_translator/utils/common/metadata_utils.py
+++ b/src/co_op_translator/utils/common/metadata_utils.py
@@ -7,10 +7,15 @@ import json
 import logging
 import threading
 from datetime import datetime
+from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 from typing import Dict, Any, Optional
 
 logger = logging.getLogger(__name__)
+
+TEXT_TRANSLATION_FAILURES_KEY = "__translation_failures__"
+TEXT_TRANSLATION_FAILURE_POLICY_VERSION = 1
+_MAX_FAILURE_MESSAGE_LENGTH = 1000
 
 
 def calculate_file_hash(file_path: Path) -> str:
@@ -577,6 +582,15 @@ def _normalize_source_key(source: str | Path) -> str:
     return str(source).replace("\\", "/")
 
 
+def _get_co_op_translator_version() -> str:
+    try:
+        return version("co_op_translator")
+    except PackageNotFoundError:
+        return "unknown"
+    except Exception:
+        return "unknown"
+
+
 def load_language_metadata(lang_dir: Path) -> dict:
     return _load_lang_metadata(lang_dir)
 
@@ -610,6 +624,15 @@ def save_text_metadata_for_source(
     with lock:
         all_metadata = _load_lang_metadata(lang_dir)
         all_metadata[normalized_key] = metadata
+
+        failures = all_metadata.get(TEXT_TRANSLATION_FAILURES_KEY)
+        if isinstance(failures, dict) and normalized_key in failures:
+            del failures[normalized_key]
+            if failures:
+                all_metadata[TEXT_TRANSLATION_FAILURES_KEY] = failures
+            else:
+                all_metadata.pop(TEXT_TRANSLATION_FAILURES_KEY, None)
+
         _save_lang_metadata(lang_dir, all_metadata)
 
     return metadata
@@ -666,6 +689,132 @@ def read_text_metadata_for_source(lang_dir: Path, source_file: str | Path) -> di
     return {}
 
 
+def _create_text_failure_metadata(
+    original_file: Path,
+    language_code: str,
+    error: Exception | None = None,
+    root_dir: Path | None = None,
+    translator_version: str | None = None,
+    policy_version: int = TEXT_TRANSLATION_FAILURE_POLICY_VERSION,
+) -> dict:
+    metadata = create_metadata(original_file, language_code, root_dir)
+    metadata["failure_date"] = metadata.pop("translation_date")
+    metadata["status"] = "failed"
+    metadata["error_type"] = error.__class__.__name__ if error else "TranslationError"
+    metadata["error_message"] = str(error or "")[:_MAX_FAILURE_MESSAGE_LENGTH]
+    metadata["translator_version"] = (
+        translator_version or _get_co_op_translator_version()
+    )
+    metadata["failure_policy_version"] = policy_version
+    return metadata
+
+
+def save_text_failure_metadata_for_source(
+    lang_dir: Path,
+    original_file: Path,
+    language_code: str,
+    root_dir: Path | None = None,
+    error: Exception | None = None,
+    translator_version: str | None = None,
+    policy_version: int = TEXT_TRANSLATION_FAILURE_POLICY_VERSION,
+) -> dict:
+    metadata = _create_text_failure_metadata(
+        original_file,
+        language_code,
+        error=error,
+        root_dir=root_dir,
+        translator_version=translator_version,
+        policy_version=policy_version,
+    )
+    source_key = metadata.get("source_file")
+    if not source_key:
+        return metadata
+
+    normalized_key = _normalize_source_key(source_key)
+
+    lock = _get_lock_for_path(_get_metadata_file_path(lang_dir))
+    with lock:
+        all_metadata = _load_lang_metadata(lang_dir)
+        failures = all_metadata.get(TEXT_TRANSLATION_FAILURES_KEY)
+        if not isinstance(failures, dict):
+            failures = {}
+
+        failures[normalized_key] = metadata
+        all_metadata[TEXT_TRANSLATION_FAILURES_KEY] = failures
+        _save_lang_metadata(lang_dir, all_metadata)
+
+    return metadata
+
+
+def _read_text_failure_metadata_for_source(
+    lang_dir: Path, source_file: str | Path
+) -> dict:
+    all_metadata = _load_lang_metadata(lang_dir)
+    failures = all_metadata.get(TEXT_TRANSLATION_FAILURES_KEY, {})
+    if not isinstance(failures, dict):
+        return {}
+
+    normalized = _normalize_source_key(source_file)
+    if normalized in failures:
+        entry = failures.get(normalized, {})
+        return entry if isinstance(entry, dict) else {}
+
+    looks_absolute = False
+    try:
+        if isinstance(source_file, Path):
+            looks_absolute = source_file.is_absolute()
+        else:
+            source_text = str(source_file)
+            if len(source_text) >= 2 and source_text[1] == ":":
+                looks_absolute = True
+            elif source_text.startswith("/") or source_text.startswith("\\"):
+                looks_absolute = True
+    except Exception:
+        looks_absolute = False
+
+    if not looks_absolute:
+        return {}
+
+    parts = normalized.split("/")
+    best_key = None
+    best_len = -1
+    for i in range(len(parts)):
+        suffix = "/".join(parts[i:])
+        if suffix in failures and len(suffix) > best_len:
+            best_key = suffix
+            best_len = len(suffix)
+
+    if best_key is None:
+        return {}
+
+    entry = failures.get(best_key, {})
+    return entry if isinstance(entry, dict) else {}
+
+
+def should_retry_text_failure_for_source(
+    lang_dir: Path,
+    original_file: Path,
+    language_code: str,
+    translator_version: str | None = None,
+    policy_version: int = TEXT_TRANSLATION_FAILURE_POLICY_VERSION,
+) -> bool:
+    failure = _read_text_failure_metadata_for_source(lang_dir, original_file)
+    if not failure:
+        return True
+
+    if failure.get("original_hash") != calculate_file_hash(original_file):
+        return True
+
+    if failure.get("language_code") != language_code:
+        return True
+
+    current_version = translator_version or _get_co_op_translator_version()
+    if failure.get("translator_version") != current_version:
+        return True
+
+    return failure.get("failure_policy_version") != policy_version
+
+
 def remove_text_metadata_for_source(lang_dir: Path, source_file: str | Path) -> None:
     normalized_key = _normalize_source_key(source_file)
     lock = _get_lock_for_path(_get_metadata_file_path(lang_dir))
@@ -709,6 +858,8 @@ def normalize_language_codes_in_lang_metadata(
             return 0
         changed = 0
         for k, v in list(data.items()):
+            if k == TEXT_TRANSLATION_FAILURES_KEY:
+                continue
             if isinstance(v, dict) and v.get("language_code") != canonical_code:
                 v["language_code"] = canonical_code
                 changed += 1

--- a/tests/co_op_translator/core/project/test_translation_manager.py
+++ b/tests/co_op_translator/core/project/test_translation_manager.py
@@ -342,16 +342,12 @@ async def test_translate_markdown_does_not_save_incomplete_retry(
     result = await translation_manager.translate_markdown(source_file, "ko")
 
     translated_file = temp_project_dir / "translations" / "ko" / "docs" / "test.md"
-    metadata_file = (
-        temp_project_dir / "translations" / "ko" / ".co-op-translator.json"
-    )
+    metadata_file = temp_project_dir / "translations" / "ko" / ".co-op-translator.json"
     metadata = json.loads(metadata_file.read_text(encoding="utf-8"))
 
     assert result == ""
     assert not translated_file.exists()
-    assert (
-        metadata[TEXT_TRANSLATION_FAILURES_KEY]["docs/test.md"]["status"] == "failed"
-    )
+    assert metadata[TEXT_TRANSLATION_FAILURES_KEY]["docs/test.md"]["status"] == "failed"
     assert (
         metadata[TEXT_TRANSLATION_FAILURES_KEY]["docs/test.md"]["error_type"]
         == "RuntimeError"
@@ -454,10 +450,9 @@ async def test_translate_all_markdown_update_keeps_previous_translation_on_failu
     ]
     assert translated_file.read_text(encoding="utf-8") == "# Previous translation\n"
     assert metadata["docs/test.md"]["original_hash"] == old_hash
-    assert (
-        metadata[TEXT_TRANSLATION_FAILURES_KEY]["docs/test.md"]["original_hash"]
-        == calculate_file_hash(source_file)
-    )
+    assert metadata[TEXT_TRANSLATION_FAILURES_KEY]["docs/test.md"][
+        "original_hash"
+    ] == calculate_file_hash(source_file)
 
 
 @pytest.mark.asyncio

--- a/tests/co_op_translator/core/project/test_translation_manager.py
+++ b/tests/co_op_translator/core/project/test_translation_manager.py
@@ -7,7 +7,11 @@ from PIL import Image
 
 from co_op_translator.core.project.translation import TranslationManager
 from co_op_translator.utils.common.file_utils import generate_translated_filename
-from co_op_translator.utils.common.metadata_utils import calculate_file_hash
+from co_op_translator.utils.common.metadata_utils import (
+    TEXT_TRANSLATION_FAILURES_KEY,
+    calculate_file_hash,
+    save_text_failure_metadata_for_source,
+)
 
 
 class FakeMarkdownTranslator:
@@ -324,35 +328,179 @@ def test_get_outdated_translations_detects_truncated_current_hash(
 
 
 @pytest.mark.asyncio
-async def test_translate_markdown_does_not_save_incomplete_retry(temp_project_dir):
+async def test_translate_markdown_does_not_save_incomplete_retry(
+    translation_manager, temp_project_dir
+):
     source_file = temp_project_dir / "docs" / "test.md"
     source_file.write_text(
         "\n".join(f"Line {index}" for index in range(40)) + "\n",
         encoding="utf-8",
     )
-    translation_manager = TranslationManager(
-        root_dir=temp_project_dir,
-        translations_dir=temp_project_dir / "translations",
-        image_dir=temp_project_dir / "translated_images",
-        language_codes=["ko"],
-        excluded_dirs=["translations", "translated_images", "logs"],
-        supported_image_extensions=[".png"],
-        supported_notebook_extensions=[".ipynb"],
-        markdown_translator=FakeTruncatingMarkdownTranslator(),
-        image_translator=FakeImageTranslator(),
-        notebook_translator=FakeNotebookTranslator(),
-        translation_types=["markdown"],
-        add_disclaimer=False,
-    )
+    translation_manager.language_codes = ["ko"]
+    translation_manager.markdown_translator = FakeTruncatingMarkdownTranslator()
 
-    with pytest.raises(RuntimeError, match="incomplete content"):
-        await translation_manager.translate_markdown(source_file, "ko")
+    result = await translation_manager.translate_markdown(source_file, "ko")
 
     translated_file = temp_project_dir / "translations" / "ko" / "docs" / "test.md"
-    assert not translated_file.exists()
-    assert not (
+    metadata_file = (
         temp_project_dir / "translations" / "ko" / ".co-op-translator.json"
-    ).exists()
+    )
+    metadata = json.loads(metadata_file.read_text(encoding="utf-8"))
+
+    assert result == ""
+    assert not translated_file.exists()
+    assert (
+        metadata[TEXT_TRANSLATION_FAILURES_KEY]["docs/test.md"]["status"] == "failed"
+    )
+    assert (
+        metadata[TEXT_TRANSLATION_FAILURES_KEY]["docs/test.md"]["error_type"]
+        == "RuntimeError"
+    )
+
+
+@pytest.mark.asyncio
+async def test_translate_all_markdown_skips_unchanged_previous_failure(
+    translation_manager, temp_project_dir
+):
+    source_file = temp_project_dir / "docs" / "test.md"
+    lang_dir = temp_project_dir / "translations" / "ko"
+    markdown_translator = FakeMarkdownTranslator()
+    save_text_failure_metadata_for_source(
+        lang_dir,
+        source_file,
+        "ko",
+        root_dir=temp_project_dir,
+        error=RuntimeError("previous incomplete translation"),
+    )
+    translation_manager.language_codes = ["ko"]
+    translation_manager.markdown_translator = markdown_translator
+
+    modified_count, errors = await translation_manager.translate_all_markdown_files()
+
+    assert modified_count == 0
+    assert errors == []
+    assert markdown_translator.calls == []
+
+
+@pytest.mark.asyncio
+async def test_translate_all_markdown_retries_failure_after_version_change(
+    translation_manager, temp_project_dir
+):
+    source_file = temp_project_dir / "docs" / "test.md"
+    lang_dir = temp_project_dir / "translations" / "ko"
+    markdown_translator = FakeMarkdownTranslator()
+    save_text_failure_metadata_for_source(
+        lang_dir,
+        source_file,
+        "ko",
+        root_dir=temp_project_dir,
+        error=RuntimeError("previous incomplete translation"),
+        translator_version="old-version",
+    )
+    translation_manager.language_codes = ["ko"]
+    translation_manager.markdown_translator = markdown_translator
+
+    modified_count, errors = await translation_manager.translate_all_markdown_files()
+    metadata = json.loads(
+        (lang_dir / ".co-op-translator.json").read_text(encoding="utf-8")
+    )
+
+    assert modified_count == 1
+    assert errors == []
+    assert markdown_translator.calls
+    assert (lang_dir / "docs" / "test.md").exists()
+    assert TEXT_TRANSLATION_FAILURES_KEY not in metadata
+
+
+@pytest.mark.asyncio
+async def test_translate_all_markdown_update_keeps_previous_translation_on_failure(
+    translation_manager, temp_project_dir
+):
+    source_file = temp_project_dir / "docs" / "test.md"
+    translated_file = temp_project_dir / "translations" / "ko" / "docs" / "test.md"
+    translated_file.parent.mkdir(parents=True)
+    translated_file.write_text("# Previous translation\n", encoding="utf-8")
+    old_hash = calculate_file_hash(source_file)
+    _write_lang_metadata(
+        temp_project_dir / "translations" / "ko",
+        {
+            "docs/test.md": {
+                "original_hash": old_hash,
+                "translation_date": "2026-01-01T00:00:00+00:00",
+                "source_file": "docs/test.md",
+                "language_code": "ko",
+            }
+        },
+    )
+    source_file.write_text(
+        "\n".join(f"Updated line {index}" for index in range(40)) + "\n",
+        encoding="utf-8",
+    )
+    translation_manager.language_codes = ["ko"]
+    translation_manager.markdown_translator = FakeTruncatingMarkdownTranslator()
+
+    modified_count, errors = await translation_manager.translate_all_markdown_files(
+        update=True
+    )
+    metadata = json.loads(
+        (temp_project_dir / "translations" / "ko" / ".co-op-translator.json").read_text(
+            encoding="utf-8"
+        )
+    )
+
+    assert modified_count == 0
+    assert errors == [
+        f"Failed to translate markdown file: {source_file.resolve()} (lang: ko)"
+    ]
+    assert translated_file.read_text(encoding="utf-8") == "# Previous translation\n"
+    assert metadata["docs/test.md"]["original_hash"] == old_hash
+    assert (
+        metadata[TEXT_TRANSLATION_FAILURES_KEY]["docs/test.md"]["original_hash"]
+        == calculate_file_hash(source_file)
+    )
+
+
+@pytest.mark.asyncio
+async def test_translate_markdown_preserves_previous_translation_on_write_failure(
+    translation_manager, temp_project_dir, monkeypatch
+):
+    source_file = temp_project_dir / "docs" / "test.md"
+    translated_file = temp_project_dir / "translations" / "ko" / "docs" / "test.md"
+    translated_file.parent.mkdir(parents=True)
+    translated_file.write_text("# Previous translation\n", encoding="utf-8")
+    old_hash = calculate_file_hash(source_file)
+    _write_lang_metadata(
+        temp_project_dir / "translations" / "ko",
+        {
+            "docs/test.md": {
+                "original_hash": old_hash,
+                "translation_date": "2026-01-01T00:00:00+00:00",
+                "source_file": "docs/test.md",
+                "language_code": "ko",
+            }
+        },
+    )
+    original_replace = Path.replace
+
+    def fail_replace(path, target):
+        if Path(target) == translated_file:
+            raise OSError("replace failed")
+        return original_replace(path, target)
+
+    monkeypatch.setattr(Path, "replace", fail_replace)
+    translation_manager.language_codes = ["ko"]
+
+    result = await translation_manager.translate_markdown(source_file, "ko")
+    metadata = json.loads(
+        (temp_project_dir / "translations" / "ko" / ".co-op-translator.json").read_text(
+            encoding="utf-8"
+        )
+    )
+
+    assert result == ""
+    assert translated_file.read_text(encoding="utf-8") == "# Previous translation\n"
+    assert metadata["docs/test.md"]["original_hash"] == old_hash
+    assert TEXT_TRANSLATION_FAILURES_KEY not in metadata
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Purpose

Preserve the last usable translated markdown file when a retry-exhausted markdown translation fails, while recording the failed state for later retry instead of failing the whole project translation run.

## Description

- Record markdown translation validation failures in `.co-op-translator.json` under `__translation_failures__`.
- Keep existing translated markdown files visible when a new translation attempt fails after retries.
- Stop re-running the same failed translation on normal runs until the source hash, translator version, or failure policy changes.
- Remove update-mode pre-deletion for markdown files so successful translations replace files, but failed translations leave the previous version intact.
- Write markdown translations via a temporary file and final replace so write failures do not truncate an existing translation.

## Related Issue

N/A

## Does this introduce a breaking change?

Will this change require users to update commands, configuration, environment variables, generated translation output, or public Python/MCP APIs?
If you're not sure, test the affected CLI, API, documentation, or GitHub Actions workflow before marking this as "No."

- [ ] Yes
- [x] No

## Type of change

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (e.g., formatting, local variables)
- [ ] Refactoring (no functional or API changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Checklist

Before submitting your pull request, please confirm the following:

- [x] **I have thoroughly tested my changes**: I confirm that I have run the code and manually tested all affected areas.
- [x] **All existing tests pass**: I have run all tests and confirmed that nothing is broken.
- [x] **I have added new tests** (if applicable): I have written tests that cover the new functionality introduced by my code changes.
- [x] **I have followed the Co-op Translator coding conventions**: My code adheres to the style guide and coding conventions outlined in the repository.
- [x] **I have documented my changes** (if applicable): I have updated the documentation to reflect the changes where necessary.

## Additional context

Root cause: markdown retry exhaustion was treated as a project-level failure, and update-mode markdown translation deleted existing translated files before retrying. If the retry failed, the previous visible translation could be lost instead of being preserved with a recorded failure state.

Validation:

```text
pytest tests/co_op_translator/core/llm/test_markdown_translator.py tests/co_op_translator/utils/llm/test_code_comment_translator.py tests/co_op_translator/core/project/test_readme_translator.py tests/co_op_translator/review/test_runner.py tests/co_op_translator/test_review_api.py tests/co_op_translator/core/project/test_translation_manager.py
63 passed
```

`git diff --check` passed.