### PR TITLE
Release: Bump version to 0.20.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "co_op_translator"
-version = "0.19.2"
+version = "0.20.0"
 description = "Easily automate the translation of your documentation into multiple languages to reach a global audience."
 authors = [
     "Minseok Song <minseok.song@mssong.com>",

--- a/src/co_op_translator/__main__.py
+++ b/src/co_op_translator/__main__.py
@@ -11,6 +11,7 @@ from co_op_translator.cli.translate import translate_command
 from co_op_translator.cli.evaluate import evaluate_command
 from co_op_translator.cli.migrate_links import migrate_links_command
 from co_op_translator.cli.review import review_command
+from co_op_translator.utils.common.console import configure_safe_console_output
 
 logger = logging.getLogger(__name__)
 
@@ -20,6 +21,8 @@ def main():
     Main entry point function that routes to the appropriate command.
     This function is used by the command-line scripts.
     """
+    configure_safe_console_output()
+
     script_name = Path(sys.argv[0]).stem
     if script_name == "evaluate":
         evaluate_command()

--- a/src/co_op_translator/api/review.py
+++ b/src/co_op_translator/api/review.py
@@ -9,6 +9,7 @@ import click
 from co_op_translator.review.models import ReviewSummary
 from co_op_translator.review.runner import ReviewConfig, ReviewRunner
 from co_op_translator.review.targets import build_review_targets
+from co_op_translator.utils.common.console import configure_safe_console_output
 from co_op_translator.utils.common.lang_utils import normalize_language_codes
 from co_op_translator.utils.common.logging_utils import setup_logging
 
@@ -77,6 +78,8 @@ def run_review(
     ``update``, ``yes``, ``add_disclaimer``, ``repo_url``, ``glossaries``, and
     ``dry_run``.
     """
+    configure_safe_console_output()
+
     del update, yes, add_disclaimer, image_dir, repo_url, glossaries, dry_run
 
     root_path = Path(root_dir).resolve()

--- a/src/co_op_translator/api/translation.py
+++ b/src/co_op_translator/api/translation.py
@@ -37,6 +37,7 @@ from co_op_translator.utils.common.file_utils import (
     update_readme_languages_table,
     update_readme_other_courses,
 )
+from co_op_translator.utils.common.console import configure_safe_console_output
 from co_op_translator.utils.common.logging_utils import setup_logging
 from co_op_translator.utils.common.metadata_utils import (
     calculate_string_hash,
@@ -281,6 +282,7 @@ def run_translation(
     Set ``readme_only`` to translate only the root README while keeping
     document links pointed at the source tree.
     """
+    configure_safe_console_output()
 
     def _split_lang_placeholder(path: str) -> tuple[str, str | None]:
         placeholder = "<lang>"

--- a/src/co_op_translator/utils/common/console.py
+++ b/src/co_op_translator/utils/common/console.py
@@ -1,0 +1,27 @@
+"""Console output helpers."""
+
+from __future__ import annotations
+
+import sys
+from typing import TextIO
+
+
+def _make_stream_encoding_safe(stream: TextIO | None) -> None:
+    """Prevent UnicodeEncodeError on consoles with narrow legacy encodings."""
+    if stream is None:
+        return
+
+    reconfigure = getattr(stream, "reconfigure", None)
+    if not callable(reconfigure):
+        return
+
+    try:
+        reconfigure(errors="replace")
+    except (LookupError, TypeError, ValueError):
+        return
+
+
+def configure_safe_console_output() -> None:
+    """Keep CLI output from crashing on Windows code pages like cp949."""
+    _make_stream_encoding_safe(sys.stdout)
+    _make_stream_encoding_safe(sys.stderr)

--- a/tests/co_op_translator/utils/common/test_console.py
+++ b/tests/co_op_translator/utils/common/test_console.py
@@ -1,0 +1,24 @@
+import io
+import sys
+
+from co_op_translator.utils.common.console import configure_safe_console_output
+
+
+def test_configure_safe_console_output_prevents_cp949_encode_errors(monkeypatch):
+    raw_stdout = io.BytesIO()
+    raw_stderr = io.BytesIO()
+    stdout = io.TextIOWrapper(raw_stdout, encoding="cp949", errors="strict")
+    stderr = io.TextIOWrapper(raw_stderr, encoding="cp949", errors="strict")
+
+    monkeypatch.setattr(sys, "stdout", stdout)
+    monkeypatch.setattr(sys, "stderr", stderr)
+
+    configure_safe_console_output()
+
+    sys.stdout.write("🚀 Translation mode: markdown\n")
+    sys.stderr.write("✅ LLM health check passed.\n")
+    sys.stdout.flush()
+    sys.stderr.flush()
+
+    assert b"Translation mode" in raw_stdout.getvalue()
+    assert b"LLM health check passed" in raw_stderr.getvalue()


### PR DESCRIPTION
## Purpose

Prepare the next Co-op Translator release by bumping the package version to `0.20.0` and covering a Windows console compatibility issue found during the pre-upgrade smoke test.

## Description

- Update the package version in `pyproject.toml` from `0.19.2` to `0.20.0`.
- Add safe stdout/stderr configuration so CLI progress output does not crash on legacy Windows code pages such as `cp949`.
- Cover the console behavior with a focused test that writes emoji-bearing output through `cp949` streams.

## Related Issue

N/A

## Does this introduce a breaking change?

Will this change require users to update commands, configuration, environment variables, generated translation output, or public Python/MCP APIs?
If you're not sure, test the affected CLI, API, documentation, or GitHub Actions workflow before marking this as "No."

- [ ] Yes
- [x] No

## Type of change

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (e.g., formatting, local variables)
- [ ] Refactoring (no functional or API changes)
- [ ] Documentation content changes
- [x] Other... Please describe: Release version bump

## Checklist

Before submitting your pull request, please confirm the following:

- [x] **I have thoroughly tested my changes**: I confirm that I have run the code and manually tested all affected areas.
- [x] **All existing tests pass**: I have run all tests and confirmed that nothing is broken.
- [x] **I have added new tests** (if applicable): I have written tests that cover the new functionality introduced by my code changes.
- [x] **I have followed the Co-op Translator coding conventions**: My code adheres to the style guide and coding conventions outlined in the repository.
- [x] **I have documented my changes** (if applicable): I have updated the documentation to reflect the changes where necessary.

## Additional context

Validation:

```text
python -m build --sdist --wheel --outdir dist-test
Successfully built co_op_translator-0.20.0.tar.gz and co_op_translator-0.20.0-py3-none-any.whl

python -m pytest tests\co_op_translator\utils\common\test_console.py tests\co_op_translator\core\project\test_translation_manager.py -q
24 passed

python -m pytest tests\co_op_translator\test_api.py tests\co_op_translator\test_review_api.py tests\co_op_translator\utils\common\test_console.py -q
18 passed

git diff --check
passed
```

Manual smoke:

- Ran real Markdown + notebook translation against `test_repo/release_0_20_smoke` with Azure OpenAI configuration.
- Ran image translation with Azure AI Vision configuration.
- Ran `co-op-review`; result: `Errors: 0`, `Warnings: 0`.
- Re-ran the CLI without `PYTHONIOENCODING`/`PYTHONUTF8`; Windows `cp949` output no longer raises `UnicodeEncodeError`.