### PR TITLE
Core: Add a README-first translation PR workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ co-op-review -l "ko"
 
 For a first run, start with [Choose your workflow](./docs/workflows.md). It compares local translation, Python automation, GitHub Actions, containers, and agent or editor integration.
 
+Want a translation pull request first? Follow [Your first README translation PR](./docs/github-actions.md#your-first-readme-translation-pr): choose one language, preview the work, then generate and review a README translation before merging. No image service setup is needed.
+
 ## How it works
 
 1. **Plan:** scan the repository, normalize language codes, and identify new or outdated source content.

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,139 @@
+name: "Co-op Translator"
+description: "Preview or translate Markdown, notebooks, and image text in documentation repositories."
+author: "Azure"
+
+branding:
+  icon: "globe"
+  color: "blue"
+
+inputs:
+  language-codes:
+    description: 'Space-separated language codes, such as "ko ja fr", or "all".'
+    required: true
+  root-dir:
+    description: "Repository root or subdirectory to translate."
+    required: false
+    default: "."
+  markdown:
+    description: "Translate Markdown files."
+    required: false
+    default: "false"
+  notebook:
+    description: "Translate Jupyter notebook files."
+    required: false
+    default: "false"
+  images:
+    description: "Translate image text. Requires Azure AI Vision credentials."
+    required: false
+    default: "false"
+  readme-only:
+    description: "Translate only the root README.md and keep links pointed at source documents."
+    required: false
+    default: "false"
+  update:
+    description: "Delete and recreate existing translations for selected languages."
+    required: false
+    default: "false"
+  dry-run:
+    description: "Preview translation volume and migration behavior without writing files."
+    required: false
+    default: "true"
+  yes:
+    description: "Automatically confirm prompts."
+    required: false
+    default: "true"
+  add-disclaimer:
+    description: "Add machine translation disclaimer sections."
+    required: false
+    default: "true"
+  repo-url:
+    description: "Repository URL used in the README languages table advisory."
+    required: false
+    default: ""
+  extra-args:
+    description: "Additional raw arguments passed to the translate CLI."
+    required: false
+    default: ""
+  python-version:
+    description: "Python version used to run Co-op Translator."
+    required: false
+    default: "3.12"
+  package-version:
+    description: 'Package source to install: "source", "latest", or an exact PyPI version.'
+    required: false
+    default: "source"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Set up Python
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+      with:
+        python-version: ${{ inputs.python-version }}
+
+    - name: Install Co-op Translator
+      shell: bash
+      env:
+        PACKAGE_VERSION: ${{ inputs.package-version }}
+      run: |
+        python -m pip install --upgrade pip
+        if [ "$PACKAGE_VERSION" = "source" ]; then
+          python -m pip install "$GITHUB_ACTION_PATH"
+        elif [ "$PACKAGE_VERSION" = "latest" ]; then
+          python -m pip install --upgrade co-op-translator
+        else
+          python -m pip install "co-op-translator==$PACKAGE_VERSION"
+        fi
+
+    - name: Run Co-op Translator
+      shell: bash
+      env:
+        PYTHONIOENCODING: utf-8
+        INPUT_LANGUAGE_CODES: ${{ inputs.language-codes }}
+        INPUT_ROOT_DIR: ${{ inputs.root-dir }}
+        INPUT_MARKDOWN: ${{ inputs.markdown }}
+        INPUT_NOTEBOOK: ${{ inputs.notebook }}
+        INPUT_IMAGES: ${{ inputs.images }}
+        INPUT_README_ONLY: ${{ inputs.readme-only }}
+        INPUT_UPDATE: ${{ inputs.update }}
+        INPUT_DRY_RUN: ${{ inputs.dry-run }}
+        INPUT_YES: ${{ inputs.yes }}
+        INPUT_ADD_DISCLAIMER: ${{ inputs.add-disclaimer }}
+        INPUT_REPO_URL: ${{ inputs.repo-url }}
+        INPUT_EXTRA_ARGS: ${{ inputs.extra-args }}
+      run: |
+        cmd=(translate -l "$INPUT_LANGUAGE_CODES" -r "$INPUT_ROOT_DIR")
+
+        if [ "$INPUT_MARKDOWN" = "true" ]; then
+          cmd+=("-md")
+        fi
+        if [ "$INPUT_NOTEBOOK" = "true" ]; then
+          cmd+=("-nb")
+        fi
+        if [ "$INPUT_IMAGES" = "true" ]; then
+          cmd+=("-img")
+        fi
+        if [ "$INPUT_README_ONLY" = "true" ]; then
+          cmd+=("--readme-only")
+        fi
+        if [ "$INPUT_UPDATE" = "true" ]; then
+          cmd+=("--update")
+        fi
+        if [ "$INPUT_DRY_RUN" = "true" ]; then
+          cmd+=("--dry-run")
+        fi
+        if [ "$INPUT_YES" = "true" ]; then
+          cmd+=("--yes")
+        fi
+        if [ "$INPUT_ADD_DISCLAIMER" = "false" ]; then
+          cmd+=("--no-disclaimer")
+        fi
+        if [ -n "$INPUT_REPO_URL" ]; then
+          cmd+=("--repo-url" "$INPUT_REPO_URL")
+        fi
+        if [ -n "$INPUT_EXTRA_ARGS" ]; then
+          read -r -a extra_args <<< "$INPUT_EXTRA_ARGS"
+          cmd+=("${extra_args[@]}")
+        fi
+
+        "${cmd[@]}"

--- a/docs/api.md
+++ b/docs/api.md
@@ -283,6 +283,17 @@ run_review(
 )
 ```
 
+After a README-only translation, use the same scope for review:
+
+```python
+run_review(language_codes="ko", root_dir="./my-course", readme_only=True)
+```
+
+`readme_only=True` reviews only `README.md` under each configured source root,
+including custom `groups` and output directories. Other documents and nested
+READMEs are excluded. A missing source README raises `ValueError`; failed
+translation checks raise `RuntimeError`.
+
 Review only files changed against a base ref and print GitHub-flavored output:
 
 ```python
@@ -549,6 +560,7 @@ The `policy` argument may be a dictionary with these fields:
 | `root_dirs` | `Iterable[str] \| None` | `None` | Multiple roots that share the same output settings. |
 | `groups` | `Iterable[tuple[str, str \| None]] \| None` | `None` | Explicit `(root_dir, translations_dir)` pairs. Takes precedence over `root_dirs`. |
 | `changed_from` | `str \| None` | `None` | Git ref used to limit review to changed source files. |
+| `readme_only` | `bool` | `False` | Review only `README.md` under each source root. A missing source README raises `ValueError`. |
 | `output_format` | `str` | `"text"` | Review output format. Supported values are `"text"` and `"github"`. |
 | `fail_on_warnings` | `bool` | `False` | Treat warnings as failures in addition to errors. |
 | `debug` | `bool` | `False` | Enable debug logging. |

--- a/docs/assets/workflows/translate-readme.yml
+++ b/docs/assets/workflows/translate-readme.yml
@@ -1,0 +1,135 @@
+# Copy to .github/workflows/translate-readme.yml in the repository to translate.
+# Requires a Co-op Translator ref containing action.yml and co-op-review --readme-only.
+# Before release, replace Azure/co-op-translator@main with your fork@branch.
+name: Translate README
+
+on:
+  workflow_dispatch:
+    inputs:
+      language:
+        description: Target language
+        type: choice
+        options:
+          - ko
+          - ja
+          - es
+          - fr
+          - de
+        default: ko
+      preview:
+        description: Preview only (no API calls or pull request)
+        type: boolean
+        default: true
+
+concurrency:
+  group: translate-readme-${{ inputs.language }}
+  cancel-in-progress: false
+
+jobs:
+  translate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: write
+      pull-requests: write
+    env:
+      LANGUAGE: ${{ inputs.language }}
+      PYTHONIOENCODING: utf-8
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+
+      - name: Preview README translation
+        id: preview
+        uses: Azure/co-op-translator@main
+        with:
+          language-codes: ${{ inputs.language }}
+          readme-only: "true"
+          dry-run: "true"
+
+      - name: Translate README
+        id: translate
+        if: ${{ !inputs.preview }}
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OPENAI_CHAT_MODEL_ID: ${{ secrets.OPENAI_CHAT_MODEL_ID }}
+          OPENAI_ORG_ID: ${{ secrets.OPENAI_ORG_ID }}
+          OPENAI_BASE_URL: ${{ secrets.OPENAI_BASE_URL }}
+          AZURE_OPENAI_API_KEY: ${{ secrets.AZURE_OPENAI_API_KEY }}
+          AZURE_OPENAI_ENDPOINT: ${{ secrets.AZURE_OPENAI_ENDPOINT }}
+          AZURE_OPENAI_MODEL_NAME: ${{ secrets.AZURE_OPENAI_MODEL_NAME }}
+          AZURE_OPENAI_CHAT_DEPLOYMENT_NAME: ${{ secrets.AZURE_OPENAI_CHAT_DEPLOYMENT_NAME }}
+          AZURE_OPENAI_API_VERSION: ${{ secrets.AZURE_OPENAI_API_VERSION }}
+        run: translate -l "$LANGUAGE" --readme-only --yes
+
+      - name: Review README translation
+        id: review
+        # Also report missing/stale output when translation fails.
+        if: ${{ !cancelled() && !inputs.preview && steps.preview.outcome == 'success' }}
+        shell: bash
+        run: |
+          set -o pipefail
+          co-op-review -l "$LANGUAGE" --readme-only --format github | tee "$RUNNER_TEMP/readme-review.md"
+
+      - name: Summarize results
+        if: ${{ always() }}
+        shell: bash
+        env:
+          PREVIEW_ONLY: ${{ inputs.preview }}
+          PREVIEW_STATUS: ${{ steps.preview.outcome }}
+          TRANSLATE_STATUS: ${{ steps.translate.outcome }}
+          REVIEW_STATUS: ${{ steps.review.outcome }}
+        run: |
+          {
+            echo '# README translation'
+            echo
+            printf 'Source: `README.md` → `translations/%s/README.md`\n\n' "$LANGUAGE"
+            printf 'Preview: **%s**; translation: **%s**; review: **%s**.\n\n' \
+              "$PREVIEW_STATUS" "$TRANSLATE_STATUS" "$REVIEW_STATUS"
+            if [ "$PREVIEW_ONLY" = "true" ]; then
+              echo 'Preview only. See the preview step for the token estimate.'
+              echo 'To translate, configure one text provider and rerun with Preview only unchecked.'
+            else
+              echo '## Changed files'
+              echo
+              files=$(git ls-files --modified --others --exclude-standard -- \
+                "translations/$LANGUAGE/README.md" "translations/$LANGUAGE/.co-op-translator.json")
+              if [ -n "$files" ]; then
+                while IFS= read -r file; do printf -- '- `%s`\n' "$file"; done <<< "$files"
+              else
+                echo 'No translation changes. No new pull request is needed.'
+              fi
+              echo
+              if [ -f "$RUNNER_TEMP/readme-review.md" ]; then
+                cat "$RUNNER_TEMP/readme-review.md"
+              fi
+              echo
+              if [ "$TRANSLATE_STATUS" != "success" ] || [ "$REVIEW_STATUS" != "success" ]; then
+                echo 'Translation or review failed. No pull request will be created; inspect the failed step logs.'
+              fi
+              echo 'Checks cover structure, source freshness, and local links. Review wording before merging.'
+            fi
+          } > "$RUNNER_TEMP/readme-pr.md"
+          cat "$RUNNER_TEMP/readme-pr.md" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Create translation pull request
+        id: pr
+        if: ${{ !inputs.preview && steps.translate.outcome == 'success' && steps.review.outcome == 'success' }}
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: co-op-translator/readme-${{ inputs.language }}
+          base: ${{ github.event.repository.default_branch }}
+          title: "Docs: Translate README to ${{ inputs.language }}"
+          commit-message: "Docs: Translate README to ${{ inputs.language }}"
+          body-path: ${{ runner.temp }}/readme-pr.md
+          add-paths: |
+            translations/${{ inputs.language }}/README.md
+            translations/${{ inputs.language }}/.co-op-translator.json
+
+      - name: Show pull request
+        if: ${{ steps.pr.outputs.pull-request-url != '' }}
+        env:
+          PR_URL: ${{ steps.pr.outputs.pull-request-url }}
+        run: printf '\n[Review translation pull request](%s)\n' "$PR_URL" >> "$GITHUB_STEP_SUMMARY"

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -190,6 +190,18 @@ Review a specific project root:
 co-op-review -l "fr" -r ./my-course
 ```
 
+Review just the README after a README-only translation:
+
+```bash
+translate -l "ko" --readme-only -y
+co-op-review -l "ko" --readme-only --format github
+```
+
+`--readme-only` ignores other documents and nested READMEs. It fails if the root
+`README.md` is missing. Combined with `--changed-from`, it reviews the README only
+when that source file changed. README-only translation leaves the source README
+unchanged, including any shared-section markers.
+
 Review only source files changed against a base ref:
 
 ```bash
@@ -209,6 +221,7 @@ co-op-review -l "ko ja" --changed-from origin/main --format github
 | `-l`, `--language-code` | No | Language code to review. Can be passed multiple times or as a space-separated value. Defaults to all discovered translation languages. |
 | `-r`, `--root-dir` | No | Project root. Defaults to the current directory. |
 | `--changed-from` | No | Git ref used to limit review to changed source files. |
+| `--readme-only` | No | Review only the root `README.md` translation. |
 | `--format` | No | Output format: `text` or `github`. Defaults to `text`. |
 
 `co-op-review` currently checks for missing translated files, missing or stale translation metadata, Markdown frontmatter and code fence integrity, invalid translated notebook JSON, and missing local Markdown or image link targets. Missing links are warnings by default; structural and freshness problems fail the command.

--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -2,7 +2,21 @@
 
 Use GitHub Actions when you want a repository to translate changed documentation automatically and open a pull request with the generated outputs.
 
-Most repositories should use the standard `GITHUB_TOKEN` setup. Use the GitHub App setup only when your organization restricts the default token permissions or requires app-based authentication.
+Start with the standard `GITHUB_TOKEN` setup, including for organization repositories where policy allows it. See [GitHub App Setup](#github-app-setup) when your organization requires an App identity or you need automatic downstream workflow runs.
+
+## Your first README translation PR
+
+Start with one root `README.md` and one target language. This workflow translates Markdown only, so Azure AI Vision is not required.
+
+1. Copy [translate-readme.yml](assets/workflows/translate-readme.yml) to `.github/workflows/translate-readme.yml` in the repository you want to translate, and commit it to that repository's default branch. The template uses the root Action in `Azure/co-op-translator@main`, which installs the CLI from the same source ref. Pin a reviewed commit for reproducible runs. When testing this feature before it is merged, use the fork and branch containing both the Action and `co-op-review --readme-only`.
+2. Open **Actions > Translate README > Run workflow**, choose a language, and leave **Preview only** checked. Review the token estimate in the preview step. Preview does not call model providers, write translations, or create a PR.
+3. Add the secrets for one [text provider](#prerequisites), and enable **Allow GitHub Actions to create and approve pull requests** under **Settings > Actions > General**. The template requests `contents: write` and `pull-requests: write` for its job; you do not need to change the default permissions for every workflow. If organization policy blocks these permissions or this setting, ask an administrator about an approved [GitHub App](#github-app-setup).
+4. Run the workflow again with **Preview only** unchecked. It previews, translates, runs `co-op-review --readme-only`, and creates or updates a translation PR only after translation and review succeed. The workflow summary links to the PR.
+5. Review the wording and file changes in the PR, then merge when ready. The workflow does not merge automatically.
+
+The PR contains only `translations/<language>/README.md` and its language metadata file. The source README stays unchanged, and links to other documents continue to point at the source documents. The PR body lists changed files and structural review results. If translation or review fails, inspect the workflow summary and failed step logs; no PR is created. If there are no changes, no new PR is needed.
+
+**Organization and CI note:** A GitHub App is optional, not a requirement of organization ownership. With `GITHUB_TOKEN`, pull-request workflows for opening, updating, or reopening a PR require a user with write access to select **Approve workflows to run**. Push workflows are not triggered by this token. For unattended downstream CI, see [GitHub App Setup](#github-app-setup) and GitHub's [workflow triggering rules](https://docs.github.com/en/actions/how-tos/writing-workflows/choosing-when-your-workflow-runs/triggering-a-workflow).
 
 ## Prerequisites
 
@@ -118,11 +132,11 @@ Change `translate -l "es fr de" -y` to the target languages and content flags yo
 
 ## GitHub App Setup
 
-Use this setup when `GITHUB_TOKEN` cannot create commits or pull requests in your organization.
+Use an approved GitHub App when your organization requires an App identity, or when the generated PR needs to trigger downstream CI without the `GITHUB_TOKEN` approval step. An App does not bypass organization policy; administrators still control its installation and permissions.
 
 ### Step 1: Create or Install a GitHub App
 
-Create a GitHub App with read/write access to **Contents** and **Pull requests**, or install the organization-provided app if your organization already maintains one.
+Use an existing organization-provided App when available, or create one with read/write access to **Contents** and **Pull requests**. Install it on the target repository with any required organization approval.
 
 Record:
 
@@ -136,29 +150,23 @@ Store them as repository secrets:
 
 ### Step 2: Generate an App Token
 
-Use the same workflow as the standard setup, but add an app-token step before the pull request step:
+Add this step immediately before the existing pull request step. For the README template, use the same success condition so previews and failed translations do not request an App token:
 
 ```yaml
       - name: Authenticate GitHub App
         id: generate_token
-        uses: tibdex/github-app-token@v1
+        if: ${{ !inputs.preview && steps.translate.outcome == 'success' && steps.review.outcome == 'success' }}
+        uses: actions/create-github-app-token@v2
         with:
-          app_id: ${{ secrets.GH_APP_ID }}
-          private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-
-      - name: Create Pull Request with translations
-        uses: peter-evans/create-pull-request@v5
-        with:
-          token: ${{ steps.generate_token.outputs.token }}
-          commit-message: "Update translations via Co-op Translator"
-          title: "Update translations via Co-op Translator"
-          branch: update-translations
-          base: main
-          delete-branch: true
-          add-paths: |
-            translations/
-            translated_images/
+          app-id: ${{ secrets.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
 ```
+
+Then change only the existing pull request step's `token` input to `${{ steps.generate_token.outputs.token }}`. Keep its success condition, branch, PR body, and `add-paths` unchanged. The token is scoped to the current repository by default. When adapting the standard setup instead of the README template, omit the `if` above because that workflow has no preview or review step IDs.
+
+See the official [create-github-app-token Action](https://github.com/actions/create-github-app-token/tree/v2) for installation and token permissions.
 
 ## Runner Limits
 

--- a/src/co_op_translator/api/review.py
+++ b/src/co_op_translator/api/review.py
@@ -69,6 +69,7 @@ def run_review(
     changed_from: str | None = None,
     output_format: str = "text",
     fail_on_warnings: bool = False,
+    readme_only: bool = False,
 ) -> ReviewSummary:
     """Programmatic deterministic review entrypoint.
 
@@ -77,6 +78,7 @@ def run_review(
     branching. Review ignores mutating translation-only options such as
     ``update``, ``yes``, ``add_disclaimer``, ``repo_url``, ``glossaries``, and
     ``dry_run``.
+    Set ``readme_only=True`` to review only README.md under each source root.
     """
     configure_safe_console_output()
 
@@ -114,6 +116,7 @@ def run_review(
             changed_from=changed_from,
             targets=targets,
             source_extensions=_source_extensions_for_review_types(review_types),
+            readme_only=readme_only,
         )
     ).run()
 

--- a/src/co_op_translator/cli/review.py
+++ b/src/co_op_translator/cli/review.py
@@ -32,6 +32,11 @@ def _split_language_options(values: tuple[str, ...]) -> list[str]:
     help="Git ref to diff against. When provided, only changed source files are reviewed.",
 )
 @click.option(
+    "--readme-only",
+    is_flag=True,
+    help="Review only the root README.md translation.",
+)
+@click.option(
     "--format",
     "output_format",
     type=click.Choice(["text", "github"]),
@@ -44,6 +49,7 @@ def review_command(
     language_code: tuple[str, ...],
     changed_from: str | None,
     output_format: str,
+    readme_only: bool,
 ) -> None:
     """Run deterministic translation review checks without API credentials."""
     root_path = Path(root_dir).resolve()
@@ -60,6 +66,7 @@ def review_command(
             notebook=True,
             changed_from=changed_from,
             output_format=output_format,
+            readme_only=readme_only,
         )
-    except RuntimeError as exc:
+    except (RuntimeError, ValueError) as exc:
         raise click.ClickException(str(exc)) from exc

--- a/src/co_op_translator/cli/translate.py
+++ b/src/co_op_translator/cli/translate.py
@@ -217,6 +217,16 @@ def translate_command(
             )
         )
 
+        # Validate root directory and README before checking provider credentials
+        root_path = Path(root_dir).resolve()
+        if not root_path.exists():
+            raise click.ClickException(f"Root directory does not exist: {root_dir}")
+        if not root_path.is_dir():
+            raise click.ClickException(f"Root path is not a directory: {root_dir}")
+
+        if readme_only and not (root_path / "README.md").is_file():
+            raise click.ClickException(f"README.md not found under {root_path}")
+
         if not dry_run:
             Config.check_configuration()
 
@@ -229,13 +239,6 @@ def translate_command(
                     "Please add AZURE_AI_SERVICE_API_KEY to your environment variables or use --markdown and/or --notebook flags to exclude images.\n"
                     "See the .env.template file for required variables."
                 )
-
-        # Validate root directory early and set up logging
-        root_path = Path(root_dir).resolve()
-        if not root_path.exists():
-            raise click.ClickException(f"Root directory does not exist: {root_dir}")
-        if not root_path.is_dir():
-            raise click.ClickException(f"Root path is not a directory: {root_dir}")
 
         log_file_path = setup_logging(
             root_path,
@@ -509,26 +512,28 @@ def translate_command(
             emit_translation_event("run_completed", metadata={"dry_run": True})
             return
 
-        # Update README shared sections BEFORE translation
-        readme_path = root_path / "README.md"
-        try:
-            if update_readme_languages_table(readme_path, repo_url=repo_url):
-                reporter.success("Updated README languages table from template.")
-            else:
-                reporter.info(
-                    "README languages table not updated "
-                    "(markers missing or template unavailable)."
-                )
-        except Exception as e:
-            logger.warning(f"Failed to update README languages table: {e}")
+        # Translate README sources as-is so freshness metadata matches committed content.
+        if request.mode != TranslationMode.README:
+            # Update README shared sections BEFORE translation
+            readme_path = root_path / "README.md"
+            try:
+                if update_readme_languages_table(readme_path, repo_url=repo_url):
+                    reporter.success("Updated README languages table from template.")
+                else:
+                    reporter.info(
+                        "README languages table not updated "
+                        "(markers missing or template unavailable)."
+                    )
+            except Exception as e:
+                logger.warning(f"Failed to update README languages table: {e}")
 
-        try:
-            if update_readme_other_courses(readme_path):
-                reporter.success(
-                    "Updated README 'Other courses' section from template."
-                )
-        except Exception as e:
-            logger.warning(f"Failed to update README 'Other courses': {e}")
+            try:
+                if update_readme_other_courses(readme_path):
+                    reporter.success(
+                        "Updated README 'Other courses' section from template."
+                    )
+            except Exception as e:
+                logger.warning(f"Failed to update README 'Other courses': {e}")
 
         if fix:
             reporter.info(

--- a/src/co_op_translator/review/runner.py
+++ b/src/co_op_translator/review/runner.py
@@ -25,6 +25,7 @@ class ReviewConfig:
     excluded_dirs: set[str] = field(default_factory=lambda: set(DEFAULT_EXCLUDED_DIRS))
     targets: list[ReviewTarget] | None = None
     source_extensions: set[str] | None = None
+    readme_only: bool = False
 
 
 class ReviewRunner:
@@ -45,6 +46,9 @@ class ReviewRunner:
         issues = []
         source_files: list[Path] = []
         for target in targets:
+            readme_path = target.source_root / "README.md"
+            if self.config.readme_only and not readme_path.is_file():
+                raise ValueError(f"README.md not found under {target.source_root}")
             if self.config.changed_from:
                 target_source_files = discover_changed_source_files(
                     root_dir,
@@ -53,6 +57,12 @@ class ReviewRunner:
                     self.config.excluded_dirs,
                     self.config.source_extensions,
                 )
+                if self.config.readme_only:
+                    target_source_files = [
+                        path for path in target_source_files if path == readme_path
+                    ]
+            elif self.config.readme_only:
+                target_source_files = [readme_path]
             else:
                 target_source_files = discover_source_files(
                     target.source_root,

--- a/tests/co_op_translator/review/test_runner.py
+++ b/tests/co_op_translator/review/test_runner.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
 from click.testing import CliRunner
 
 from co_op_translator.cli.review import review_command
@@ -102,3 +103,58 @@ def test_review_cli_outputs_github_summary(tmp_path):
     assert result.exit_code == 0
     assert "## Co-op Review" in result.output
     assert "Status: **passed**" in result.output
+
+
+def test_readme_review_ignores_untranslated_docs_and_nested_readmes(tmp_path):
+    source_file = _write_source(tmp_path, "README.md")
+    _write_translation(tmp_path, source_file, "ko")
+    _write_source(tmp_path, "docs/guide.md")
+    _write_source(tmp_path, "docs/README.md")
+    _write_source(tmp_path, "examples/demo.ipynb", "{}")
+
+    result = CliRunner().invoke(
+        review_command,
+        ["-r", str(tmp_path), "-l", "ko", "--readme-only", "--format", "github"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "| Source files reviewed | 1 |" in result.output
+    assert "Status: **passed**" in result.output
+    # Full review still reports the other missing translations.
+    assert ReviewRunner(ReviewConfig(tmp_path, languages=["ko"])).run().error_count == 3
+
+
+@pytest.mark.parametrize("problem", ["missing-source", "missing-translation", "stale"])
+def test_readme_review_fails_for_incomplete_output(tmp_path, problem):
+    if problem != "missing-source":
+        source = _write_source(tmp_path, "README.md")
+        if problem == "stale":
+            _write_translation(tmp_path, source, "ko")
+            source.write_text("# Updated source\n", encoding="utf-8")
+
+    result = CliRunner().invoke(
+        review_command, ["-r", str(tmp_path), "-l", "ko", "--readme-only"]
+    )
+
+    assert result.exit_code == 1
+    assert "README.md" in result.output
+
+
+def test_readme_review_intersects_changed_sources(tmp_path, monkeypatch):
+    from co_op_translator.review import runner
+
+    source = _write_source(tmp_path, "README.md")
+    guide = _write_source(tmp_path, "docs/guide.md")
+    _write_translation(tmp_path, source, "ko")
+    monkeypatch.setattr(
+        runner, "discover_changed_source_files", lambda *args: [source, guide]
+    )
+    config = ReviewConfig(
+        tmp_path, languages=["ko"], changed_from="origin/main", readme_only=True
+    )
+    summary = ReviewRunner(config).run()
+    assert summary.source_files == [Path("README.md")]
+    assert summary.error_count == 0
+
+    monkeypatch.setattr(runner, "discover_changed_source_files", lambda *args: [guide])
+    assert ReviewRunner(config).run().source_files == []

--- a/tests/co_op_translator/test_readme_onboarding_cli.py
+++ b/tests/co_op_translator/test_readme_onboarding_cli.py
@@ -1,0 +1,80 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from click.testing import CliRunner
+
+from co_op_translator.cli import translate as translate_cli
+from co_op_translator.cli.translate import translate_command
+from co_op_translator.api.review import run_review
+from co_op_translator.core.project.readme_translator import ReadmeTranslator
+
+
+@pytest.mark.parametrize("preview", [True, False])
+def test_readme_cli_preserves_source_and_scopes_output(monkeypatch, tmp_path, preview):
+    source = "# Hello\n\n[Guide](docs/guide.md)\n"
+    (tmp_path / "README.md").write_text(source, encoding="utf-8")
+    (tmp_path / "docs").mkdir()
+    (tmp_path / "docs/guide.md").write_text("# Guide\n", encoding="utf-8")
+    provider = MagicMock()
+    provider.translate_markdown = AsyncMock(
+        return_value="# 안녕하세요\n\n[안내](docs/guide.md)\n"
+    )
+
+    def make_translator(*args, **kwargs):
+        kwargs["markdown_translator"] = provider
+        return ReadmeTranslator(*args, **kwargs)
+
+    monkeypatch.setattr(translate_cli, "ReadmeTranslator", make_translator)
+    for owner, name in (
+        (translate_cli.Config, "check_configuration"),
+        (translate_cli.LLMConfig, "validate_connectivity"),
+        (translate_cli.VisionConfig, "validate_connectivity"),
+    ):
+        mock = MagicMock(return_value=True)
+        if preview:
+            mock.side_effect = AssertionError("Preview must not check credentials")
+        monkeypatch.setattr(owner, name, mock)
+
+    shared_updates = []
+    for name in ("update_readme_languages_table", "update_readme_other_courses"):
+        mock = MagicMock()
+        shared_updates.append(mock)
+        monkeypatch.setattr(translate_cli, name, mock)
+
+    args = ["-r", str(tmp_path), "-l", "ko", "--readme-only", "--no-disclaimer", "-y"]
+    if preview:
+        args.append("--dry-run")
+    result = CliRunner().invoke(translate_command, args)
+
+    assert result.exit_code == 0, result.output
+    assert (tmp_path / "README.md").read_text(encoding="utf-8") == source
+    for mock in shared_updates:
+        mock.assert_not_called()
+    if preview:
+        provider.translate_markdown.assert_not_awaited()
+        assert not (tmp_path / "translations").exists()
+    else:
+        provider.translate_markdown.assert_awaited_once()
+        assert not (tmp_path / "translations/ko/docs").exists()
+        summary = run_review(
+            root_dir=str(tmp_path), language_codes="ko", readme_only=True
+        )
+        assert summary.error_count == summary.warning_count == 0
+
+
+@pytest.mark.parametrize("preview", [True, False])
+def test_readme_cli_rejects_missing_source_before_provider_checks(
+    monkeypatch, tmp_path, preview
+):
+    config_check = MagicMock(side_effect=AssertionError("Must validate source first"))
+    monkeypatch.setattr(translate_cli.Config, "check_configuration", config_check)
+    args = ["-r", str(tmp_path), "-l", "ko", "--readme-only", "-y"]
+    if preview:
+        args.append("--dry-run")
+
+    result = CliRunner().invoke(translate_command, args)
+
+    assert result.exit_code == 1
+    assert "README.md not found" in result.output
+    config_check.assert_not_called()
+    assert not (tmp_path / "translations").exists()

--- a/tests/co_op_translator/test_review_api.py
+++ b/tests/co_op_translator/test_review_api.py
@@ -91,3 +91,21 @@ def test_run_review_supports_multiple_root_dirs(tmp_path):
         Path("content1") / "one.md",
         Path("content2") / "two.md",
     ]
+
+
+def test_readme_review_supports_custom_output_and_multiple_roots(tmp_path):
+    groups = []
+    for name in ("course", "guide"):
+        source_root = tmp_path / name
+        source = _write_source(source_root, "README.md")
+        _write_source(source_root, "other.md")
+        output_root = tmp_path / "i18n" / name
+        _write_translation(source_root, output_root, source, "ko")
+        groups.append((str(source_root), str(output_root)))
+
+    summary = run_review(
+        root_dir=str(tmp_path), language_codes="ko", groups=groups, readme_only=True
+    )
+
+    assert summary.error_count == 0
+    assert summary.source_files == [Path("course/README.md"), Path("guide/README.md")]


### PR DESCRIPTION
## Purpose

Let a maintainer start with one README and one language, preview the work, and receive a translation pull request with review results. Today, connecting installation, translation, review, and PR creation requires assembling separate steps, and a full review incorrectly fails this first run for documents intentionally left untranslated.

## Description

- Add a root composite Action that installs Co-op Translator from its own source ref by default and previews or runs translation.
- Add a manual README workflow template: preview → translate → deterministic review → create or update a PR. Preview is the default; PR creation requires successful translation and review, and commits only the selected README and language metadata. The workflow and PR summaries include changed files and check results.
- Add `co-op-review --readme-only` and `run_review(readme_only=True)`, including custom source/output roots and intersection with `--changed-from`.
- Preserve the source README during README-only CLI translation so freshness metadata matches committed content. Reject a missing source README before checking provider credentials.
- Document the first-run path with `GITHUB_TOKEN`, plus optional organization-approved GitHub App authentication and downstream CI behavior. Update the App example to `actions/create-github-app-token@v2`.

## Related Issue

No linked issue.

## Does this introduce a breaking change?

Will this change require users to update commands, configuration, environment variables, generated translation output, or public Python/MCP APIs?
If you're not sure, test the affected CLI, API, documentation, or GitHub Actions workflow before marking this as "No."

- [ ] Yes
- [x] No

The review option is additive and existing full-project behavior is preserved. README-only translation now keeps shared sections in the source README unchanged; existing commands and metadata formats do not require migration.

## Type of change

- [x] Bugfix
- [x] Feature
- [ ] Code style update (e.g., formatting, local variables)
- [ ] Refactoring (no functional or API changes)
- [x] Documentation content changes
- [ ] Other... Please describe:

## Checklist

Before submitting your pull request, please confirm the following:

- [ ] **I have thoroughly tested my changes**: I confirm that I have run the code and manually tested all affected areas.
- [x] **All existing tests pass**: I have run all tests and confirmed that nothing is broken.
- [x] **I have added new tests** (if applicable): I have written tests that cover the new functionality introduced by my code changes.
- [x] **I have followed the Co-op Translator coding conventions**: My code adheres to the style guide and coding conventions outlined in the repository.
- [x] **I have documented my changes** (if applicable): I have updated the documentation to reflect the changes where necessary.

## Additional context

Validation on Windows with Python 3.14:

- `pytest -m "not api_key_required" -q`: **412 passed**.
- `ruff check src tests` and `black --check src tests`: passed.
- Parsed both Action/workflow YAML files and checked all embedded Bash scripts with `bash -n`.
- Executed the workflow summary script in temporary Git repositories for preview, success, failure, and no-change cases. Verified file allowlisting, PR success conditions, and nonzero review status propagation through `tee`.

The first checklist item remains unchecked because live model calls and end-to-end translation PR creation in a consumer GitHub repository have not been exercised. Translation tests use an injected model stub. Before this PR is merged, testing the workflow requires changing the template's `Azure/co-op-translator@main` reference to the fork/ref containing this implementation.
