### PR TITLE
Build: Make provider tests environment-independent

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,14 +16,6 @@ jobs:
   test:
     name: Python ${{ matrix.python-version }}
     runs-on: ubuntu-latest
-    env:
-      AZURE_OPENAI_API_KEY: dummy
-      AZURE_OPENAI_ENDPOINT: https://example.openai.azure.com/
-      AZURE_OPENAI_MODEL_NAME: gpt-4o
-      AZURE_OPENAI_CHAT_DEPLOYMENT_NAME: dummy
-      AZURE_OPENAI_API_VERSION: 2024-12-01-preview
-      AZURE_AI_SERVICE_API_KEY: dummy
-      AZURE_AI_SERVICE_ENDPOINT: https://example.cognitiveservices.azure.com/
 
     strategy:
       fail-fast: false

--- a/tests/co_op_translator/core/project/test_dynamic_exclusion.py
+++ b/tests/co_op_translator/core/project/test_dynamic_exclusion.py
@@ -1,4 +1,6 @@
 from pathlib import Path
+from unittest.mock import MagicMock, patch
+
 from co_op_translator.core.project.project_translator import ProjectTranslator
 from co_op_translator.utils.common.file_utils import filter_files
 
@@ -15,12 +17,23 @@ def test_dynamic_exclusion_of_root_language_dirs(tmp_path: Path):
     (root / "cn" / "b.md").write_text("y", encoding="utf-8")
     (root / "docs" / "c.md").write_text("z", encoding="utf-8")
 
-    # Initialize translator (this will compute dynamic exclusions)
-    pt = ProjectTranslator(
-        language_codes="ko",
-        root_dir=str(root),
-        translation_types=["markdown"],
-    )
+    # Initialize the project without requiring an external LLM provider. The
+    # translator factories are unrelated to the directory exclusion behavior.
+    with (
+        patch(
+            "co_op_translator.core.project.project_translator.text_translator.TextTranslator.create",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "co_op_translator.core.project.project_translator.markdown_translator.MarkdownTranslator.create",
+            return_value=MagicMock(),
+        ),
+    ):
+        pt = ProjectTranslator(
+            language_codes="ko",
+            root_dir=str(root),
+            translation_types=["markdown"],
+        )
 
     files = filter_files(root, pt.excluded_dirs, extension=".md")
     paths = {str(p.relative_to(root)).replace("\\", "/") for p in files}

--- a/tests/co_op_translator/core/project/test_project_translator.py
+++ b/tests/co_op_translator/core/project/test_project_translator.py
@@ -1,12 +1,10 @@
 import pytest
-import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 from co_op_translator.core.project.project_translator import ProjectTranslator
-from co_op_translator.config.llm_config.provider import LLMProvider
 
 
 @pytest.fixture
-async def temp_project_dir(tmp_path):
+def temp_project_dir(tmp_path):
     """Create a temporary project directory structure."""
     # Create project structure
     docs_dir = tmp_path / "docs"
@@ -24,7 +22,7 @@ async def temp_project_dir(tmp_path):
 
 
 @pytest.fixture
-async def project_translator(temp_project_dir):
+def project_translator(temp_project_dir):
     """Create a ProjectTranslator instance with mocked dependencies."""
     with (
         patch(
@@ -37,18 +35,14 @@ async def project_translator(temp_project_dir):
             "co_op_translator.core.vision.image_translator.ImageTranslator"
         ) as mock_image_translator,
         patch(
-            "co_op_translator.core.llm.jupyter_notebook_translator.JupyterNotebookTranslator"
+            "co_op_translator.core.project.project_translator.JupyterNotebookTranslator"
         ) as mock_jupyter_translator,
-        patch(
-            "co_op_translator.config.llm_config.config.LLMConfig.get_available_provider"
-        ) as mock_get_provider,
     ):
-        # Setup mock translators and config
+        # Setup mock translators
         mock_text_translator.create.return_value = MagicMock()
         mock_markdown_translator.create.return_value = MagicMock()
         mock_image_translator.create.return_value = MagicMock()
         mock_jupyter_translator.create.return_value = MagicMock()
-        mock_get_provider.return_value = LLMProvider.AZURE_OPENAI  # Mock LLM provider
 
         translator = ProjectTranslator("ko ja", root_dir=temp_project_dir)
         translator.translation_manager.translate_all_markdown_files = AsyncMock(
@@ -99,12 +93,12 @@ async def test_check_and_retry_translations(project_translator, temp_project_dir
 
 def test_translate_project(project_translator):
     """Test the synchronous translate_project method."""
-    # Setup
-    with patch.object(asyncio, "run", side_effect=lambda x: None) as mock_run:
-        # Execute
-        project_translator.translate_project()
-        # Verify
-        mock_run.assert_called_once()
+    project_translator.translate_project()
+
+    project_translator.translation_manager.translate_project_async.assert_awaited_once_with(
+        update=False,
+        fast_mode=False,
+    )
 
 
 @pytest.mark.asyncio
@@ -118,23 +112,18 @@ async def test_markdown_only_mode(temp_project_dir):
             "co_op_translator.core.llm.markdown_translator.MarkdownTranslator"
         ) as mock_markdown_translator,
         patch(
-            "co_op_translator.core.llm.jupyter_notebook_translator.JupyterNotebookTranslator"
+            "co_op_translator.core.project.project_translator.JupyterNotebookTranslator"
         ) as mock_jupyter_translator,
-        patch(
-            "co_op_translator.config.llm_config.config.LLMConfig.get_available_provider"
-        ) as mock_get_provider,
     ):
         # Setup translator mocks
