### PR TITLE
Build: Restore default Dependabot pull request limits

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,6 @@ updates:
     labels:
       - "build"
       - "dependencies"
-    open-pull-requests-limit: 10
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -22,7 +21,6 @@ updates:
     labels:
       - "build"
       - "dependencies"
-    open-pull-requests-limit: 5
 
   - package-ecosystem: "docker"
     directory: "/"
@@ -34,4 +32,3 @@ updates:
     labels:
       - "build"
       - "dependencies"
-    open-pull-requests-limit: 5


### PR DESCRIPTION
## Purpose

## Description

- Removed the custom `open-pull-requests-limit` values for pip, GitHub Actions, and Docker.
- Kept the existing weekly schedules, labels, directories, and package ecosystems unchanged.
- Dependabot will now use GitHub's default limit of five open version-update pull requests per package ecosystem.

## Related Issue

N/A

## Does this introduce a breaking change?

Will this change require users to update commands, configuration, environment variables, generated translation output, or public Python/MCP APIs?
If you're not sure, test the affected CLI, API, documentation, or GitHub Actions workflow before marking this as "No."

- [ ] Yes
- [x] No

## Type of change

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (e.g., formatting, local variables)
- [ ] Refactoring (no functional or API changes)
- [ ] Documentation content changes
- [x] Other... Please describe: Build configuration

## Checklist

Before submitting your pull request, please confirm the following:

- [x] **I have thoroughly tested my changes**: I validated the Dependabot YAML and confirmed that no explicit pull request limit overrides remain.
- [x] **All existing tests pass**: The full test suite passes (`326 passed`).
- [x] **I have added new tests** (if applicable): No new executable code paths were introduced by this configuration-only change.
- [x] **I have followed the Co-op Translator coding conventions**: The existing Dependabot YAML structure and conventions are preserved.
- [x] **I have documented my changes** (if applicable): No user-facing documentation changes are required.

## Additional context

GitHub's default is five open version-update pull requests per package ecosystem, so the three configured ecosystems can still have up to 15 open pull requests in total. This change does not close or modify existing Dependabot pull requests.
