### PR TITLE
Build: Bump version to 0.20.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "co_op_translator"
-version = "0.20.0"
+version = "0.20.1"
 description = "Easily automate the translation of your documentation into multiple languages to reach a global audience."
 authors = [
     "Minseok Song <minseok.song@mssong.com>",


### PR DESCRIPTION
## Purpose

Prepare the patch release for the fixes and maintenance work merged since `v0.20.0`.

## Description

Bump the package version from `0.20.0` to `0.20.1`.

Release highlights include:

- Preserve Markdown URLs and prevent tables from breaking across translation chunks.
- Support credential-free, write-free dry runs across CLI, Python API, and MCP.
- Make the test suite independent of provider credentials.
- Synchronize pip and Poetry dependency manifests with Python 3.12 installation coverage.
- Pin GitHub Actions to immutable commit SHAs and update maintained dependencies.

## Related Issue

N/A

## Does this introduce a breaking change?

Will this change require users to update commands, configuration, environment variables, generated translation output, or public Python/MCP APIs?
If you're not sure, test the affected CLI, API, documentation, or GitHub Actions workflow before marking this as "No."

- [ ] Yes
- [x] No

## Type of change

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (e.g., formatting, local variables)
- [ ] Refactoring (no functional or API changes)
- [ ] Documentation content changes
- [x] Other... Please describe: Patch release version bump

## Checklist

Before submitting your pull request, please confirm the following:

- [x] **I have thoroughly tested my changes**: I confirm that I have run the code and manually tested all affected areas.
- [x] **All existing tests pass**: I have run all tests and confirmed that nothing is broken.
- [x] **I have added new tests** (if applicable): I have written tests that cover the new functionality introduced by my code changes.
- [x] **I have followed the Co-op Translator coding conventions**: My code adheres to the style guide and coding conventions outlined in the repository.
- [x] **I have documented my changes** (if applicable): I have updated the documentation to reflect the changes where necessary.

## Additional context

- The final combined main branch passed `354` tests before this metadata-only version change.
- The configured version parses as `0.20.1`.
- `poetry check --lock` and `git diff --check` pass.
