### PR TITLE
Docs: Reframe README around real-world translation maintenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,196 @@
 # Co-op Translator
 
-_Easily automate and maintain translations for your educational GitHub content across multiple languages as your project evolves._
+Keep multilingual GitHub documentation current as your source evolves.
+
+Co-op Translator detects changed source content, updates stale translations, and preserves the links and structure of Markdown, Jupyter notebooks, and images.
 
 ![Python 3.10–3.12](https://img.shields.io/badge/python-3.10--3.12-blue)
 [![Python package](https://img.shields.io/pypi/v/co-op-translator?color=4BA3FF)](https://pypi.org/project/co-op-translator/)
-[![License: MIT](https://img.shields.io/github/license/azure/co-op-translator?color=4BA3FF)](https://github.com/azure/co-op-translator/blob/main/LICENSE)
-[![Downloads](https://static.pepy.tech/badge/co-op-translator)](https://pepy.tech/project/co-op-translator)
-[![Downloads](https://static.pepy.tech/badge/co-op-translator/month)](https://pepy.tech/project/co-op-translator)
 [![Container: GHCR](https://img.shields.io/badge/Container-GHCR-2496ED?logo=docker&logoColor=fff)](https://github.com/azure/co-op-translator/pkgs/container/co-op-translator)
-[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
+[![License: MIT](https://img.shields.io/github/license/azure/co-op-translator?color=4BA3FF)](https://github.com/azure/co-op-translator/blob/main/LICENSE)
+[![Monthly downloads](https://static.pepy.tech/badge/co-op-translator/month)](https://pepy.tech/project/co-op-translator)
 
-[![GitHub contributors](https://img.shields.io/github/contributors/azure/co-op-translator.svg)](https://GitHub.com/azure/co-op-translator/graphs/contributors/)
-[![GitHub issues](https://img.shields.io/github/issues/azure/co-op-translator.svg)](https://GitHub.com/azure/co-op-translator/issues/)
-[![GitHub pull-requests](https://img.shields.io/github/issues-pr/azure/co-op-translator.svg)](https://GitHub.com/azure/co-op-translator/pulls/)
-[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](http://makeapullrequest.com)
+**[Get started](#get-started)** · **[See real repositories](#see-co-op-translator-in-real-repositories)** · **[Read the documentation](https://azure.github.io/co-op-translator/)**
 
-**Start here:** [Choose your workflow](https://azure.github.io/co-op-translator/workflows/) | [Configuration](https://azure.github.io/co-op-translator/configuration/) | [CLI](https://azure.github.io/co-op-translator/cli/) | [Python API](https://azure.github.io/co-op-translator/api/) | [MCP Server](https://azure.github.io/co-op-translator/mcp/)
+> Translating one file is easy. Keeping an entire documentation repository translated, linked, and up to date is the hard part.
 
-### 🌐 Multi-Language Support
+## Why Co-op Translator?
 
-#### Supported by [Co-op Translator](https://github.com/Azure/co-op-translator)
+Translation is not finished when a model returns text. Repository-scale documentation needs to stay complete, navigable, and synchronized after every source change.
+
+| Problem | How Co-op Translator helps |
+| --- | --- |
+| Source content keeps changing | Source hashes and language-scoped metadata identify stale files and skip unchanged translations. |
+| Long documents do not fit one reliable model response | Markdown is split into manageable chunks, with retry and re-chunking for failed sections. |
+| Models can alter Markdown structure or destinations | Structure checks and parser-based protection preserve Markdown URLs, code, and Markdown structure. |
+| Links must follow the translated repository tree | Relative links for Markdown, notebooks, images, and README files are rewritten for `translations/<lang>/...`. |
+| A repository contains more than prose | One workflow can handle Markdown, Jupyter notebooks, image text, and repository-level review. |
+
+## See Co-op Translator in real repositories
+
+Co-op Translator has been used in Microsoft open-source learning repositories that combine lessons, code samples, links, notebooks, and supporting assets.
+
+### [AI Agents for Beginners](https://github.com/microsoft/ai-agents-for-beginners)
+
+A lesson-based repository with code samples and supporting documentation organized into language-specific versions.
+
+**[View repository](https://github.com/microsoft/ai-agents-for-beginners)** · **[Browse translations](https://github.com/microsoft/ai-agents-for-beginners/tree/main/translations)**
+
+### [Generative AI for Beginners](https://github.com/microsoft/generative-ai-for-beginners)
+
+A large curriculum containing lessons, code, images, and links across a multilingual documentation tree.
+
+**[View repository](https://github.com/microsoft/generative-ai-for-beginners)** · **[Browse translations](https://github.com/microsoft/generative-ai-for-beginners/tree/main/translations)**
+
+### [MCP for Beginners](https://github.com/microsoft/mcp-for-beginners)
+
+Technical learning content covering Model Context Protocol concepts, examples, and language-scoped documentation.
+
+**[View repository](https://github.com/microsoft/mcp-for-beginners)** · **[Browse translations](https://github.com/microsoft/mcp-for-beginners/tree/main/translations)**
+
+<details>
+<summary>Explore more multilingual Microsoft learning repositories</summary>
+
+- [LangChain4j for Beginners](https://github.com/microsoft/LangChain4j-for-Beginners)
+- [AZD for Beginners](https://github.com/microsoft/AZD-for-beginners)
+- [Edge AI for Beginners](https://github.com/microsoft/edgeai-for-beginners)
+- [Generative AI for Beginners using .NET](https://github.com/microsoft/Generative-AI-for-beginners-dotnet)
+- [Generative AI for Beginners using Java](https://github.com/microsoft/generative-ai-for-beginners-java)
+- [ML for Beginners](https://aka.ms/ml-beginners)
+- [Data Science for Beginners](https://aka.ms/datascience-beginners)
+- [AI for Beginners](https://aka.ms/ai-beginners)
+- [Cybersecurity for Beginners](https://github.com/microsoft/Security-101)
+- [Web Dev for Beginners](https://aka.ms/webdev-beginners)
+- [IoT for Beginners](https://aka.ms/iot-beginners)
+- [PhiCookBook](https://github.com/microsoft/PhiCookBook)
+
+</details>
+
+## Get started
+
+Install Co-op Translator and preview the work without configuring provider credentials:
+
+```bash
+pip install co-op-translator
+translate -l "ko" -md --dry-run
+```
+
+Configure [Azure OpenAI or OpenAI credentials](./docs/configuration.md), then run the translation and deterministic review:
+
+```bash
+translate -l "ko" -md
+co-op-review -l "ko"
+```
+
+For a first run, start with [Choose your workflow](./docs/workflows.md). It compares local translation, Python automation, GitHub Actions, containers, and agent or editor integration.
+
+## How it works
+
+1. **Plan:** scan the repository, normalize language codes, and identify new or outdated source content.
+2. **Translate:** process Markdown, notebook cells, and image text with configured providers. MCP host agents can translate Markdown and notebook chunks.
+3. **Preserve structure:** protect code and URL destinations, then rewrite relative paths for the translated repository tree.
+4. **Track and review:** save language-scoped metadata so later runs can skip unchanged files and report missing, stale, or structurally incomplete translations.
+
+Translated content remains in the repository, where it can be reviewed, versioned, and updated with the source:
+
+![Example of translated content organization](./imgs/translation-ex.png)
+
+## Translation state is managed like a software artifact
+
+Co-op Translator manages translations as **versioned software artifacts**, not as disconnected static files. Language-scoped metadata records the source state for translated Markdown, images, and notebooks.
+
+This design lets repository owners:
+
+- Detect outdated translations without retranslating unchanged files
+- Apply the same maintenance model to Markdown, images, and notebooks
+- Review translation completeness and repository structure in CI
+- Scale translation maintenance across large, fast-moving repositories
+
+[Read how translation state is managed](https://techcommunity.microsoft.com/blog/azuredevcommunityblog/rethinking-documentation-translation-treating-translations-as-versioned-software/4491755)
+
+## Core capabilities
+
+- Incremental translation based on source changes and language-scoped metadata
+- Markdown chunking, recovery, structural validation, and URL protection
+- Translation of Markdown, Jupyter notebooks, and text embedded in images
+- Relative-link rewriting for translated repository layouts
+- Credential-free, write-free dry runs across the CLI, Python API, and MCP
+- Deterministic review of translation freshness, structure, and local links
+- Azure OpenAI and OpenAI support for provider-backed translation
+- Azure AI Vision support for image text extraction
+- Host-agent translation of Markdown and notebook chunks through MCP
+
+## Choose your interface
+
+| Interface | Best for | Guide |
+| --- | --- | --- |
+| CLI | Local repository work and scripts | [CLI reference](./docs/cli.md) |
+| Python API | Applications and custom automation | [Python API](./docs/api.md) |
+| MCP server | Agent and editor workflows | [MCP server](./docs/mcp.md) |
+| GitHub Actions | Repository translation in CI | [GitHub Actions](./docs/github-actions.md) |
+| Container | Isolated or repeatable CLI runs | [Quick run](#container) |
+
+### Container
+
+Container quick run with Bash or Zsh:
+
+```bash
+docker run --rm -it --env-file .env -v "${PWD}:/work" ghcr.io/azure/co-op-translator:latest -l "ko" -md
+```
+
+Container quick run with PowerShell:
+
+```powershell
+docker run --rm -it --env-file .env -v ${PWD}:/work ghcr.io/azure/co-op-translator:latest -l "ko" -md
+```
+
+## Featured by Microsoft
+
+- **Microsoft's The Future of AI series:** [Unlock Global Collaboration with Co-op Translator: Automate Markdown and Image Translations Using Azure AI Foundry](https://techcommunity.microsoft.com/blog/azure-ai-foundry-blog/the-future-of-ai-unleashing-the-potential-of-ai-translation/4394200)
+- **Open at Microsoft:** [Unlocking Multilingual Accessibility with Co-op Translator: A Case Study on Phi-3 Cookbook](https://www.youtube.com/watch?v=jX_swfH_KNU)
+- **Microsoft Reactor:** [Unlocking Multilingual Mastery: Dive into Co-op Translator with Azure](https://www.youtube.com/watch?v=boTtKVPBLAc)
+
+[![Open at Microsoft: Co-op Translator and Phi-3 Cookbook](./imgs/open-ms-thumbnail.jpg)](https://www.youtube.com/watch?v=jX_swfH_KNU)
+
+## Case studies and engineering deep dives
+
+### Case studies
+
+- [Automate Markdown and Image Translations Using Co-op Translator: Phi-3 Cookbook Case Study](https://techcommunity.microsoft.com/blog/educatordeveloperblog/automate-markdown-and-image-translations-using-co-op-translator-phi-3-cookbook-c/4263474)
+- [Translating AI and ML for Beginners Curriculums in Less Than a Day](https://techcommunity.microsoft.com/blog/azuredevcommunityblog/translating-ai-and-ml-for-beginners-curriculums-in-less-than-a-day/4381854)
+
+### Engineering deep dives
+
+- [Rethinking Documentation Translation: Treating Translations as Versioned Software Assets](https://techcommunity.microsoft.com/blog/azuredevcommunityblog/rethinking-documentation-translation-treating-translations-as-versioned-software/4491755)
+- [Fixing Broken Markdown in AI Translation: Hardening a Production Pipeline](https://techcommunity.microsoft.com/blog/azuredevcommunityblog/fixing-broken-markdown-in-ai-translation-hardening-a-production-pipeline/4511378)
+
+## Documentation
+
+- [Documentation site](https://azure.github.io/co-op-translator/)
+- [Choose your workflow](./docs/workflows.md)
+- [Configuration](./docs/configuration.md)
+- [Azure AI setup](./docs/azure-ai-setup.md)
+- [CLI reference](./docs/cli.md)
+- [Python API](./docs/api.md)
+- [MCP server](./docs/mcp.md)
+- [GitHub Actions](./docs/github-actions.md)
+- [README languages template](./docs/readme-languages-template.md)
+- [Supported languages](./docs/supported-languages.md)
+- [Troubleshooting](./docs/troubleshooting.md)
+
+### Microsoft-specific guide
+
+> [!NOTE]
+> For maintainers of the Microsoft “For Beginners” repositories only.
+
+- [Updating the “other courses” list](./docs/microsoft-beginners.md)
+
+## Supported languages and cloning
+
+Co-op Translator supports 50+ language and locale codes. Expand this section to browse translated README files and see how to clone the repository without translation assets.
+
+<details>
+<summary>View supported languages and sparse-checkout instructions</summary>
 
 <!-- CO-OP TRANSLATOR LANGUAGES TABLE START -->
 [Arabic](./translations/ar/README.md) | [Bengali](./translations/bn/README.md) | [Bulgarian](./translations/bg/README.md) | [Burmese (Myanmar)](./translations/my/README.md) | [Chinese (Simplified)](./translations/zh-CN/README.md) | [Chinese (Traditional, Hong Kong)](./translations/zh-HK/README.md) | [Chinese (Traditional, Macau)](./translations/zh-MO/README.md) | [Chinese (Traditional, Taiwan)](./translations/zh-TW/README.md) | [Croatian](./translations/hr/README.md) | [Czech](./translations/cs/README.md) | [Danish](./translations/da/README.md) | [Dutch](./translations/nl/README.md) | [Estonian](./translations/et/README.md) | [Finnish](./translations/fi/README.md) | [French](./translations/fr/README.md) | [German](./translations/de/README.md) | [Greek](./translations/el/README.md) | [Hebrew](./translations/he/README.md) | [Hindi](./translations/hi/README.md) | [Hungarian](./translations/hu/README.md) | [Indonesian](./translations/id/README.md) | [Italian](./translations/it/README.md) | [Japanese](./translations/ja/README.md) | [Kannada](./translations/kn/README.md) | [Khmer](./translations/km/README.md) | [Korean](./translations/ko/README.md) | [Lithuanian](./translations/lt/README.md) | [Malay](./translations/ms/README.md) | [Malayalam](./translations/ml/README.md) | [Marathi](./translations/mr/README.md) | [Nepali](./translations/ne/README.md) | [Nigerian Pidgin](./translations/pcm/README.md) | [Norwegian](./translations/no/README.md) | [Persian (Farsi)](./translations/fa/README.md) | [Polish](./translations/pl/README.md) | [Portuguese (Brazil)](./translations/pt-BR/README.md) | [Portuguese (Portugal)](./translations/pt-PT/README.md) | [Punjabi (Gurmukhi)](./translations/pa/README.md) | [Romanian](./translations/ro/README.md) | [Russian](./translations/ru/README.md) | [Serbian (Cyrillic)](./translations/sr/README.md) | [Slovak](./translations/sk/README.md) | [Slovenian](./translations/sl/README.md) | [Spanish](./translations/es/README.md) | [Swahili](./translations/sw/README.md) | [Swedish](./translations/sv/README.md) | [Tagalog (Filipino)](./translations/tl/README.md) | [Tamil](./translations/ta/README.md) | [Telugu](./translations/te/README.md) | [Thai](./translations/th/README.md) | [Turkish](./translations/tr/README.md) | [Ukrainian](./translations/uk/README.md) | [Urdu](./translations/ur/README.md) | [Vietnamese](./translations/vi/README.md)
@@ -45,177 +216,18 @@ _Easily automate and maintain translations for your educational GitHub content a
 > This gives you everything you need to complete the course with a much faster download.
 <!-- CO-OP TRANSLATOR LANGUAGES TABLE END -->
 
-[![GitHub watchers](https://img.shields.io/github/watchers/azure/co-op-translator.svg?style=social&label=Watch)](https://GitHub.com/azure/co-op-translator/watchers/)
-[![GitHub forks](https://img.shields.io/github/forks/azure/co-op-translator.svg?style=social&label=Fork)](https://GitHub.com/azure/co-op-translator/network/)
-[![GitHub stars](https://img.shields.io/github/stars/azure/co-op-translator?style=social&label=Star)](https://GitHub.com/azure/co-op-translator/stargazers/)
-
-[![Microsoft Foundry Discord](https://dcbadge.limes.pink/api/server/nTYy5BXMWG)](https://discord.gg/nTYy5BXMWG)
-
-[![Open in GitHub Codespaces](https://img.shields.io/static/v1?style=for-the-badge&label=Github%20Codespaces&message=Open&color=24292F&logo=github)](https://codespaces.new/azure/co-op-translator)
-
-## Overview
-
-**Co-op Translator** helps you localize your educational GitHub content into multiple languages effortlessly.
-When you update your Markdown files, images, or notebooks, translations stay automatically synchronized, ensuring your content remains accurate and up to date for learners worldwide.
-
-Use it from the CLI for repository translation, from the Python API for automation, or through the MCP server for agent and editor workflows.
-
-Example of how translated content is organized:
-
-![Example](./imgs/translation-ex.png)
-
-## Why Co-op Translator?
-
-Translating one file is easy. Keeping an entire documentation repository
-translated, linked, and up to date is the hard part.
-
-| Problem | How Co-op Translator helps |
-| --- | --- |
-| Long docs are not one prompt | Large Markdown files are split into chunks, so a long README does not depend on one fragile model response. If a chunk fails, Co-op Translator can retry and re-chunk only the failed part. |
-| Incomplete translations should not be marked current | A truncated translation should never be sealed as up to date. Co-op Translator checks translation integrity before saving and can detect structurally incomplete existing translations. |
-| Links should match the translated repo structure | Manual translations often leave relative links pointing back to the source tree. Co-op Translator rewrites Markdown, notebook, image, and README links to match the `translations/<lang>/...` structure. |
-| Translation should work across an entire repo | Co-op Translator handles README files, docs, notebooks, and image text as part of one repository workflow, instead of translating files one by one. |
-| Maintaining translations matters more than creating them once | Source hashes and translation metadata let Co-op Translator find outdated files, skip unchanged files, and keep translated content synchronized as the source repo evolves. |
-
-## How translation state is managed
-
-Co-op Translator manages translated content as **versioned software artifacts**,  
-not as static files.
-
-The tool tracks the state of translated Markdown, images, and notebooks
-using **language-scoped metadata**.
-
-This design allows Co-op Translator to:
-
-- Reliably detect outdated translations
-- Treat Markdown, images, and notebooks consistently
-- Scale safely across large, fast-moving, multi-language repositories
-
-By modeling translations as managed artifacts,
-translation workflows align naturally with modern
-software dependency and artifact management practices.
-
-→ [How translation state is managed](https://techcommunity.microsoft.com/blog/azuredevcommunityblog/rethinking-documentation-translation-treating-translations-as-versioned-software/4491755)
-
-### Related deep dives
-
-- [Fixing Broken Markdown in AI Translation: Hardening a Production Pipeline](https://techcommunity.microsoft.com/blog/azuredevcommunityblog/fixing-broken-markdown-in-ai-translation-hardening-a-production-pipeline/4511378)
-
-## Get Started
-
-Co-op Translator can be used from the CLI, the Python API, or the MCP server. Start with the workflow guide if you are choosing between local translation, automation, CI, and agent/editor integration.
-
-- [Choose your workflow](./docs/workflows.md)
-- [Configure credentials](./docs/configuration.md)
-- [Translate from the CLI](./docs/cli.md)
-- [Automate with the Python API](./docs/api.md)
-- [Connect with the MCP Server](./docs/mcp.md)
-- [Run in GitHub Actions](./docs/github-actions.md)
-
-Minimal CLI example after configuration:
-
-```bash
-python -m venv .venv
-# Windows
-.venv\Scripts\activate
-# macOS/Linux
-source .venv/bin/activate
-
-pip install co-op-translator
-translate -l "ko" -md
-co-op-review -l "ko"
-```
-
-For first runs on large repositories, use `--dry-run` before writing translated files. See the [CLI Reference](./docs/cli.md) for content type flags, logs, review, and link migration.
-
-Container quick run with Bash/Zsh:
-
-```bash
-docker run --rm -it --env-file .env -v "${PWD}:/work" ghcr.io/azure/co-op-translator:latest -l "ko" -md
-```
-
-Container quick run with PowerShell:
-
-```powershell
-docker run --rm -it --env-file .env -v ${PWD}:/work ghcr.io/azure/co-op-translator:latest -l "ko" -md
-```
-
-## Features
-
-- Automated translation for Markdown, notebooks, and images
-- Keeps translations in sync with source changes
-- Works locally (CLI) or in CI (GitHub Actions)
-- Exposes Markdown, notebook, image, review, and project translation tools through MCP
-- Uses Azure OpenAI or OpenAI for provider-backed translation
-- Lets MCP host agents translate Markdown and notebook chunks without Co-op Translator LLM credentials
-- Uses Azure AI Vision for image text extraction and translation
-- Reviews translation structure and freshness with deterministic checks
-- Preserves Markdown formatting and structure
-
-## Docs
-
-- [Documentation site](https://azure.github.io/co-op-translator/)
-- [Choose your workflow](./docs/workflows.md)
-- [Configuration](./docs/configuration.md)
-- [Azure AI Setup](./docs/azure-ai-setup.md)
-- [CLI Reference](./docs/cli.md)
-- [Python API](./docs/api.md)
-- [MCP Server](./docs/mcp.md)
-- [GitHub Actions](./docs/github-actions.md)
-- [README languages template](./docs/readme-languages-template.md)
-- [Supported languages](./docs/supported-languages.md)
-- [Contributing](./CONTRIBUTING.md)
-- [Troubleshooting](./docs/troubleshooting.md)
-
-### Microsoft-specific guide
-> [!NOTE]
-> For maintainers of the Microsoft “For Beginners” repositories only.
-
-- [Updating the “other courses” list (for MS Beginners repositories only)](./docs/microsoft-beginners.md)
-
-## Support us and foster global learning
-
-Join us in revolutionizing how educational content is shared globally! Give [Co-op Translator](https://github.com/azure/co-op-translator) a ⭐ on GitHub and support our mission to break down language barriers in learning and technology. Your interest and contributions make a significant impact! Code contributions and feature suggestions are always welcome.
-
-### Explore Microsoft educational content in your language
-
-- [LangChain4j-for-Beginners](https://github.com/microsoft/LangChain4j-for-Beginners)
-- [AZD for Beginners](https://github.com/microsoft/AZD-for-beginners)
-- [Edge AI for Beginners](https://github.com/microsoft/edgeai-for-beginners)
-- [Model Context Protocol (MCP) For Beginners](https://github.com/microsoft/mcp-for-beginners)
-- [AI Agents for Beginners](https://github.com/microsoft/ai-agents-for-beginners)
-- [Generative AI for Beginners using .NET](https://github.com/microsoft/Generative-AI-for-beginners-dotnet)
-- [Generative AI for Beginners](https://github.com/microsoft/generative-ai-for-beginners)
-- [Generative AI for Beginners using Java](https://github.com/microsoft/generative-ai-for-beginners-java)
-- [ML for Beginners](https://aka.ms/ml-beginners)
-- [Data Science for Beginners](https://aka.ms/datascience-beginners)
-- [AI for Beginners](https://aka.ms/ai-beginners)
-- [Cybersecurity for Beginners](https://github.com/microsoft/Security-101)
-- [Web Dev for Beginners](https://aka.ms/webdev-beginners)
-- [IoT for Beginners](https://aka.ms/iot-beginners)
-- [PhiCookBook](https://github.com/microsoft/PhiCookBook)
-
-## Video presentations
-
-👉 Click the image below to watch on YouTube.
-
-- **Open at Microsoft**: A brief 18-minute introduction and quick guide on how to use Co-op Translator.
-
-  [![Open at Microsoft](./imgs/open-ms-thumbnail.jpg)](https://www.youtube.com/watch?v=jX_swfH_KNU)
+</details>
 
 ## Contributing
 
-This project welcomes contributions and suggestions. Interested in contributing to Azure Co-op Translator? Please see our [CONTRIBUTING.md](./CONTRIBUTING.md) for guidelines on how you can help make Co-op Translator more accessible.
-
-## Contributors
+Contributions and suggestions are welcome. See [CONTRIBUTING.md](./CONTRIBUTING.md) for development setup, coding conventions, and pull request guidance.
 
 [![co-op-translator contributors](https://contrib.rocks/image?repo=Azure/co-op-translator)](https://github.com/Azure/co-op-translator/graphs/contributors)
 
 ## Code of Conduct
 
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
-For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or
-contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
+For more information, see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with additional questions or comments.
 
 ## Responsible AI
 
@@ -238,12 +250,10 @@ trademarks or logos is subject to and must follow
 Use of Microsoft trademarks or logos in modified versions of this project must not cause confusion or imply Microsoft sponsorship.
 Any use of third-party trademarks or logos are subject to those third-party's policies.
 
-## Getting Help
+## Getting help
 
-If you get stuck or have any questions about building AI apps, join:
+For project problems, open a [GitHub issue](https://github.com/Azure/co-op-translator/issues). For questions about building AI applications, use the Microsoft Foundry community channels:
 
 [![Microsoft Foundry Discord](https://dcbadge.limes.pink/api/server/nTYy5BXMWG)](https://discord.gg/nTYy5BXMWG)
-
-If you have product feedback or errors while building visit:
 
 [![Microsoft Foundry Developer Forum](https://img.shields.io/badge/GitHub-Microsoft_Foundry_Developer_Forum-blue?style=for-the-badge&logo=github&color=000000&logoColor=fff)](https://aka.ms/foundry/forum)


### PR DESCRIPTION
## Purpose

Make Co-op Translator's value clear before presenting its full setup and language list. The README now leads with the repository-maintenance problem, demonstrates the project in real Microsoft open-source repositories, and then guides readers to the right workflow.

## Description

- Reframes the opening around keeping multilingual GitHub documentation current as source content evolves.
- Adds three representative repositories with direct links to their translated content.
- Moves the shortest credential-free dry run and the main translation/review commands closer to the top.
- Consolidates overlapping feature descriptions into a problem/solution table, workflow overview, core capabilities, and interface guide.
- Keeps the Open at Microsoft presentation and adds the Microsoft Future of AI feature, Reactor presentation, case studies, and engineering deep dives.
- Moves the existing generated language and sparse-checkout block into a collapsed section lower in the README. The generated block and `src/co_op_translator/templates/languages_table.md` are unchanged.
- Preserves the existing Responsible AI and trademark text.

## Related Issue

N/A

## Does this introduce a breaking change?

Will this change require users to update commands, configuration, environment variables, generated translation output, or public Python/MCP APIs?
If you're not sure, test the affected CLI, API, documentation, or GitHub Actions workflow before marking this as "No."

- [ ] Yes
- [x] No

## Type of change

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (e.g., formatting, local variables)
- [ ] Refactoring (no functional or API changes)
- [x] Documentation content changes
- [ ] Other... Please describe:

## Checklist

Before submitting your pull request, please confirm the following:

- [x] **I have thoroughly tested my changes**: I confirm that I have run the code and manually tested all affected areas.
- [ ] **All existing tests pass**: The 354 credential-free tests pass; the translation review check intentionally reports stale translated READMEs as described below.
- [ ] **I have added new tests** (if applicable): No executable code changed.
- [x] **I have followed the Co-op Translator coding conventions**: My code adheres to the style guide and coding conventions outlined in the repository.
- [x] **I have documented my changes** (if applicable): I have updated the documentation to reflect the changes where necessary.

## Additional context

Validation completed:

- `python -m pytest -m "not api_key_required"`: 354 passed.
- `git diff --check`: passed.
- GitHub GFM rendering: two tables and two `<details>` sections rendered successfully.
- Local Markdown links: 74 checked, 0 missing.
- Representative external links: documentation, three translation directories, two videos, and five Microsoft Tech Community articles returned HTTP 200.
- README language updater round trip: unchanged; surrounding `<details>` elements were preserved.

`co-op-review --changed-from upstream/main --format github` reports 110 expected errors across 55 languages: one stale-metadata result and one code-fence-count difference per translated README. This PR intentionally keeps translated READMEs out of scope so the English positioning and structure can be reviewed first; translations can be regenerated after the source copy is accepted.
