### PR TITLE
Core: Prevent Markdown tables from breaking across translation chunks

### DIFF
--- a/src/co_op_translator/core/llm/markdown_translator.py
+++ b/src/co_op_translator/core/llm/markdown_translator.py
@@ -176,7 +176,7 @@ class MarkdownTranslator(ABC):
             is_rtl,
             md_file_path,
         )
-        translated_content = "\n".join(results)
+        translated_content = "".join(results)
 
         # Step 4: Normalize emphasis markers for CJK scripts to improve renderer compatibility
         translated_content = normalize_cjk_emphasis_markers(
@@ -339,7 +339,7 @@ class MarkdownTranslator(ABC):
                 )
             )
 
-        return "\n".join(sub_results)
+        return "".join(sub_results)
 
     async def _translate_chunk_once(
         self,

--- a/tests/co_op_translator/core/llm/test_markdown_translator.py
+++ b/tests/co_op_translator/core/llm/test_markdown_translator.py
@@ -566,6 +566,44 @@ async def test_translate_markdown_rebuilds_lines_from_collapsed_anchor_output(
 
 
 @pytest.mark.asyncio
+async def test_translate_markdown_preserves_table_across_chunk_boundary(
+    real_markdown_translator,
+    monkeypatch,
+):
+    """Joining translated chunks must not add a blank line inside a table."""
+
+    document = (
+        "| # | Lesson |\n"
+        "| --- | --- |\n"
+        "| 03 | Responsible AI |\n"
+        "| 04 | Prompt engineering |\n"
+    )
+    chunks = [
+        "| # | Lesson |\n| --- | --- |\n| 03 | Responsible AI |\n",
+        "| 04 | Prompt engineering |\n",
+    ]
+    assert "".join(chunks) == document
+
+    monkeypatch.setattr(
+        "co_op_translator.core.llm.markdown_translator.process_markdown",
+        lambda content, max_tokens=2600, encoding="o200k_base": chunks,
+    )
+
+    async def echo_prompt_body(prompt, index, total):
+        _, body = prompt.split(SPLIT_DELIMITER, 1)
+        return body
+
+    with patch.object(
+        real_markdown_translator, "_run_prompt", new_callable=AsyncMock
+    ) as mock_run_prompt:
+        mock_run_prompt.side_effect = echo_prompt_body
+        result = await real_markdown_translator.translate_markdown(document, "ja")
+
+    assert result == document
+    assert "Responsible AI |\n\n| 04" not in result
+
+
+@pytest.mark.asyncio
 async def test_translate_markdown_missing_chunk_end_marker_is_incomplete(
     real_markdown_translator,
 ):
@@ -643,7 +681,9 @@ async def test_translate_markdown_splits_incomplete_chunk_after_retry(
         split_max_tokens.append(max_tokens)
         if max_tokens == 2600:
             return [content]
-        return ["# Needs split\n\nFirst part.\n", "Second part.\n"]
+        chunks = ["# Needs split\n\nFirst part.\n\n", "Second part.\n"]
+        assert "".join(chunks) == content
+        return chunks
 
     monkeypatch.setattr(
         "co_op_translator.core.llm.markdown_translator.process_markdown",
@@ -677,9 +717,7 @@ async def test_translate_markdown_splits_incomplete_chunk_after_retry(
             source_path=test_file,
         )
 
-    assert "# Dividido" in result
-    assert "Primera parte." in result
-    assert "Segunda parte." in result
+    assert result == "# Dividido\n\nPrimera parte.\n\nSegunda parte.\n"
     assert original_failures == 2
     assert split_max_tokens == [2600, 1300]
 


### PR DESCRIPTION
## Purpose

Prevent translated Markdown tables from breaking when a table spans multiple translation chunks.

## Description

`split_markdown_content()` preserves each chunk's original boundary whitespace so that `"".join(chunks)` reconstructs the source exactly. The translation path instead used `"\n".join(...)`, which added an extra newline at every chunk boundary. When a boundary fell between lessons 03 and 04, the inserted blank line terminated the Markdown table.

This change:

- concatenates translated Markdown chunks without injecting extra newlines
- applies the same lossless reassembly rule to recovery subchunks
- adds regression coverage for a table split across chunk boundaries
- strengthens the recovery test to verify exact whitespace preservation

## Related Issue

Fixes #505

## Does this introduce a breaking change?

Will this change require users to update commands, configuration, environment variables, generated translation output, or public Python/MCP APIs?
If you're not sure, test the affected CLI, API, documentation, or GitHub Actions workflow before marking this as "No."

- [ ] Yes
- [x] No

## Type of change

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (e.g., formatting, local variables)
- [ ] Refactoring (no functional or API changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Checklist

Before submitting your pull request, please confirm the following:

- [x] **I have thoroughly tested my changes**: I confirm that I have run the code and manually tested all affected areas.
- [ ] **All existing tests pass**: I have run all tests and confirmed that nothing is broken.
- [x] **I have added new tests** (if applicable): I have written tests that cover the new functionality introduced by my code changes.
- [x] **I have followed the Co-op Translator coding conventions**: My code adheres to the style guide and coding conventions outlined in the repository.
- [ ] **I have documented my changes** (if applicable): I have updated the documentation to reflect the changes where necessary.

## Additional context

All tests covering this change pass. I also ran the affected `generative-ai-for-beginners` README through a live Azure OpenAI translation and confirmed that all 22 lesson rows render as a single table, including the chunk boundary between lessons 03 and 04.