-        mock_text_translator_instance = AsyncMock()
+        mock_text_translator_instance = MagicMock()
         mock_text_translator.create.return_value = mock_text_translator_instance
 
-        mock_markdown_translator_instance = AsyncMock()
+        mock_markdown_translator_instance = MagicMock()
         mock_markdown_translator.create.return_value = mock_markdown_translator_instance
 
-        mock_jupyter_translator_instance = AsyncMock()
+        mock_jupyter_translator_instance = MagicMock()
         mock_jupyter_translator.create.return_value = mock_jupyter_translator_instance
-
-        mock_get_provider.return_value = LLMProvider.AZURE_OPENAI
 
         # Create translator in markdown-only mode
         translator = ProjectTranslator(
@@ -156,6 +145,7 @@ async def test_markdown_only_mode(temp_project_dir):
         # Verify markdown-only mode configuration
         assert translator.translation_types == ["markdown"]
         assert translator.image_translator is None
+        mock_jupyter_translator.create.assert_not_called()
 
         # Test async operation to ensure all coroutines are properly handled
         await translator.translation_manager.translate_project_async()
@@ -177,17 +167,13 @@ async def test_project_translator_custom_output_directories(temp_project_dir):
             "co_op_translator.core.vision.image_translator.ImageTranslator"
         ) as mock_image_translator,
         patch(
-            "co_op_translator.core.llm.jupyter_notebook_translator.JupyterNotebookTranslator"
+            "co_op_translator.core.project.project_translator.JupyterNotebookTranslator"
         ) as mock_jupyter_translator,
-        patch(
-            "co_op_translator.config.llm_config.config.LLMConfig.get_available_provider"
-        ) as mock_get_provider,
     ):
         mock_text_translator.create.return_value = MagicMock()
         mock_markdown_translator.create.return_value = MagicMock()
         mock_image_translator.create.return_value = MagicMock()
         mock_jupyter_translator.create.return_value = MagicMock()
-        mock_get_provider.return_value = LLMProvider.AZURE_OPENAI
 
         custom_translations = temp_project_dir / "content" / "i18n"
         custom_images = temp_project_dir / "public" / "translated_media"
@@ -225,17 +211,13 @@ async def test_project_translator_relative_output_directories(temp_project_dir):
             "co_op_translator.core.vision.image_translator.ImageTranslator"
         ) as mock_image_translator,
         patch(
-            "co_op_translator.core.llm.jupyter_notebook_translator.JupyterNotebookTranslator"
+            "co_op_translator.core.project.project_translator.JupyterNotebookTranslator"
         ) as mock_jupyter_translator,
-        patch(
-            "co_op_translator.config.llm_config.config.LLMConfig.get_available_provider"
-        ) as mock_get_provider,
     ):
         mock_text_translator.create.return_value = MagicMock()
         mock_markdown_translator.create.return_value = MagicMock()
         mock_image_translator.create.return_value = MagicMock()
         mock_jupyter_translator.create.return_value = MagicMock()
-        mock_get_provider.return_value = LLMProvider.AZURE_OPENAI
 
         translator = ProjectTranslator(
             "ko ja",


### PR DESCRIPTION
## Purpose

Make the unit test suite independent of Azure/OpenAI credentials so CI catches accidental provider initialization instead of masking it with dummy configuration.

## Description

- Removes dummy Azure OpenAI and Azure AI Service environment variables from the CI test job.
- Patches `JupyterNotebookTranslator` at the runtime lookup used by `ProjectTranslator`.
- Mocks translator factories in the directory-exclusion test because provider setup is outside that test's scope.
- Converts synchronous pytest fixtures from `async def` to `def` and verifies the real synchronous `translate_project()` wrapper.

No production code or runtime behavior is changed.

## Related Issue

N/A

## Does this introduce a breaking change?

Will this change require users to update commands, configuration, environment variables, generated translation output, or public Python/MCP APIs?
If you're not sure, test the affected CLI, API, documentation, or GitHub Actions workflow before marking this as "No."

- [ ] Yes
- [x] No

## Type of change

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (e.g., formatting, local variables)
- [x] Refactoring (no functional or API changes)
- [ ] Documentation content changes
- [x] Other: Build and test infrastructure

## Checklist

Before submitting your pull request, please confirm the following:

- [x] **I have thoroughly tested my changes**: I confirm that I have run the code and manually tested all affected areas.
- [x] **All existing tests pass**: I have run all tests and confirmed that nothing is broken.
- [x] **I have added new tests** (if applicable): Existing tests now exercise the credential-free path and the real synchronous wrapper.
- [x] **I have followed the Co-op Translator coding conventions**: My code adheres to the style guide and coding conventions outlined in the repository.
- [x] **I have documented my changes** (if applicable): No user-facing documentation changes are required for test-only behavior.

## Additional context

Local verification with provider credentials removed:

- `python -m pytest -m "not api_key_required" -q` — 344 passed
- `python -m ruff check src tests` — passed
- `python -m black --check src tests` — passed
- `git diff --check` — passed

The GitHub Actions matrix will repeat the suite on Python 3.10, 3.11, and 3.12 without injected provider credentials.
